### PR TITLE
make priorities configurable and extract a task source interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Priorities can be added, renamed, recolored, and reordered in settings
+
+### Fixed
+
+- The import dialog offered the built-in statuses and priorities instead of the configured ones
+
 ## [1.8.0] - 2026-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Priorities can be added, renamed, recolored, and reordered in settings
+- Status and priority icons accept Lucide icon names alongside emoji, with suggestions while typing in settings
 
 ### Fixed
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { MarkdownView, Plugin, Notice } from 'obsidian'
 import { DEFAULT_SETTINGS, PMSettings, Project, Task } from './types'
 import { flattenTasks, findTask } from './store/TaskTreeOps'
 import { ProjectStore } from './store'
+import type { TaskSource } from './store'
 import { PMSettingTab } from './settings'
 import { ProjectView, PM_PROJECT_VIEW_TYPE } from './views/ProjectView'
 import { DashboardView, PM_DASHBOARD_VIEW_TYPE } from './views/DashboardView'
@@ -13,7 +14,7 @@ import { safeAsync } from './utils'
 
 export default class PMPlugin extends Plugin {
   settings: PMSettings = { ...DEFAULT_SETTINGS }
-  store!: ProjectStore
+  store!: TaskSource
   notifier!: Notifier
   router!: PMViewRouter
   undoStack: Array<{ undo: () => Promise<void>; redo: () => Promise<void> }> = []

--- a/src/modals/ImportModal.ts
+++ b/src/modals/ImportModal.ts
@@ -1,9 +1,7 @@
-import { Modal, TFile, Notice } from 'obsidian'
+import { App, Modal, TFile, Notice } from 'obsidian'
+import type PMPlugin from '../main'
 import type { Project, TaskStatus, TaskPriority } from '../types'
-import { makeTask, DEFAULT_STATUSES, DEFAULT_PRIORITIES } from '../types'
-import { parseFrontmatter, TASK_FRONTMATTER_KEY } from '../store/YamlParser'
-import { serializeTask, taskFilePath } from '../store/YamlSerializer'
-import { ensureFolder } from '../store/vaultFs'
+import { getDefaultStatusId, getDefaultPriorityId } from '../utils'
 
 interface FileItem {
   file: TFile
@@ -23,11 +21,20 @@ export class ImportModal extends Modal {
 
   // Phase 2 state
   private phase: 1 | 2 = 1
-  private defaultStatus: TaskStatus = 'todo'
-  private defaultPriority: TaskPriority = 'medium'
+  private defaultStatus: TaskStatus
+  private defaultPriority: TaskPriority
   private fileHandling: 'move' | 'copy' = 'move'
   private project: Project | null = null
   private onImportComplete: (() => void) | null = null
+
+  constructor(
+    app: App,
+    private plugin: PMPlugin
+  ) {
+    super(app)
+    this.defaultStatus = getDefaultStatusId(plugin.settings.statuses)
+    this.defaultPriority = getDefaultPriorityId(plugin.settings.priorities)
+  }
 
   onOpen(): void {
     const { contentEl } = this
@@ -144,7 +151,7 @@ export class ImportModal extends Modal {
 
     const statusSelect = statusGroup.createEl('select')
 
-    DEFAULT_STATUSES.forEach((s) => {
+    this.plugin.settings.statuses.forEach((s) => {
       const option = statusSelect.createEl('option', { text: s.label })
       option.value = s.id
       if (s.id === this.defaultStatus) option.selected = true
@@ -160,14 +167,14 @@ export class ImportModal extends Modal {
 
     const prioritySelect = priorityGroup.createEl('select')
 
-    DEFAULT_PRIORITIES.forEach((p) => {
+    this.plugin.settings.priorities.forEach((p) => {
       const option = prioritySelect.createEl('option', { text: p.label })
       option.value = p.id
       if (p.id === this.defaultPriority) option.selected = true
     })
 
     prioritySelect.addEventListener('change', (e) => {
-      this.defaultPriority = (e.target as HTMLSelectElement).value as TaskPriority
+      this.defaultPriority = (e.target as HTMLSelectElement).value
     })
 
     // File handling radio
@@ -314,95 +321,35 @@ export class ImportModal extends Modal {
     }
 
     const selectedFiles = this.files.filter((f) => f.selected).map((f) => f.file)
-    const skipped: string[] = []
-    const imported: string[] = []
+    let skipped = 0
+    let imported = 0
 
-    try {
-      // Task folder mirrors ProjectStore.projectTaskFolder: <projectFile>_tasks
-      const tasksFolder = this.project.filePath.replace(/\.md$/, '_tasks')
-
-      for (const file of selectedFiles) {
-        try {
-          // Read file content
-          const content = await this.app.vault.read(file)
-
-          // Parse frontmatter
-          const { frontmatter, body } = parseFrontmatter(content)
-
-          // Check if already imported
-          if (frontmatter && frontmatter[TASK_FRONTMATTER_KEY] === true) {
-            skipped.push(file.basename)
-            continue
-          }
-
-          // Create task
-          const task = makeTask({
-            title: file.basename.replace(/\.md$/, ''),
-            description: body,
-            status: this.defaultStatus,
-            priority: this.defaultPriority
-          })
-
-          // Generate file path for task
-          const newFilePath = taskFilePath(task.title, tasksFolder)
-
-          // Serialize task to file content
-          const newContent = serializeTask(task, this.project, null)
-
-          if (this.fileHandling === 'move') {
-            // Move: rename to new location, then update content
-            try {
-              await ensureFolder(this.app, tasksFolder)
-
-              // Rename file to new path
-              await this.app.fileManager.renameFile(file, newFilePath)
-
-              // Get the moved file and update its content
-              const movedFile = this.app.vault.getAbstractFileByPath(newFilePath)
-              if (movedFile instanceof TFile) {
-                await this.app.vault.modify(movedFile, newContent)
-              }
-
-              imported.push(file.basename)
-            } catch (err) {
-              console.error(`Failed to move ${file.basename}:`, err)
-              skipped.push(file.basename)
-            }
-          } else {
-            // Copy: create new file, keep original
-            try {
-              await ensureFolder(this.app, tasksFolder)
-
-              await this.app.vault.create(newFilePath, newContent)
-              imported.push(file.basename)
-            } catch (err) {
-              console.error(`Failed to copy ${file.basename}:`, err)
-              skipped.push(file.basename)
-            }
-          }
-        } catch (err) {
-          console.error(`Error processing ${file.basename}:`, err)
-          skipped.push(file.basename)
-        }
+    for (const file of selectedFiles) {
+      try {
+        const result = await this.plugin.store.importNoteAsTask(this.project, file, {
+          status: this.defaultStatus,
+          priority: this.defaultPriority,
+          handling: this.fileHandling
+        })
+        if (result === 'imported') imported++
+        else skipped++
+      } catch (err) {
+        console.error(`Failed to import ${file.basename}:`, err)
+        skipped++
       }
-
-      // Call project reload callback if provided
-      if (this.onImportComplete) {
-        this.onImportComplete()
-      }
-
-      // Show summary notification
-      let message = `Imported ${imported.length} task${imported.length !== 1 ? 's' : ''}`
-      if (skipped.length > 0) {
-        message += ` (${skipped.length} skipped)`
-      }
-      new Notice(message, 3000)
-
-      this.close()
-    } catch (err) {
-      console.error('Import error:', err)
-      new Notice('Error during import. Check console for details.', 5000)
     }
+
+    if (this.onImportComplete) {
+      this.onImportComplete()
+    }
+
+    let message = `Imported ${imported} task${imported !== 1 ? 's' : ''}`
+    if (skipped > 0) {
+      message += ` (${skipped} skipped)`
+    }
+    new Notice(message, 3000)
+
+    this.close()
   }
 
   setProject(project: Project): void {

--- a/src/modals/TaskFormFields.ts
+++ b/src/modals/TaskFormFields.ts
@@ -1,5 +1,5 @@
 import type PMPlugin from '../main'
-import { Project, Task, TaskType, TaskPriority, Recurrence } from '../types'
+import { Project, Task, TaskType, Recurrence } from '../types'
 import { flattenTasks } from '../store/TaskTreeOps'
 import { wouldCreateCycle } from '../store/Scheduler'
 import { renderPropRow } from '../ui/FormField'
@@ -144,7 +144,7 @@ export function renderTaskFormFields(container: HTMLElement, ctx: TaskFormFields
           icon: p.icon || PRIORITY_CHEVRONS[p.id]
         })),
         onChange: (id) => {
-          task.priority = id as TaskPriority
+          task.priority = id
           rerender()
         }
       })

--- a/src/modals/TaskFormFields.ts
+++ b/src/modals/TaskFormFields.ts
@@ -117,7 +117,7 @@ export function renderTaskFormFields(container: HTMLElement, ctx: TaskFormFields
       renderSelectControl({
         container: cell,
         value: task.status,
-        options: statuses.map((s) => ({ id: s.id, label: s.label, color: s.color })),
+        options: statuses.map((s) => ({ id: s.id, label: s.label, color: s.color, icon: s.icon || undefined })),
         onChange: (id) => {
           task.status = id
           rerender()

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -14,7 +14,7 @@ import type PMPlugin from '../main'
 import { Project, Task, makeTask } from '../types'
 import { flattenTasks } from '../store/TaskTreeOps'
 import { TaskFileNameConflictError } from '../store'
-import { safeAsync, getDefaultStatusId, getPriorityConfig } from '../utils'
+import { safeAsync, getDefaultStatusId, getDefaultPriorityId, getPriorityConfig } from '../utils'
 import { confirmDialog } from '../ui/ModalFactory'
 import { renderTaskFormFields } from './TaskFormFields'
 import { renderTimeTrackingPanel } from './TimeTrackingPanel'
@@ -54,7 +54,7 @@ export class TaskModal extends Modal {
     } else {
       this.task = makeTask({
         status: getDefaultStatusId(plugin.settings.statuses),
-        priority: 'medium',
+        priority: getDefaultPriorityId(plugin.settings.priorities),
         type: parentId ? 'subtask' : 'task',
         ...defaults
       })

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,10 +1,37 @@
-import { App, PluginSettingTab, Setting, Notice } from 'obsidian'
+import { AbstractInputSuggest, App, PluginSettingTab, Setting, Notice, getIconIds, setIcon } from 'obsidian'
 import type PMPlugin from './main'
 import { PMSettings, DEFAULT_SETTINGS, makeId } from './types'
 import { flattenTasks } from './store/TaskTreeOps'
 
 export type { PMSettings }
 export { DEFAULT_SETTINGS }
+
+/** Suggests Lucide icon ids for the status/priority icon inputs. Typed emoji are kept as-is. */
+class IconSuggest extends AbstractInputSuggest<string> {
+  protected getSuggestions(query: string): string[] {
+    const q = query.trim().toLowerCase()
+    if (!q) return []
+    return getIconIds()
+      .filter((id) => id.includes(q))
+      .slice(0, 24)
+  }
+
+  renderSuggestion(id: string, el: HTMLElement): void {
+    el.addClass('pm-icon-suggestion')
+    setIcon(el.createSpan({ cls: 'pm-icon-suggestion-glyph' }), id)
+    el.createSpan({ text: id })
+  }
+}
+
+/** Wire icon-name suggestions to an icon input; picking a suggestion saves through the input's change handler. */
+function attachIconSuggest(app: App, input: HTMLInputElement): void {
+  const suggest = new IconSuggest(app, input)
+  suggest.onSelect((id) => {
+    suggest.setValue(id)
+    input.dispatchEvent(new Event('change'))
+    suggest.close()
+  })
+}
 
 export class PMSettingTab extends PluginSettingTab {
   plugin: PMPlugin
@@ -310,10 +337,11 @@ export class PMSettingTab extends PluginSettingTab {
 
       this.wireRowDragReorder(row, i, this.plugin.settings.statuses, () => this.renderStatusList(container))
 
-      // Icon input
+      // Icon input: emoji or a Lucide icon id (with suggestions)
       const icon = row.createEl('input', { type: 'text', value: s.icon })
       icon.addClass('pm-settings-status-icon')
       icon.placeholder = ''
+      attachIconSuggest(this.app, icon)
       icon.addEventListener('change', () => {
         this.plugin.settings.statuses[i].icon = icon.value
         void this.plugin.saveSettings()
@@ -367,10 +395,11 @@ export class PMSettingTab extends PluginSettingTab {
 
       this.wireRowDragReorder(row, i, this.plugin.settings.priorities, () => this.renderPriorityList(container))
 
-      // Icon input
+      // Icon input: emoji or a Lucide icon id (with suggestions)
       const icon = row.createEl('input', { type: 'text', value: p.icon })
       icon.addClass('pm-settings-status-icon')
       icon.placeholder = ''
+      attachIconSuggest(this.app, icon)
       icon.addEventListener('change', () => {
         this.plugin.settings.priorities[i].icon = icon.value
         void this.plugin.saveSettings()

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -207,6 +207,33 @@ export class PMSettingTab extends PluginSettingTab {
           this.renderStatusList(statusContainer)
         })
     )
+
+    // ── Priorities ────────────────────────────────────────────────────────────
+    new Setting(containerEl).setName('Priorities').setHeading()
+    containerEl.createEl('p', {
+      cls: 'pm-settings-desc',
+      text: 'Customize priority labels, colors, and icons. Drag to reorder from most to least important.'
+    })
+
+    const priorityContainer = containerEl.createDiv('pm-settings-statuses')
+    this.renderPriorityList(priorityContainer)
+
+    new Setting(containerEl).addButton((btn) =>
+      btn
+        .setButtonText('+ add priority')
+        .setCta()
+        .onClick(() => {
+          const id = 'priority-' + makeId().slice(0, 6)
+          this.plugin.settings.priorities.push({
+            id,
+            label: 'New priority',
+            color: '#8a94a0',
+            icon: ''
+          })
+          void this.plugin.saveSettings()
+          this.renderPriorityList(priorityContainer)
+        })
+    )
   }
 
   private renderMembersList(container: HTMLElement): void {
@@ -230,27 +257,50 @@ export class PMSettingTab extends PluginSettingTab {
     })
   }
 
-  private async remapOrphanTasks(deletedId: string, deletedLabel: string): Promise<void> {
-    const statuses = this.plugin.settings.statuses
-    if (statuses.length === 0) return
-    const defaultStatus = statuses[0]
+  private async remapOrphanTasks(field: 'status' | 'priority', deletedId: string, deletedLabel: string): Promise<void> {
+    const configs = field === 'status' ? this.plugin.settings.statuses : this.plugin.settings.priorities
+    if (configs.length === 0) return
+    const fallback = configs[0]
     const folder = this.plugin.settings.projectsFolder
     const projects = await this.plugin.store.loadAllProjects(folder)
     let remapped = 0
     for (const project of projects) {
       const ids = flattenTasks(project.tasks)
-        .filter(({ task }) => task.status === deletedId)
+        .filter(({ task }) => task[field] === deletedId)
         .map(({ task }) => task.id)
       if (ids.length) {
-        await this.plugin.store.updateTasks(project, ids, { status: defaultStatus.id })
+        await this.plugin.store.updateTasks(project, ids, { [field]: fallback.id })
         remapped += ids.length
       }
     }
     if (remapped > 0) {
-      new Notice(
-        `Remapped ${remapped} task${remapped === 1 ? '' : 's'} from '${deletedLabel}' to '${defaultStatus.label}'.`
-      )
+      new Notice(`Remapped ${remapped} task${remapped === 1 ? '' : 's'} from '${deletedLabel}' to '${fallback.label}'.`)
     }
+  }
+
+  /** Wire drag-to-reorder on a config row; on drop, moves the dragged item to this row's index. */
+  private wireRowDragReorder<T>(row: HTMLElement, index: number, items: T[], rerender: () => void): void {
+    row.createSpan({ text: '⠿', cls: 'pm-settings-drag-handle' })
+    row.draggable = true
+    row.addEventListener('dragstart', (e) => {
+      e.dataTransfer?.setData('text/plain', String(index))
+      row.addClass('pm-settings-row--dragging')
+    })
+    row.addEventListener('dragend', () => {
+      row.removeClass('pm-settings-row--dragging')
+    })
+    row.addEventListener('dragover', (e) => {
+      e.preventDefault()
+    })
+    row.addEventListener('drop', (e) => {
+      e.preventDefault()
+      const fromIdx = parseInt(e.dataTransfer?.getData('text/plain') ?? '', 10)
+      if (isNaN(fromIdx) || fromIdx === index) return
+      const [moved] = items.splice(fromIdx, 1)
+      items.splice(index, 0, moved)
+      void this.plugin.saveSettings()
+      rerender()
+    })
   }
 
   private renderStatusList(container: HTMLElement): void {
@@ -258,29 +308,7 @@ export class PMSettingTab extends PluginSettingTab {
     this.plugin.settings.statuses.forEach((s, i) => {
       const row = container.createDiv('pm-settings-status-row')
 
-      // Drag handle
-      row.createSpan({ text: '⠿', cls: 'pm-settings-drag-handle' })
-      row.draggable = true
-      row.addEventListener('dragstart', (e) => {
-        e.dataTransfer?.setData('text/plain', String(i))
-        row.addClass('pm-settings-row--dragging')
-      })
-      row.addEventListener('dragend', () => {
-        row.removeClass('pm-settings-row--dragging')
-      })
-      row.addEventListener('dragover', (e) => {
-        e.preventDefault()
-      })
-      row.addEventListener('drop', (e) => {
-        e.preventDefault()
-        const fromIdx = parseInt(e.dataTransfer?.getData('text/plain') ?? '', 10)
-        if (isNaN(fromIdx) || fromIdx === i) return
-        const statuses = this.plugin.settings.statuses
-        const [moved] = statuses.splice(fromIdx, 1)
-        statuses.splice(i, 0, moved)
-        void this.plugin.saveSettings()
-        this.renderStatusList(container)
-      })
+      this.wireRowDragReorder(row, i, this.plugin.settings.statuses, () => this.renderStatusList(container))
 
       // Icon input
       const icon = row.createEl('input', { type: 'text', value: s.icon })
@@ -327,7 +355,54 @@ export class PMSettingTab extends PluginSettingTab {
         this.plugin.settings.statuses.splice(i, 1)
         void this.plugin.saveSettings()
         this.renderStatusList(container)
-        void this.remapOrphanTasks(deletedStatus.id, deletedStatus.label)
+        void this.remapOrphanTasks('status', deletedStatus.id, deletedStatus.label)
+      })
+    })
+  }
+
+  private renderPriorityList(container: HTMLElement): void {
+    container.empty()
+    this.plugin.settings.priorities.forEach((p, i) => {
+      const row = container.createDiv('pm-settings-status-row')
+
+      this.wireRowDragReorder(row, i, this.plugin.settings.priorities, () => this.renderPriorityList(container))
+
+      // Icon input
+      const icon = row.createEl('input', { type: 'text', value: p.icon })
+      icon.addClass('pm-settings-status-icon')
+      icon.placeholder = ''
+      icon.addEventListener('change', () => {
+        this.plugin.settings.priorities[i].icon = icon.value
+        void this.plugin.saveSettings()
+      })
+
+      // Label input
+      const label = row.createEl('input', { type: 'text', value: p.label })
+      label.addClass('pm-settings-status-label')
+      label.addEventListener('change', () => {
+        this.plugin.settings.priorities[i].label = label.value
+        void this.plugin.saveSettings()
+      })
+
+      // Color picker
+      const color = row.createEl('input', { type: 'color', value: p.color })
+      color.addEventListener('change', () => {
+        this.plugin.settings.priorities[i].color = color.value
+        void this.plugin.saveSettings()
+      })
+
+      // Delete button
+      const del = row.createEl('button', { text: '✕', cls: 'pm-settings-del' })
+      del.addEventListener('click', () => {
+        if (this.plugin.settings.priorities.length <= 1) {
+          new Notice('You must have at least one priority.')
+          return
+        }
+        const deletedPriority = this.plugin.settings.priorities[i]
+        this.plugin.settings.priorities.splice(i, 1)
+        void this.plugin.saveSettings()
+        this.renderPriorityList(container)
+        void this.remapOrphanTasks('priority', deletedPriority.id, deletedPriority.label)
       })
     })
   }

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -779,3 +779,67 @@ describe('ProjectStore project cache', () => {
     expect(reloaded).toBe(clone)
   })
 })
+
+describe('ProjectStore.importNoteAsTask', () => {
+  async function importInto(handling: 'move' | 'copy') {
+    const { store, vault, app } = newStore()
+    const project = await store.createProject('Import', 'Projects')
+    const note = await vault.create('Notes/Idea.md', 'the note body')
+    const result = await store.importNoteAsTask(project, note, {
+      status: 'in-progress',
+      priority: 'high',
+      handling
+    })
+    return { store, vault, app, project, result }
+  }
+
+  it('copies a note into the tasks folder and keeps the original', async () => {
+    const { vault, result } = await importInto('copy')
+    expect(result).toBe('imported')
+    expect(vault.getAbstractFileByPath('Notes/Idea.md')).toBeInstanceOf(TFile)
+
+    const created = vault.getAbstractFileByPath('Projects/Import_tasks/idea.md')
+    if (!(created instanceof TFile)) throw new Error('imported task file missing')
+    const content = await vault.read(created)
+    expect(content).toContain('pm-task: true')
+    expect(content).toContain('status: "in-progress"')
+    expect(content).toContain('priority: "high"')
+    expect(content).toContain('the note body')
+  })
+
+  it('moves a note into the tasks folder', async () => {
+    const { vault, result } = await importInto('move')
+    expect(result).toBe('imported')
+    expect(vault.getAbstractFileByPath('Notes/Idea.md')).toBeNull()
+
+    const moved = vault.getAbstractFileByPath('Projects/Import_tasks/idea.md')
+    if (!(moved instanceof TFile)) throw new Error('imported task file missing')
+    const content = await vault.read(moved)
+    expect(content).toContain('pm-task: true')
+    expect(content).toContain('the note body')
+  })
+
+  it('imported tasks appear as top-level tasks on the next project load', async () => {
+    const { vault, app, project } = await importInto('move')
+    const store2 = new ProjectStore(app, () => STATUSES)
+    const file = vault.getAbstractFileByPath(project.filePath)
+    if (!(file instanceof TFile)) throw new Error('project file missing')
+    const reloaded = expectDefined(await store2.loadProject(file))
+    expect(reloaded.tasks.map((t) => t.title)).toContain('Idea')
+  })
+
+  it('skips notes that are already tasks', async () => {
+    const { store, vault, project } = await importInto('copy')
+    const existing = vault.getAbstractFileByPath('Projects/Import_tasks/idea.md')
+    if (!(existing instanceof TFile)) throw new Error('imported task file missing')
+    const before = await vault.read(existing)
+
+    const result = await store.importNoteAsTask(project, existing, {
+      status: 'todo',
+      priority: 'low',
+      handling: 'move'
+    })
+    expect(result).toBe('skipped')
+    expect(await vault.read(existing)).toBe(before)
+  })
+})

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -32,6 +32,7 @@ import {
   TASK_SLUG_MAX_LENGTH
 } from './YamlSerializer'
 import { ensureFolder, moveTaskAttachmentFolder } from './vaultFs'
+import type { ImportNoteOptions, TaskSource } from './TaskSource'
 
 /**
  * 'fm' — only frontmatter changed; body content is unaffected. Save path can
@@ -96,7 +97,7 @@ function fileNameFromPath(path: string): string {
  * The in-memory Project.tasks tree is assembled on load from individual
  * task files and remains unchanged for views.
  */
-export class ProjectStore {
+export class ProjectStore implements TaskSource {
   /** Per-project promise chains to serialize concurrent saves */
   private saveQueues = new Map<string, Promise<void>>()
 
@@ -698,6 +699,40 @@ export class ProjectStore {
     this.markDirty(project, [task.id], 'full')
     if (parentId) this.markDirty(project, [parentId], 'full')
     await this.saveProject(project)
+  }
+
+  /**
+   * Convert an arbitrary vault note into a top-level task file in the project's
+   * tasks folder. The note body becomes the task description; notes that are
+   * already pm-tasks are skipped. The task is picked up on the next project
+   * load via the orphan self-heal, matching how the tasks folder is scanned.
+   */
+  async importNoteAsTask(project: Project, file: TFile, opts: ImportNoteOptions): Promise<'imported' | 'skipped'> {
+    const content = await this.app.vault.read(file)
+    const { frontmatter, body } = parseFrontmatter(content)
+    if (frontmatter?.[TASK_FRONTMATTER_KEY] === true) return 'skipped'
+
+    const task = makeTask({
+      title: file.basename,
+      description: body,
+      status: opts.status,
+      priority: opts.priority
+    })
+    const folder = this.projectTaskFolder(project)
+    await this.ensureFolder(folder)
+    const newFilePath = taskFilePath(task.title, folder)
+    const newContent = serializeTask(task, project, null)
+
+    if (opts.handling === 'move') {
+      await this.app.fileManager.renameFile(file, newFilePath)
+      const moved = this.app.vault.getAbstractFileByPath(newFilePath)
+      if (moved instanceof TFile) {
+        await this.app.vault.process(moved, () => newContent)
+      }
+    } else {
+      await this.app.vault.create(newFilePath, newContent)
+    }
+    return 'imported'
   }
 
   async duplicateTask(project: Project, sourceId: string, includeSubtasks: boolean): Promise<Task | null> {

--- a/src/store/TaskSource.ts
+++ b/src/store/TaskSource.ts
@@ -1,0 +1,52 @@
+import type { Plugin, TFile } from 'obsidian'
+import type { Project, StatusConfig, Task, TaskPriority, TaskStatus } from '../types'
+import type { TaskFileNameConflictError } from './ProjectStore'
+
+export interface ImportNoteOptions {
+  status: TaskStatus
+  priority: TaskPriority
+  handling: 'move' | 'copy'
+}
+
+/**
+ * The task persistence surface views, modals, and commands program against
+ * (`plugin.store`). ProjectStore is the default implementation over pm-task
+ * markdown files; alternative backends (e.g. TaskNotes-managed notes) implement
+ * the same contract.
+ */
+export interface TaskSource {
+  registerCacheInvalidation(plugin: Plugin): void
+  consumeSelfWrite(path: string): boolean
+  ensureFolder(folderPath: string): Promise<void>
+
+  loadAllProjects(folder: string): Promise<Project[]>
+  loadProject(file: TFile): Promise<Project | null>
+  loadTaskBody(task: Task): Promise<void>
+  loadProjectBody(project: Project): Promise<void>
+
+  createProject(title: string, folder: string): Promise<Project>
+  saveProject(project: Project): Promise<void>
+  deleteProject(project: Project): Promise<void>
+
+  addTask(project: Project, parentId?: string | null): Promise<Task>
+  insertTask(project: Project, task: Task, parentId?: string | null): Promise<void>
+  duplicateTask(project: Project, sourceId: string, includeSubtasks: boolean): Promise<Task | null>
+  importNoteAsTask(project: Project, file: TFile, opts: ImportNoteOptions): Promise<'imported' | 'skipped'>
+  updateTask(project: Project, taskId: string, patch: Partial<Task>): Promise<void>
+  updateTasks(
+    project: Project,
+    taskIds: string[],
+    patch: Partial<Task> | ((task: Task) => Partial<Task> | null)
+  ): Promise<void>
+  moveTask(project: Project, taskId: string, newParentId: string | null): Promise<void>
+  moveTasks(project: Project, taskIds: string[], newParentId: string | null): Promise<void>
+  reorderTask(project: Project, taskId: string, targetId: string, position: 'before' | 'after'): Promise<void>
+  deleteTask(project: Project, taskId: string): Promise<void>
+  deleteTasks(project: Project, taskIds: string[]): Promise<void>
+  archiveTask(project: Project, taskId: string): Promise<void>
+  unarchiveTask(project: Project, taskId: string): Promise<void>
+
+  scheduleAfterChange(project: Project, changedTaskId?: string, statuses?: StatusConfig[]): Promise<number>
+  saveTaskAttachment(project: Project, task: Task, fileName: string, data: ArrayBuffer): Promise<TFile>
+  findTaskFileConflict(project: Project, task: Task): TaskFileNameConflictError | null
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,6 @@
 export { archiveTask, unarchiveTask } from './ArchiveOps'
 export { ProjectStore, TaskFileNameConflictError } from './ProjectStore'
+export type { ImportNoteOptions, TaskSource } from './TaskSource'
 export { computeSchedule, wouldCreateCycle } from './Scheduler'
 export {
   applyTaskFilter,

--- a/src/styles/kanban.css
+++ b/src/styles/kanban.css
@@ -49,8 +49,15 @@
   padding: 10px 12px 8px;
 }
 .pm-kanban-col-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font-size: 13px;
   font-weight: 600;
+}
+.pm-kanban-col-badge-icon {
+  display: inline-flex;
+  --icon-size: 14px;
 }
 .pm-kanban-col-header-right {
   display: flex;

--- a/src/styles/project-modal.css
+++ b/src/styles/project-modal.css
@@ -267,9 +267,19 @@
   flex: 1;
 }
 .pm-settings-status-icon {
-  width: 40px;
+  width: 90px;
   text-align: center;
-  flex: 0 0 40px;
+  flex: 0 0 90px;
+}
+.pm-icon-suggestion {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.pm-icon-suggestion-glyph {
+  display: inline-flex;
+  color: var(--text-muted);
+  --icon-size: 16px;
 }
 .pm-settings-status-label {
   flex: 1;

--- a/src/styles/task-editor.css
+++ b/src/styles/task-editor.css
@@ -78,6 +78,10 @@ textarea.pm-te-title:focus {
   color: var(--pm-glyph-color, var(--text-muted));
   --icon-size: 14px;
 }
+.pm-glyph-text {
+  font-size: 12px;
+  line-height: 1;
+}
 .pm-glyph-dot {
   width: 8px;
   height: 8px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import { today } from './dates'
 import type { TaskIndex } from './store/TaskIndex'
 
 export type TaskStatus = string
-export type TaskPriority = 'critical' | 'high' | 'medium' | 'low'
+export type TaskPriority = string
 export type GanttGranularity = 'day' | 'week' | 'month' | 'quarter'
 export type GanttWeekLabel = 'weekNumber' | 'dateRange' | 'both'
 export type ViewMode = 'table' | 'gantt' | 'kanban'

--- a/src/ui/ModalFactory.ts
+++ b/src/ui/ModalFactory.ts
@@ -281,7 +281,7 @@ export function openImportModal(
   project: Project,
   onImportComplete?: () => void | Promise<void>
 ): void {
-  const modal = new ImportModal(plugin.app)
+  const modal = new ImportModal(plugin.app, plugin)
   modal.setProject(project)
   if (onImportComplete) {
     modal.setOnImportComplete(() => {

--- a/src/ui/StatusBadge.ts
+++ b/src/ui/StatusBadge.ts
@@ -1,7 +1,12 @@
 import { Menu } from 'obsidian'
 import type { Task, TaskStatus, TaskPriority, StatusConfig, PriorityConfig } from '../types'
-import { getStatusConfig, getPriorityConfig, formatBadgeText } from '../utils'
+import { getStatusConfig, getPriorityConfig, formatBadgeText, isIconName } from '../utils'
 import { Chip } from './primitives/Chip'
+
+/** Returns the config's icon when it's a named (Lucide) icon; emoji/text icons render inline via formatBadgeText. */
+function namedIcon(config: { icon: string } | undefined): string | null {
+  return config?.icon && isIconName(config.icon) ? config.icon : null
+}
 
 export function renderStatusBadge(
   container: HTMLElement,
@@ -18,15 +23,19 @@ export function renderStatusBadge(
     .onClick((e) => {
       const menu = new Menu()
       for (const s of statuses) {
-        menu.addItem((item) =>
+        menu.addItem((item) => {
           item
             .setTitle(formatBadgeText(s.icon, s.label))
             .setChecked(s.id === task.status)
             .onClick(() => onChange(s.id))
-        )
+          const icon = namedIcon(s)
+          if (icon) item.setIcon(icon)
+        })
       }
       menu.showAtMouseEvent(e)
     })
+  const icon = namedIcon(config)
+  if (icon) badge.setLeadingIcon(icon)
   return badge.el
 }
 
@@ -48,18 +57,23 @@ export function renderPriorityBadge(
     .setLabel(formatBadgeText(config?.icon, config?.label ?? task.priority))
     .setColor(config?.color ?? 'var(--text-muted)')
     .setVariant('plain')
-  if (!config?.icon) {
+  const icon = namedIcon(config)
+  if (icon) {
+    badge.setLeadingIcon(icon)
+  } else if (!config?.icon) {
     badge.setLeadingIcon(PRIORITY_CHEVRONS[task.priority] ?? 'equal')
   }
   badge.onClick((e) => {
     const menu = new Menu()
     for (const p of priorities) {
-      menu.addItem((item) =>
+      menu.addItem((item) => {
         item
           .setTitle(formatBadgeText(p.icon, p.label))
           .setChecked(p.id === task.priority)
           .onClick(() => onChange(p.id))
-      )
+        const itemIcon = namedIcon(p)
+        if (itemIcon) item.setIcon(itemIcon)
+      })
     }
     menu.showAtMouseEvent(e)
   })

--- a/src/ui/StatusBadge.ts
+++ b/src/ui/StatusBadge.ts
@@ -30,7 +30,7 @@ export function renderStatusBadge(
   return badge.el
 }
 
-export const PRIORITY_CHEVRONS: Record<TaskPriority, string> = {
+export const PRIORITY_CHEVRONS: Record<string, string> = {
   critical: 'chevrons-up',
   high: 'chevron-up',
   medium: 'equal',
@@ -49,7 +49,7 @@ export function renderPriorityBadge(
     .setColor(config?.color ?? 'var(--text-muted)')
     .setVariant('plain')
   if (!config?.icon) {
-    badge.setLeadingIcon(PRIORITY_CHEVRONS[task.priority])
+    badge.setLeadingIcon(PRIORITY_CHEVRONS[task.priority] ?? 'equal')
   }
   badge.onClick((e) => {
     const menu = new Menu()

--- a/src/ui/composites/KanbanColumn.ts
+++ b/src/ui/composites/KanbanColumn.ts
@@ -1,5 +1,6 @@
+import { setIcon } from 'obsidian'
 import type { Task } from '../../types'
-import { formatBadgeText, safeAsync } from '../../utils'
+import { formatBadgeText, isIconName, safeAsync } from '../../utils'
 import { KanbanCard } from './KanbanCard'
 
 export interface KanbanColumnStatus {
@@ -45,10 +46,13 @@ export class KanbanColumn {
     topBar.setCssStyles({ background: props.status.color })
 
     const titleRow = header.createDiv('pm-kanban-col-title-row')
-    const badge = titleRow.createSpan({
-      text: formatBadgeText(props.status.icon, props.status.label),
-      cls: 'pm-kanban-col-badge'
-    })
+    const badge = titleRow.createSpan({ cls: 'pm-kanban-col-badge' })
+    if (props.status.icon && isIconName(props.status.icon)) {
+      setIcon(badge.createSpan({ cls: 'pm-kanban-col-badge-icon' }), props.status.icon)
+      badge.appendText(props.status.label)
+    } else {
+      badge.setText(formatBadgeText(props.status.icon, props.status.label))
+    }
     badge.style.color = props.status.color
 
     const headerRight = titleRow.createDiv('pm-kanban-col-header-right')

--- a/src/ui/composites/ProjectHeader/FilterRow.ts
+++ b/src/ui/composites/ProjectHeader/FilterRow.ts
@@ -1,5 +1,5 @@
 import { ButtonComponent, Menu } from 'obsidian'
-import type { Project, FilterState, StatusConfig, PriorityConfig, TaskPriority, DueDateFilter } from '../../../types'
+import type { Project, FilterState, StatusConfig, PriorityConfig, DueDateFilter } from '../../../types'
 import { collectAllAssignees, collectAllTags } from '../../../store'
 import { countActiveFilters } from '../../../store/TaskFilter'
 import { renderFilterDropdown } from '../../FilterDropdown'
@@ -61,7 +61,7 @@ export class FilterRow {
       filter.priorities,
       priorities.map((p) => ({ id: p.id, label: formatBadgeText(p.icon, p.label) })),
       (selected) => {
-        filter.priorities = selected as TaskPriority[]
+        filter.priorities = selected
         notify()
       }
     )

--- a/src/ui/composites/properties/optionList.ts
+++ b/src/ui/composites/properties/optionList.ts
@@ -1,4 +1,5 @@
 import { setIcon } from 'obsidian'
+import { isIconName } from '../../../utils'
 import { Avatar } from '../../primitives/Avatar'
 
 export interface SelectItem {
@@ -13,12 +14,14 @@ export interface GlyphSpec {
   icon?: string
 }
 
-/** Renders a leading glyph for an option: a tinted icon if `icon` is set, else a colored dot. */
+/** Renders a leading glyph for an option: a tinted named icon or emoji text if `icon` is set, else a colored dot. */
 export function renderGlyph(parent: HTMLElement, spec: GlyphSpec): void {
-  if (spec.icon) {
+  if (spec.icon && isIconName(spec.icon)) {
     const ic = parent.createSpan({ cls: 'pm-glyph-icon' })
     setIcon(ic, spec.icon)
     if (spec.color) ic.setCssProps({ '--pm-glyph-color': spec.color })
+  } else if (spec.icon) {
+    parent.createSpan({ cls: 'pm-glyph-icon pm-glyph-text', text: spec.icon })
   } else if (spec.color) {
     const dot = parent.createSpan({ cls: 'pm-glyph-dot' })
     dot.setCssProps({ '--pm-glyph-color': spec.color })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,6 +34,12 @@ export function getDefaultStatusId(statuses: StatusConfig[]): string {
   return statuses.length > 0 ? statuses[0].id : 'todo'
 }
 
+/** Returns the default priority id for new tasks: 'medium' when configured, else the middle of the list */
+export function getDefaultPriorityId(priorities: PriorityConfig[]): string {
+  if (priorities.some((p) => p.id === 'medium')) return 'medium'
+  return priorities.length > 0 ? priorities[Math.floor(priorities.length / 2)].id : 'medium'
+}
+
 /** Returns the first status id marked as complete */
 export function getCompleteStatusId(statuses: StatusConfig[]): string {
   const found = statuses.find((s) => s.complete)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Notice } from 'obsidian'
+import { Notice, setIcon } from 'obsidian'
 import type { Task, StatusConfig, PriorityConfig, TaskPriority } from './types'
 import { today, parsePlainDate, Temporal } from './dates'
 
@@ -90,8 +90,24 @@ export function getPriorityConfig(priorities: PriorityConfig[], id: TaskPriority
   return priorities.find((p) => p.id === id)
 }
 
-/** Format a config's icon + label into display text (e.g. "🔴 Critical") */
+const iconNameCache = new Map<string, boolean>()
+
+/** True when Obsidian renders this string as a named icon (e.g. a Lucide id like 'flame'); false for emoji/plain text. */
+export function isIconName(icon: string): boolean {
+  let known = iconNameCache.get(icon)
+  if (known === undefined) {
+    const probe = activeDocument.createElement('span')
+    setIcon(probe, icon)
+    known = probe.childElementCount > 0
+    iconNameCache.set(icon, known)
+  }
+  return known
+}
+
+/** Format a config's icon + label into display text (e.g. "🔴 Critical").
+ *  Named icons are excluded — they can't render as text; icon-capable callers draw them via setIcon. */
 export function formatBadgeText(icon: string | undefined, label: string): string {
+  if (icon && isIconName(icon)) return label
   return [icon, label].filter(Boolean).join(' ')
 }
 

--- a/src/views/table/TableFilters.ts
+++ b/src/views/table/TableFilters.ts
@@ -1,8 +1,14 @@
-import type { Task, TaskPriority, StatusConfig } from '../../types'
+import type { Task, TaskPriority, StatusConfig, PriorityConfig } from '../../types'
 import type { TableState } from './TableRenderer'
 import { statusSortOrder } from '../../utils'
 
-export function compareTask(a: Task, b: Task, state: TableState, statuses: StatusConfig[] = []): number {
+export function compareTask(
+  a: Task,
+  b: Task,
+  state: TableState,
+  statuses: StatusConfig[] = [],
+  priorities: PriorityConfig[] = []
+): number {
   const dir = state.sortDir === 'asc' ? 1 : -1
   switch (state.sortKey) {
     case 'title':
@@ -10,7 +16,7 @@ export function compareTask(a: Task, b: Task, state: TableState, statuses: Statu
     case 'status':
       return dir * (statusSortOrder(a.status, statuses) - statusSortOrder(b.status, statuses))
     case 'priority':
-      return dir * priorityOrder(a.priority) - dir * priorityOrder(b.priority)
+      return dir * (priorityOrder(a.priority, priorities) - priorityOrder(b.priority, priorities))
     case 'due':
       return dir * (a.due || 'zzz').localeCompare(b.due || 'zzz')
     case 'assignees':
@@ -22,6 +28,7 @@ export function compareTask(a: Task, b: Task, state: TableState, statuses: Statu
   }
 }
 
-function priorityOrder(p: TaskPriority): number {
-  return { critical: 0, high: 1, medium: 2, low: 3 }[p] ?? 99
+function priorityOrder(p: TaskPriority, priorities: PriorityConfig[]): number {
+  const idx = priorities.findIndex((cfg) => cfg.id === p)
+  return idx >= 0 ? idx : 999
 }

--- a/src/views/table/TableRenderer.ts
+++ b/src/views/table/TableRenderer.ts
@@ -170,7 +170,9 @@ function fillTableBody(ctx: TableContext): void {
     list.push(f)
   }
   for (const list of childrenByParent.values()) {
-    list.sort((a, b) => compareTask(a.task, b.task, ctx.state, ctx.plugin.settings.statuses))
+    list.sort((a, b) =>
+      compareTask(a.task, b.task, ctx.state, ctx.plugin.settings.statuses, ctx.plugin.settings.priorities)
+    )
   }
 
   const sorted: FlatTask[] = []

--- a/test/fakeVault.ts
+++ b/test/fakeVault.ts
@@ -164,6 +164,7 @@ export function makeFakeApp(): { app: FakeAppLike; vault: FakeVault } {
     vault,
     fileManager: {
       trashFile: (file: TAbstractFile) => vault.trashFile(file),
+      renameFile: (file: TAbstractFile, newPath: string) => vault.rename(file, newPath),
       processFrontMatter: async (file: TFile, fn: (fm: Record<string, unknown>) => void): Promise<void> => {
         await vault.process(file, (content) => {
           const { frontmatter, body } = splitFrontmatter(content)
@@ -202,6 +203,7 @@ export interface FakeAppLike {
   vault: FakeVault
   fileManager: {
     trashFile: (file: TAbstractFile) => Promise<void>
+    renameFile: (file: TAbstractFile, newPath: string) => Promise<void>
     processFrontMatter: (file: TFile, fn: (fm: Record<string, unknown>) => void) => Promise<void>
   }
   metadataCache: { getFileCache: (file: TFile) => { frontmatter?: Record<string, unknown> } | null }

--- a/test/obsidian-stub.ts
+++ b/test/obsidian-stub.ts
@@ -6,6 +6,8 @@ export class Notice {
   hide(): void {}
 }
 
+export function setIcon(): void {}
+
 export function normalizePath(p: string): string {
   return p.replace(/\\/g, '/').replace(/\/+/g, '/').replace(/^\/+/, '').replace(/\/+$/, '')
 }


### PR DESCRIPTION
Groundwork for the TaskNotes integration (#16), useful on its own.

- priorities are editable in settings now, same as statuses: add, rename, recolor, drag to reorder, delete with orphan remapping. Sort order and the new-task default follow the config
- extracted a TaskSource interface from ProjectStore so plugin.store is a contract instead of a concrete class
- the import modal goes through the store now (new importNoteAsTask) instead of writing files itself, and its dropdowns use the configured statuses/priorities. Also swapped the last vault.modify for vault.process

178 unit tests pass (4 new for the import path), checked the settings editor and import dialog by hand in a dev vault.