### PR TITLE
import tasknotes tasks and palettes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Priorities can be added, renamed, recolored, and reordered in settings
 - Status and priority icons accept emoji or any icon available in Obsidian, including Lucide icons and icons added by other plugins, with suggestions while typing in settings
+- TaskNotes tasks can be imported with their dates, dependencies, subtasks, tags, and archive state ([#16](https://github.com/StepanKropachev/obsidian-pm/issues/16))
+- Statuses and priorities can be imported from TaskNotes in settings ([#16](https://github.com/StepanKropachev/obsidian-pm/issues/16))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,36 @@ For teams:
 
 There is no real-time multi-user editing. Two people editing the same task at once produces a sync conflict, same as any Markdown note.
 
+## Using with TaskNotes
+
+Project Manager works alongside the [TaskNotes](https://github.com/callumalpass/tasknotes) plugin (4.10 or newer).
+
+### Import TaskNotes tasks
+
+The regular **Import notes as tasks** command recognizes TaskNotes tasks and converts them with their fields intact:
+
+- scheduled and due dates map to start and due
+- `blockedBy` dependencies between imported notes become task dependencies
+- project links between imported notes become parent/subtask relationships
+- tags, time estimates, completion dates, simple recurrence, and archive state carry over
+- statuses and priorities the imported tasks use are added to your palettes automatically
+
+Choose **move** to turn the TaskNotes notes into task files inside the project's task folder, or **copy** to keep the originals untouched.
+
+### Align statuses and priorities
+
+**Settings > Import from TaskNotes** copies TaskNotes' status and priority palettes into Project Manager, so both plugins use the same values, names, and colors. Entries TaskNotes doesn't know are kept.
+
+### Let TaskNotes see Project Manager tasks
+
+TaskNotes can be configured to list and edit Project Manager tasks in place, without conversion:
+
+1. In TaskNotes settings, set task identification to **property** with name `pm-task` and value `true`.
+2. In its field mapping, map **scheduled** to `start`.
+3. Add your Project Manager status and priority values to TaskNotes' palettes.
+
+Task hierarchy and dependencies don't resolve on the TaskNotes side (it uses project links and `blockedBy`, Project Manager uses id references), but both plugins edit frontmatter non-destructively, so each one's extra fields survive the other's writes.
+
 ## Settings
 
 | Setting | Description |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,5 +16,11 @@ export default defineConfig([
     rules: {
       'obsidianmd/no-static-styles-assignment': 'off'
     }
+  },
+  {
+    files: ['src/**/*.ts'],
+    rules: {
+      'obsidianmd/ui/sentence-case': ['error', { ignoreWords: ['TaskNotes'] }]
+    }
   }
 ])

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
     'obsidianmd/regex-lookbehind': 'error',
     'obsidianmd/settings-tab/no-manual-html-headings': 'error',
     'obsidianmd/settings-tab/no-problematic-settings-headings': 'error',
-    'obsidianmd/ui/sentence-case': 'error',
+    'obsidianmd/ui/sentence-case': ['error', { ignoreWords: ['TaskNotes'] }],
     'obsidianmd/ui/sentence-case-json': 'warn',
     'obsidianmd/vault/iterate': 'error'
   }

--- a/src/integrations/tasknotes.test.ts
+++ b/src/integrations/tasknotes.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_SETTINGS, type PMSettings } from '../types'
+import { importTaskNotesPalettes, type TaskNotesApi } from './tasknotes'
+
+function makeApi(): TaskNotesApi {
+  return {
+    apiVersion: 1,
+    hasCapability: () => true,
+    getTask: () => Promise.resolve(null),
+    getSettingsSnapshot: () => ({}),
+    getStatuses: () => [
+      { id: 'open', value: 'open', label: 'Open', color: '#808080', isCompleted: false, order: 1 },
+      { id: 'none', value: 'none', label: 'None', color: '#cccccc', isCompleted: false, order: 0 },
+      { id: 'in-progress', value: 'in-progress', label: 'In progress', color: '#0066cc', isCompleted: false, order: 2 },
+      { id: 'done', value: 'done', label: 'Finished', color: '#00aa00', isCompleted: true, order: 3 }
+    ],
+    getPriorities: () => [
+      { id: 'low', value: 'low', label: 'Low', color: '#00aa00', weight: 1 },
+      { id: 'urgent', value: 'urgent', label: 'Urgent', color: '#ff0000', weight: 9 },
+      { id: 'high', value: 'high', label: 'Very high', color: '#ff8800', weight: 3 }
+    ]
+  }
+}
+
+function makeSettings(): PMSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    statuses: DEFAULT_SETTINGS.statuses.map((s) => ({ ...s })),
+    priorities: DEFAULT_SETTINGS.priorities.map((p) => ({ ...p }))
+  }
+}
+
+describe('importTaskNotesPalettes', () => {
+  it('adds unknown statuses and priorities in TaskNotes order', () => {
+    const settings = makeSettings()
+    const { added } = importTaskNotesPalettes(makeApi(), settings)
+
+    const statusIds = settings.statuses.map((s) => s.id)
+    expect(statusIds).toContain('none')
+    expect(statusIds).toContain('open')
+    expect(statusIds.indexOf('none')).toBeLessThan(statusIds.indexOf('open'))
+
+    const priorityIds = settings.priorities.map((p) => p.id)
+    expect(priorityIds).toContain('urgent')
+    // Higher TaskNotes weight lands earlier (most important first).
+    expect(priorityIds.indexOf('urgent')).toBeLessThan(priorityIds.indexOf('low'))
+    expect(added).toBe(3)
+  })
+
+  it('updates label, color, and completion of entries with a matching id', () => {
+    const settings = makeSettings()
+    const { updated } = importTaskNotesPalettes(makeApi(), settings)
+
+    const done = settings.statuses.find((s) => s.id === 'done')
+    expect(done?.label).toBe('Finished')
+    expect(done?.complete).toBe(true)
+    const high = settings.priorities.find((p) => p.id === 'high')
+    expect(high?.label).toBe('Very high')
+    expect(high?.color).toBe('#ff8800')
+    expect(updated).toBeGreaterThanOrEqual(2)
+  })
+
+  it('keeps entries TaskNotes does not know and is idempotent', () => {
+    const settings = makeSettings()
+    importTaskNotesPalettes(makeApi(), settings)
+    expect(settings.statuses.map((s) => s.id)).toContain('blocked')
+    expect(settings.priorities.map((p) => p.id)).toContain('critical')
+
+    const second = importTaskNotesPalettes(makeApi(), settings)
+    expect(second).toEqual({ added: 0, updated: 0 })
+  })
+})

--- a/src/integrations/tasknotes.ts
+++ b/src/integrations/tasknotes.ts
@@ -1,0 +1,177 @@
+import type { App } from 'obsidian'
+import type { PMSettings, PriorityConfig, StatusConfig } from '../types'
+
+export interface TaskNotesStatus {
+  id: string
+  value: string
+  label: string
+  color: string
+  isCompleted: boolean
+  order: number
+}
+
+export interface TaskNotesPriority {
+  id: string
+  value: string
+  label: string
+  color: string
+  weight: number
+}
+
+export interface TaskNotesDependency {
+  uid: string
+  reltype?: string
+  gap?: string
+}
+
+/** A TaskNotes task as returned by its runtime API, with field names already normalized by their field mapping. */
+export interface TaskNotesTaskInfo {
+  path: string
+  title: string
+  status: string
+  priority: string
+  due?: string
+  scheduled?: string
+  timeEstimate?: number
+  tags?: string[]
+  projects?: string[]
+  blockedBy?: Array<TaskNotesDependency | string>
+  archived: boolean
+  completedDate?: string
+  dateCreated?: string
+  dateModified?: string
+  recurrence?: string
+}
+
+/** The slice of the TaskNotes runtime API v1 this plugin consumes. */
+export interface TaskNotesApi {
+  apiVersion: number
+  hasCapability(capability: string): boolean
+  getStatuses(): TaskNotesStatus[]
+  getPriorities(): TaskNotesPriority[]
+  getTask(path: string): Promise<TaskNotesTaskInfo | null>
+  getSettingsSnapshot(): { taskTag?: string; fieldMapping?: Record<string, string> }
+}
+
+function getTaskNotesPlugin(app: App): { api?: unknown } | null {
+  const registry = (app as App & { plugins?: { getPlugin?: (id: string) => unknown } }).plugins
+  const plugin = registry?.getPlugin?.('tasknotes')
+  return plugin && typeof plugin === 'object' ? plugin : null
+}
+
+/** True when the TaskNotes plugin is installed and enabled, regardless of its version. */
+export function isTaskNotesInstalled(app: App): boolean {
+  return getTaskNotesPlugin(app) !== null
+}
+
+/** The TaskNotes runtime API, or null when the plugin is missing or predates API v1 (TaskNotes 4.10). */
+export function getTaskNotesApi(app: App): TaskNotesApi | null {
+  const api = getTaskNotesPlugin(app)?.api as TaskNotesApi | undefined
+  if (!api || api.apiVersion !== 1 || !api.hasCapability('catalog.read')) return null
+  return api
+}
+
+/**
+ * Upsert one ordered TaskNotes palette into ours. Entries with a matching id are
+ * patched in place; missing entries are inserted right after the last TaskNotes
+ * entry we matched, so relative TaskNotes order carries over without disturbing
+ * entries TaskNotes doesn't know.
+ */
+function upsertPalette<T extends { id: string }>(
+  target: T[],
+  incoming: Array<{ id: string; make: () => T; patch: (existing: T) => boolean }>
+): { added: number; updated: number } {
+  let added = 0
+  let updated = 0
+  let anchor = -1
+  for (const item of incoming) {
+    const idx = target.findIndex((cfg) => cfg.id === item.id)
+    if (idx >= 0) {
+      anchor = idx
+      if (item.patch(target[idx])) updated++
+    } else {
+      anchor += 1
+      target.splice(anchor, 0, item.make())
+      added++
+    }
+  }
+  return { added, updated }
+}
+
+/**
+ * Resolve a TaskNotes reference (a "[[wikilink]]" or a plain vault path) to a
+ * vault file path, or null when it doesn't resolve.
+ */
+export function resolveTaskNotesRef(app: App, ref: string, sourcePath: string): string | null {
+  const inner = ref.replace(/^\[\[/, '').replace(/\]\]$/, '').split('|')[0].split('#')[0].trim()
+  if (!inner) return null
+  if (app.vault.getFileByPath(inner)) return inner
+  return app.metadataCache.getFirstLinkpathDest(inner, sourcePath)?.path ?? null
+}
+
+/**
+ * Add palette entries (appended at the end) for TaskNotes status/priority values
+ * that imported tasks use but our settings don't define yet, so those tasks stay
+ * visible in status-driven views. Returns how many entries were added.
+ */
+export function ensurePaletteEntries(
+  api: TaskNotesApi,
+  settings: PMSettings,
+  statusValues: Set<string>,
+  priorityValues: Set<string>
+): number {
+  let added = 0
+  for (const s of api.getStatuses()) {
+    if (statusValues.has(s.value) && !settings.statuses.some((cfg) => cfg.id === s.value)) {
+      settings.statuses.push({ id: s.value, label: s.label, color: s.color, icon: '', complete: s.isCompleted })
+      added++
+    }
+  }
+  for (const p of api.getPriorities()) {
+    if (priorityValues.has(p.value) && !settings.priorities.some((cfg) => cfg.id === p.value)) {
+      settings.priorities.push({ id: p.value, label: p.label, color: p.color, icon: '' })
+      added++
+    }
+  }
+  return added
+}
+
+/** Upsert TaskNotes' configured statuses and priorities into our palettes. */
+export function importTaskNotesPalettes(api: TaskNotesApi, settings: PMSettings): { added: number; updated: number } {
+  const statuses = upsertPalette(
+    settings.statuses,
+    [...api.getStatuses()]
+      .sort((a, b) => a.order - b.order)
+      .map((s) => ({
+        id: s.value,
+        make: () => ({ id: s.value, label: s.label, color: s.color, icon: '', complete: s.isCompleted }),
+        patch: (existing: StatusConfig) => {
+          if (existing.label === s.label && existing.color === s.color && existing.complete === s.isCompleted) {
+            return false
+          }
+          existing.label = s.label
+          existing.color = s.color
+          existing.complete = s.isCompleted
+          return true
+        }
+      }))
+  )
+
+  const priorities = upsertPalette(
+    settings.priorities,
+    [...api.getPriorities()]
+      .sort((a, b) => b.weight - a.weight)
+      .map((p) => ({
+        id: p.value,
+        make: () => ({ id: p.value, label: p.label, color: p.color, icon: '' }),
+        patch: (existing: PriorityConfig) => {
+          if (existing.label === p.label && existing.color === p.color) return false
+          existing.label = p.label
+          existing.color = p.color
+          return true
+        }
+      }))
+  )
+
+  return { added: statuses.added + priorities.added, updated: statuses.updated + priorities.updated }
+}

--- a/src/integrations/tasknotesImport.test.ts
+++ b/src/integrations/tasknotesImport.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import type { TaskNotesTaskInfo } from './tasknotes'
+import { buildImportForest, type TaskNotesImportItem } from './tasknotesImport'
+
+const OPTS = { defaultStatus: 'todo', defaultPriority: 'medium', taskTag: 'task', archiveTag: 'archived' }
+
+function makeInfo(overrides: Partial<TaskNotesTaskInfo> = {}): TaskNotesTaskInfo {
+  return {
+    path: 'Tasks/x.md',
+    title: 'X',
+    status: 'open',
+    priority: 'normal',
+    archived: false,
+    ...overrides
+  }
+}
+
+function makeItem(path: string, overrides: Partial<TaskNotesImportItem> = {}): TaskNotesImportItem {
+  return {
+    path,
+    info: makeInfo({ path, title: path.slice(path.lastIndexOf('/') + 1).replace(/\.md$/, '') }),
+    parentPaths: [],
+    blockedByPaths: [],
+    ...overrides
+  }
+}
+
+describe('buildImportForest', () => {
+  it('maps TaskNotes fields onto the task', () => {
+    const item = makeItem('Tasks/a.md')
+    item.info = makeInfo({
+      path: 'Tasks/a.md',
+      title: 'Write docs',
+      status: 'in-progress',
+      priority: 'high',
+      scheduled: '2026-07-06T09:00',
+      due: '2026-07-10',
+      timeEstimate: 90,
+      tags: ['task', 'docs', 'archived'],
+      completedDate: '2026-07-09',
+      dateCreated: '2026-06-01T10:00:00.000+02:00',
+      recurrence: 'DTSTART:20260706;FREQ=WEEKLY;INTERVAL=2'
+    })
+    const { roots } = buildImportForest([item], OPTS)
+
+    expect(roots).toHaveLength(1)
+    const task = roots[0]
+    expect(task.title).toBe('Write docs')
+    expect(task.status).toBe('in-progress')
+    expect(task.priority).toBe('high')
+    expect(task.start).toBe('2026-07-06')
+    expect(task.due).toBe('2026-07-10')
+    expect(task.timeEstimate).toBe(1.5)
+    expect(task.tags).toEqual(['docs'])
+    expect(task.completed).toBe('2026-07-09')
+    expect(task.createdAt).toBe('2026-06-01T10:00:00.000+02:00')
+    expect(task.recurrence).toEqual({ interval: 'weekly', every: 2 })
+  })
+
+  it('drops complex recurrence rules and falls back to defaults for empty fields', () => {
+    const item = makeItem('Tasks/b.md')
+    item.info = makeInfo({ path: 'Tasks/b.md', title: 'B', status: '', priority: '', recurrence: 'FREQ=HOURLY' })
+    const { roots } = buildImportForest([item], OPTS)
+    expect(roots[0].status).toBe('todo')
+    expect(roots[0].priority).toBe('medium')
+    expect(roots[0].recurrence).toBeUndefined()
+  })
+
+  it('turns project links between imported tasks into parent/child edges', () => {
+    const parent = makeItem('Tasks/parent.md')
+    const child = makeItem('Tasks/child.md', { parentPaths: ['Tasks/parent.md'] })
+    const external = makeItem('Tasks/other.md', { parentPaths: ['Projects/Elsewhere.md'] })
+    const { roots } = buildImportForest([parent, child, external], OPTS)
+
+    expect(roots.map((t) => t.title)).toEqual(['parent', 'other'])
+    expect(roots[0].subtasks.map((t) => t.title)).toEqual(['child'])
+    expect(roots[0].subtasks[0].type).toBe('subtask')
+  })
+
+  it('breaks project-link cycles instead of nesting forever', () => {
+    const a = makeItem('Tasks/a.md', { parentPaths: ['Tasks/b.md'] })
+    const b = makeItem('Tasks/b.md', { parentPaths: ['Tasks/a.md'] })
+    const { roots } = buildImportForest([a, b], OPTS)
+
+    expect(roots).toHaveLength(1)
+    expect(roots[0].subtasks).toHaveLength(1)
+  })
+
+  it('maps blockedBy references within the selection to dependencies and drops the rest', () => {
+    const blocker = makeItem('Tasks/blocker.md')
+    const blocked = makeItem('Tasks/blocked.md', {
+      blockedByPaths: ['Tasks/blocker.md', 'Tasks/not-imported.md']
+    })
+    const { byPath } = buildImportForest([blocker, blocked], OPTS)
+
+    const blockerId = byPath.get('Tasks/blocker.md')?.id
+    expect(byPath.get('Tasks/blocked.md')?.dependencies).toEqual([blockerId])
+  })
+
+  it('marks archived tasks so they land in the archive folder', () => {
+    const item = makeItem('Tasks/done.md')
+    item.info = makeInfo({ path: 'Tasks/done.md', title: 'done', archived: true })
+    const { roots } = buildImportForest([item], OPTS)
+    expect(roots[0].archived).toBe(true)
+  })
+})

--- a/src/integrations/tasknotesImport.ts
+++ b/src/integrations/tasknotesImport.ts
@@ -1,0 +1,123 @@
+import type { Recurrence, Task } from '../types'
+import { makeTask } from '../types'
+import type { TaskNotesTaskInfo } from './tasknotes'
+
+/** One selected TaskNotes task with its link references already resolved to vault paths. */
+export interface TaskNotesImportItem {
+  path: string
+  info: TaskNotesTaskInfo
+  /** Resolved `projects` link paths; the first one that is also being imported becomes the parent. */
+  parentPaths: string[]
+  /** Resolved `blockedBy` paths; entries that are also being imported become dependencies. */
+  blockedByPaths: string[]
+}
+
+export interface TaskNotesImportOptions {
+  defaultStatus: string
+  defaultPriority: string
+  /** TaskNotes' task-identification tag, stripped from imported tags (usually "task"). */
+  taskTag: string
+  /** TaskNotes' archive tag, stripped from imported tags (usually "archived"). */
+  archiveTag: string
+}
+
+const RRULE_INTERVALS: Record<string, Recurrence['interval']> = {
+  DAILY: 'daily',
+  WEEKLY: 'weekly',
+  MONTHLY: 'monthly',
+  YEARLY: 'yearly'
+}
+
+/** Map a simple RRULE (FREQ + optional INTERVAL) to our recurrence model; complex rules are dropped. */
+function mapRecurrence(rrule: string | undefined): Recurrence | undefined {
+  const freq = rrule?.match(/FREQ=(DAILY|WEEKLY|MONTHLY|YEARLY)/)
+  if (!freq) return undefined
+  const every = rrule?.match(/INTERVAL=(\d+)/)
+  return { interval: RRULE_INTERVALS[freq[1]], every: every ? parseInt(every[1], 10) : 1 }
+}
+
+function dateOnly(value: string | undefined): string {
+  return value ? value.slice(0, 10) : ''
+}
+
+function mapItemToTask(item: TaskNotesImportItem, opts: TaskNotesImportOptions): Task {
+  const info = item.info
+  const task = makeTask({
+    title: info.title || item.path.slice(item.path.lastIndexOf('/') + 1).replace(/\.md$/, ''),
+    status: info.status || opts.defaultStatus,
+    priority: info.priority || opts.defaultPriority,
+    start: dateOnly(info.scheduled),
+    due: dateOnly(info.due),
+    completed: dateOnly(info.completedDate),
+    tags: (info.tags ?? []).filter((t) => t !== opts.taskTag && t !== opts.archiveTag),
+    recurrence: mapRecurrence(info.recurrence)
+  })
+  if (info.timeEstimate && info.timeEstimate > 0) {
+    task.timeEstimate = Math.round((info.timeEstimate / 60) * 100) / 100
+  }
+  if (info.dateCreated) task.createdAt = info.dateCreated
+  if (info.dateModified) task.updatedAt = info.dateModified
+  if (info.archived) task.archived = true
+  return task
+}
+
+/**
+ * Convert resolved TaskNotes tasks into a task forest: project links between
+ * imported tasks become parent/child edges (first match wins, cycles break to
+ * root), and blockedBy references between imported tasks become dependencies.
+ * References to notes outside the import selection are dropped.
+ */
+export function buildImportForest(
+  items: TaskNotesImportItem[],
+  opts: TaskNotesImportOptions
+): { roots: Task[]; byPath: Map<string, Task> } {
+  const byPath = new Map<string, Task>()
+  for (const item of items) {
+    byPath.set(item.path, mapItemToTask(item, opts))
+  }
+
+  const parentOf = new Map<string, string>()
+  for (const item of items) {
+    const candidate = item.parentPaths.find((p) => p !== item.path && byPath.has(p))
+    if (!candidate) continue
+    // Walk the ancestor chain; adopting a parent whose ancestry includes this
+    // task would create a cycle, so such a task stays a root.
+    let ancestor: string | undefined = candidate
+    let cycle = false
+    while (ancestor) {
+      if (ancestor === item.path) {
+        cycle = true
+        break
+      }
+      ancestor = parentOf.get(ancestor)
+    }
+    if (!cycle) parentOf.set(item.path, candidate)
+  }
+
+  const roots: Task[] = []
+  for (const item of items) {
+    const task = byPath.get(item.path)
+    if (!task) continue
+    const parentPath = parentOf.get(item.path)
+    if (parentPath) {
+      const parent = byPath.get(parentPath)
+      if (parent) {
+        task.type = 'subtask'
+        parent.subtasks.push(task)
+        continue
+      }
+    }
+    roots.push(task)
+  }
+
+  for (const item of items) {
+    const task = byPath.get(item.path)
+    if (!task) continue
+    task.dependencies = item.blockedByPaths
+      .filter((p) => p !== item.path && byPath.has(p))
+      .map((p) => byPath.get(p)?.id)
+      .filter((id): id is string => !!id)
+  }
+
+  return { roots, byPath }
+}

--- a/src/modals/ImportModal.ts
+++ b/src/modals/ImportModal.ts
@@ -2,6 +2,14 @@ import { App, Modal, TFile, Notice } from 'obsidian'
 import type PMPlugin from '../main'
 import type { Project, TaskStatus, TaskPriority } from '../types'
 import { getDefaultStatusId, getDefaultPriorityId } from '../utils'
+import {
+  ensurePaletteEntries,
+  getTaskNotesApi,
+  resolveTaskNotesRef,
+  type TaskNotesApi,
+  type TaskNotesTaskInfo
+} from '../integrations/tasknotes'
+import { buildImportForest, type TaskNotesImportItem } from '../integrations/tasknotesImport'
 
 interface FileItem {
   file: TFile
@@ -324,7 +332,19 @@ export class ImportModal extends Modal {
     let skipped = 0
     let imported = 0
 
+    const api = getTaskNotesApi(this.app)
+    const taskNotesApi = api?.hasCapability('tasks.read') ? api : null
+    const taskNotesTasks: Array<{ file: TFile; info: TaskNotesTaskInfo }> = []
+
     for (const file of selectedFiles) {
+      const alreadyPmTask = this.app.metadataCache.getFileCache(file)?.frontmatter?.['pm-task'] === true
+      if (taskNotesApi && !alreadyPmTask) {
+        const info = await taskNotesApi.getTask(file.path).catch(() => null)
+        if (info) {
+          taskNotesTasks.push({ file, info })
+          continue
+        }
+      }
       try {
         const result = await this.plugin.store.importNoteAsTask(this.project, file, {
           status: this.defaultStatus,
@@ -339,6 +359,15 @@ export class ImportModal extends Modal {
       }
     }
 
+    if (taskNotesApi && taskNotesTasks.length) {
+      try {
+        imported += await this.importTaskNotesTasks(taskNotesApi, this.project, taskNotesTasks)
+      } catch (err) {
+        console.error('Failed to import TaskNotes tasks:', err)
+        skipped += taskNotesTasks.length
+      }
+    }
+
     if (this.onImportComplete) {
       this.onImportComplete()
     }
@@ -350,6 +379,54 @@ export class ImportModal extends Modal {
     new Notice(message, 3000)
 
     this.close()
+  }
+
+  /**
+   * Convert TaskNotes tasks preserving their fields: scheduled/due dates,
+   * blockedBy dependencies and project-link hierarchy (within the selection),
+   * tags, time estimate, completion, and archive state.
+   */
+  private async importTaskNotesTasks(
+    api: TaskNotesApi,
+    project: Project,
+    tasks: Array<{ file: TFile; info: TaskNotesTaskInfo }>
+  ): Promise<number> {
+    const snapshot = api.hasCapability('settings.snapshot') ? api.getSettingsSnapshot() : {}
+    const taskTag = snapshot.taskTag || 'task'
+    const archiveTag = snapshot.fieldMapping?.archiveTag || 'archived'
+
+    const resolve = (refs: string[] | undefined, sourcePath: string): string[] =>
+      (refs ?? []).map((ref) => resolveTaskNotesRef(this.app, ref, sourcePath)).filter((p): p is string => p !== null)
+
+    const items: TaskNotesImportItem[] = tasks.map(({ file, info }) => ({
+      path: file.path,
+      info,
+      parentPaths: resolve(info.projects, file.path),
+      blockedByPaths: resolve(
+        (info.blockedBy ?? []).map((dep) => (typeof dep === 'string' ? dep : dep.uid)),
+        file.path
+      )
+    }))
+
+    const { roots, byPath } = buildImportForest(items, {
+      defaultStatus: this.defaultStatus,
+      defaultPriority: this.defaultPriority,
+      taskTag,
+      archiveTag
+    })
+
+    const usedStatuses = new Set(items.map((i) => i.info.status).filter(Boolean))
+    const usedPriorities = new Set(items.map((i) => i.info.priority).filter(Boolean))
+    if (ensurePaletteEntries(api, this.plugin.settings, usedStatuses, usedPriorities) > 0) {
+      await this.plugin.saveSettings()
+    }
+
+    const sources = new Map<string, TFile>()
+    for (const { file } of tasks) {
+      const task = byPath.get(file.path)
+      if (task) sources.set(task.id, file)
+    }
+    return this.plugin.store.importTaskForest(project, roots, sources, this.fileHandling)
   }
 
   setProject(project: Project): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,6 +2,7 @@ import { AbstractInputSuggest, App, PluginSettingTab, Setting, Notice, getIconId
 import type PMPlugin from './main'
 import { PMSettings, DEFAULT_SETTINGS, makeId } from './types'
 import { flattenTasks } from './store/TaskTreeOps'
+import { getTaskNotesApi, importTaskNotesPalettes, isTaskNotesInstalled } from './integrations/tasknotes'
 
 export type { PMSettings }
 export { DEFAULT_SETTINGS }
@@ -261,6 +262,31 @@ export class PMSettingTab extends PluginSettingTab {
           this.renderPriorityList(priorityContainer)
         })
     )
+
+    if (isTaskNotesInstalled(this.app)) {
+      new Setting(containerEl).setName('TaskNotes').setHeading()
+
+      new Setting(containerEl)
+        .setName('Import statuses and priorities')
+        .setDesc('Add or update statuses and priorities to match TaskNotes. Entries TaskNotes does not know are kept.')
+        .addButton((btn) =>
+          btn.setButtonText('Import from TaskNotes').onClick(() => {
+            const api = getTaskNotesApi(this.app)
+            if (!api) {
+              new Notice('TaskNotes 4.10 or newer is required.')
+              return
+            }
+            const { added, updated } = importTaskNotesPalettes(api, this.plugin.settings)
+            void this.plugin.saveSettings()
+            this.display()
+            new Notice(
+              added || updated
+                ? `Imported from TaskNotes: ${added} added, ${updated} updated.`
+                : 'Statuses and priorities already match TaskNotes.'
+            )
+          })
+        )
+    }
   }
 
   private renderMembersList(container: HTMLElement): void {

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -843,3 +843,44 @@ describe('ProjectStore.importNoteAsTask', () => {
     expect(await vault.read(existing)).toBe(before)
   })
 })
+
+describe('ProjectStore.importTaskForest', () => {
+  it('writes a parent/child forest that reloads as a tree with dependencies', async () => {
+    const { store, vault, app } = newStore()
+    const project = await store.createProject('Forest', 'Projects')
+    const parentSource = await vault.create('Notes/Parent.md', 'parent body')
+    const childSource = await vault.create('Notes/Child.md', 'child body')
+
+    const child = makeTask({ title: 'Child', type: 'subtask' })
+    const parent = makeTask({ title: 'Parent', subtasks: [child] })
+    child.dependencies = [parent.id]
+    const sources = new Map([
+      [parent.id, parentSource],
+      [child.id, childSource]
+    ])
+
+    const count = await store.importTaskForest(project, [parent], sources, 'move')
+    expect(count).toBe(2)
+    expect(vault.getAbstractFileByPath('Notes/Parent.md')).toBeNull()
+
+    const store2 = new ProjectStore(app, () => STATUSES)
+    const file = vault.getAbstractFileByPath(project.filePath)
+    if (!(file instanceof TFile)) throw new Error('project file missing')
+    const reloaded = expectDefined(await store2.loadProject(file))
+    const top = reloaded.tasks.find((t) => t.title === 'Parent')
+    expect(expectDefined(top).subtasks.map((t) => t.title)).toEqual(['Child'])
+    expect(expectDefined(top).subtasks[0].dependencies).toEqual([parent.id])
+    expect(expectDefined(top).description).toBe('parent body')
+  })
+
+  it('places archived tasks in the Archive subfolder', async () => {
+    const { store, vault } = newStore()
+    const project = await store.createProject('Arch', 'Projects')
+    const source = await vault.create('Notes/Old.md', 'old body')
+    const task = makeTask({ title: 'Old', archived: true })
+
+    await store.importTaskForest(project, [task], new Map([[task.id, source]]), 'copy')
+    expect(vault.getAbstractFileByPath('Projects/Arch_tasks/Archive/old.md')).toBeInstanceOf(TFile)
+    expect(vault.getAbstractFileByPath('Notes/Old.md')).toBeInstanceOf(TFile)
+  })
+})

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -735,6 +735,55 @@ export class ProjectStore implements TaskSource {
     return 'imported'
   }
 
+  /**
+   * Persist a converted task forest (e.g. a TaskNotes import) as task files.
+   * Each node's description comes from its source note body; 'move' turns the
+   * source file into the task file, 'copy' leaves sources untouched. The
+   * project file is not rewritten — the next load self-heals top-level order
+   * and parenting from the written parentId/subtaskIds.
+   */
+  async importTaskForest(
+    project: Project,
+    roots: Task[],
+    sources: Map<string, TFile>,
+    handling: 'move' | 'copy'
+  ): Promise<number> {
+    const baseFolder = this.projectTaskFolder(project)
+    await this.ensureFolder(baseFolder)
+    let imported = 0
+
+    const writeNode = async (task: Task, parent: Task | null): Promise<void> => {
+      const folder = task.archived ? normalizePath(baseFolder + '/Archive') : baseFolder
+      if (task.archived) await this.ensureFolder(folder)
+      const source = sources.get(task.id)
+      if (source) {
+        const { body } = parseFrontmatter(await this.app.vault.read(source))
+        task.description = body
+      }
+      const desired = taskFilePath(task.title, folder)
+      const dest = this.uniqueChildPath(folder, desired.slice(desired.lastIndexOf('/') + 1))
+      const content = serializeTask(task, project, parent)
+      if (handling === 'move' && source) {
+        await this.app.fileManager.renameFile(source, dest)
+        const moved = this.app.vault.getAbstractFileByPath(dest)
+        if (moved instanceof TFile) {
+          await this.app.vault.process(moved, () => content)
+        }
+      } else {
+        await this.app.vault.create(dest, content)
+      }
+      imported++
+      for (const child of task.subtasks) {
+        await writeNode(child, task)
+      }
+    }
+
+    for (const root of roots) {
+      await writeNode(root, null)
+    }
+    return imported
+  }
+
   async duplicateTask(project: Project, sourceId: string, includeSubtasks: boolean): Promise<Task | null> {
     const source = findTaskById(project, sourceId)
     if (!source) return null

--- a/src/store/TaskSource.ts
+++ b/src/store/TaskSource.ts
@@ -32,6 +32,12 @@ export interface TaskSource {
   insertTask(project: Project, task: Task, parentId?: string | null): Promise<void>
   duplicateTask(project: Project, sourceId: string, includeSubtasks: boolean): Promise<Task | null>
   importNoteAsTask(project: Project, file: TFile, opts: ImportNoteOptions): Promise<'imported' | 'skipped'>
+  importTaskForest(
+    project: Project,
+    roots: Task[],
+    sources: Map<string, TFile>,
+    handling: 'move' | 'copy'
+  ): Promise<number>
   updateTask(project: Project, taskId: string, patch: Partial<Task>): Promise<void>
   updateTasks(
     project: Project,


### PR DESCRIPTION
First slice of the TaskNotes integration (#16).

- the import command now recognizes TaskNotes tasks (via their runtime API, so custom field names work) and keeps dates, tags, time estimates, completion, archive state, blockedBy dependencies, and project-link hierarchy within the selection
- new settings button imports TaskNotes' status/priority palettes, upserting by id so existing entries survive
- statuses/priorities used by imported tasks get added to the palettes automatically so tasks don't vanish from kanban
- README section on using both plugins together, including the reverse setup (TaskNotes reading pm tasks)

Needs TaskNotes 4.10+, degrades to the plain note import without it. 189 tests pass (11 new), verified against real TaskNotes data in a dev vault.