### PR TITLE
pin the gantt timeline header while scrolling tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The gantt timeline header stays pinned to the top when scrolling through tasks
+
 ## [1.7.0] - 2026-07-02
 
 ### Added

--- a/src/styles/gantt.css
+++ b/src/styles/gantt.css
@@ -149,6 +149,17 @@
   position: relative;
 }
 
+/* Timeline header: pinned to the top on vertical scroll, scrolls with the body
+   horizontally (only `top` is constrained, so the horizontal axis stays free). */
+.pm-gantt-header-sticky {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+}
+.pm-gantt-header-svg {
+  display: block;
+}
+
 .pm-gantt-svg-container {
   position: relative;
 }

--- a/src/views/gantt/GanttHeaderRenderer.ts
+++ b/src/views/gantt/GanttHeaderRenderer.ts
@@ -45,7 +45,7 @@ export function renderTimelineHeader(ctx: RendererContext): void {
   else if (granularity === 'month') renderMonthHeader(g, ctx)
   else renderQuarterHeader(g, ctx)
 
-  ctx.svgEl.appendChild(g)
+  ctx.headerSvgEl.appendChild(g)
 }
 
 function renderDayHeader(g: SVGGElement, ctx: RendererContext): void {

--- a/src/views/gantt/GanttRenderer.ts
+++ b/src/views/gantt/GanttRenderer.ts
@@ -13,6 +13,7 @@ export { renderTaskBar, renderMilestoneLabels, renderDependencyArrows } from './
 
 export interface RendererContext {
   svgEl: SVGSVGElement
+  headerSvgEl: SVGSVGElement
   cfg: TimelineCfg
   plugin: PMPlugin
   project: Project
@@ -91,9 +92,7 @@ export function renderTodayLine(ctx: RendererContext, svgHeight: number): void {
   const x = dateToX(ctx.cfg, today())
   if (x < 0 || x > ctx.cfg.totalWidth) return
 
-  const g = svgEl('g', { class: 'pm-gantt-today-group' })
-
-  g.appendChild(
+  ctx.svgEl.appendChild(
     svgEl('line', {
       x1: x,
       y1: HEADER_HEIGHT - 8,
@@ -103,12 +102,12 @@ export function renderTodayLine(ctx: RendererContext, svgHeight: number): void {
     })
   )
 
-  g.appendChild(
+  // The diamond cap sits in the header band, so it rides the sticky header and
+  // stays visible while the rows scroll underneath.
+  ctx.headerSvgEl.appendChild(
     svgEl('polygon', {
       points: `${x},${HEADER_HEIGHT - 16} ${x + 6},${HEADER_HEIGHT - 8} ${x},${HEADER_HEIGHT} ${x - 6},${HEADER_HEIGHT - 8}`,
       class: 'pm-gantt-today-diamond'
     })
   )
-
-  ctx.svgEl.appendChild(g)
 }

--- a/src/views/gantt/GanttTaskBarRenderer.ts
+++ b/src/views/gantt/GanttTaskBarRenderer.ts
@@ -325,7 +325,7 @@ export function renderMilestoneLabels(ctx: RendererContext): void {
   const milestones = ctx.flatTasks.filter((f) => f.task.type === 'milestone' && (f.task.due || f.task.start))
   if (!milestones.length) return
 
-  const labelsG = svgEl('g', { class: 'pm-gantt-milestone-labels' })
+  const linesG = svgEl('g', { class: 'pm-gantt-milestone-labels' })
 
   for (const { task } of milestones) {
     const date = parsePlainDate(task.due) ?? parsePlainDate(task.start)
@@ -335,7 +335,7 @@ export function renderMilestoneLabels(ctx: RendererContext): void {
     const color = statusConfig?.color ?? getComputedStyle(ctx.svgEl).getPropertyValue('--interactive-accent').trim()
 
     const totalH = HEADER_HEIGHT + ctx.flatTasks.filter((f) => f.visible || f.depth === 0).length * ROW_HEIGHT
-    labelsG.appendChild(
+    linesG.appendChild(
       svgEl('line', {
         x1: x,
         y1: HEADER_HEIGHT,
@@ -348,6 +348,7 @@ export function renderMilestoneLabels(ctx: RendererContext): void {
       })
     )
 
+    // Label rides the sticky header so it stays visible while rows scroll.
     const label = svgEl('text', {
       x,
       y: 14,
@@ -356,10 +357,10 @@ export function renderMilestoneLabels(ctx: RendererContext): void {
       fill: color
     })
     label.textContent = task.title.length > 16 ? task.title.slice(0, 14) + '\u2026' : task.title
-    labelsG.appendChild(label)
+    ctx.headerSvgEl.appendChild(label)
   }
 
-  ctx.svgEl.appendChild(labelsG)
+  ctx.svgEl.appendChild(linesG)
 }
 
 // ─── Dependency arrows ─────────────────────────────────────────────────────

--- a/src/views/gantt/GanttView.ts
+++ b/src/views/gantt/GanttView.ts
@@ -28,6 +28,7 @@ export class GanttView implements SubView {
   private granularity: GanttGranularity
   private scrollEl!: HTMLElement
   private svgEl!: SVGSVGElement
+  private headerSvgEl!: SVGSVGElement
   private flatTasks: FlatTask[] = []
   private cfg!: TimelineCfg
   private drag: DragState = makeDragState()
@@ -157,8 +158,24 @@ export class GanttView implements SubView {
     // Right panel: timeline
     const rightPanel = wrapper.createDiv('pm-gantt-right')
     this.scrollEl = rightPanel
-    const svgContainer = this.scrollEl.createDiv('pm-gantt-svg-container')
+
+    // Timeline header lives in its own SVG inside a sticky wrapper. It shares the
+    // right panel's horizontal scroll (so it tracks the body left/right) but pins to
+    // the top on vertical scroll, keeping the time period visible while rows scroll.
+    const headerSticky = rightPanel.createDiv('pm-gantt-header-sticky')
+    headerSticky.style.width = `${this.cfg.totalWidth}px`
+    headerSticky.style.height = `${HEADER_HEIGHT}px`
+    this.headerSvgEl = svgEl('svg', {
+      width: this.cfg.totalWidth,
+      height: HEADER_HEIGHT,
+      class: 'pm-gantt-header-svg'
+    })
+    headerSticky.appendChild(this.headerSvgEl)
+
+    const svgContainer = rightPanel.createDiv('pm-gantt-svg-container')
     svgContainer.style.width = `${this.cfg.totalWidth}px`
+    // Tuck the body's top band (still drawn at y=HEADER_HEIGHT) under the sticky header.
+    svgContainer.style.marginTop = `-${HEADER_HEIGHT}px`
 
     const totalRows = this.flatTasks.filter((f) => f.visible || f.depth === 0).length
     const svgHeight = HEADER_HEIGHT + (totalRows + 1) * ROW_HEIGHT // +1 for add-task row
@@ -274,6 +291,7 @@ export class GanttView implements SubView {
   private makeRendererContext(): RendererContext {
     return {
       svgEl: this.svgEl,
+      headerSvgEl: this.headerSvgEl,
       cfg: this.cfg,
       plugin: this.plugin,
       project: this.project,


### PR DESCRIPTION
Gantt timeline header stays pinned to the top while you scroll through tasks, so the time period stays visible. Ref #133 