### PR TITLE
let each project choose which statuses it uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Status and priority icons accept emoji or any icon available in Obsidian, including Lucide icons and icons added by other plugins, with suggestions while typing in settings
 - TaskNotes tasks can be imported with their dates, dependencies, subtasks, tags, and archive state ([#16](https://github.com/StepanKropachev/obsidian-pm/issues/16))
 - Statuses and priorities can be imported from TaskNotes in settings ([#16](https://github.com/StepanKropachev/obsidian-pm/issues/16))
+- Projects can limit which statuses they use, hiding the other kanban columns ([#57](https://github.com/StepanKropachev/obsidian-pm/issues/57))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Card-based board grouped by status. Drag cards between columns to update status 
 ### Customization
 - **Custom fields** — Add per-project fields: text, number, date, select, multi-select, person, checkbox, URL.
 - **Custom statuses & priorities** — Edit labels, colors, and icons for each status and priority level.
+- **Per-project statuses** — Each project can limit which statuses it uses, so its board only shows relevant columns. Statuses still in use by tasks always stay visible.
 - **Saved views** — Save filter/sort combinations in Table view and switch between them instantly.
 - **Team roster** — Manage a global team list for assignment across all projects, plus per-project team members.
 

--- a/src/modals/ProjectModal.ts
+++ b/src/modals/ProjectModal.ts
@@ -1,9 +1,10 @@
-import { App, ButtonComponent, Modal } from 'obsidian'
+import { App, ButtonComponent, Modal, Notice } from 'obsidian'
 import type PMPlugin from '../main'
 import { Project, CustomFieldDef, makeId, makeProject } from '../types'
 import { rebuildTaskIndex } from '../store'
-import { safeAsync } from '../utils'
+import { formatBadgeText, safeAsync } from '../utils'
 import { Avatar } from '../ui/primitives/Avatar'
+import { renderStatusDot } from '../ui/StatusBadge'
 
 const PROJECT_COLORS = [
   '#8b72be',
@@ -209,6 +210,38 @@ export class ProjectModal extends Modal {
       })
     }
     renderCFs()
+
+    // ── Statuses ──────────────────────────────────────────────────────────────
+    const statusSection = el.createDiv('pm-modal-section')
+    const statusHeader = statusSection.createDiv('pm-modal-section-header')
+    statusHeader.createSpan({ text: 'Statuses', cls: 'pm-modal-subheading' })
+    statusHeader.createSpan({ text: 'Which statuses this project uses', cls: 'pm-modal-hint' })
+
+    const allStatuses = this.plugin.settings.statuses
+    const enabledSet = new Set(
+      this.project.enabledStatuses?.length ? this.project.enabledStatuses : allStatuses.map((s) => s.id)
+    )
+    const statusList = statusSection.createDiv('pm-status-toggle-list')
+    for (const s of allStatuses) {
+      const row = statusList.createEl('label', { cls: 'pm-status-toggle' })
+      const checkbox = row.createEl('input', { type: 'checkbox' })
+      checkbox.checked = enabledSet.has(s.id)
+      renderStatusDot(row, s.id, allStatuses, 'pm-status-toggle-dot')
+      row.createSpan({ text: formatBadgeText(s.icon, s.label) })
+      checkbox.addEventListener('change', () => {
+        if (checkbox.checked) {
+          enabledSet.add(s.id)
+        } else if (enabledSet.size === 1) {
+          checkbox.checked = true
+          new Notice('A project needs at least one status.')
+          return
+        } else {
+          enabledSet.delete(s.id)
+        }
+        // All enabled is stored as "no selection" so new global statuses show up automatically.
+        this.project.enabledStatuses = enabledSet.size === allStatuses.length ? undefined : [...enabledSet]
+      })
+    }
 
     // ── Footer ────────────────────────────────────────────────────────────────
     const footer = el.createDiv('pm-modal-footer')

--- a/src/modals/TaskFormFields.ts
+++ b/src/modals/TaskFormFields.ts
@@ -4,7 +4,7 @@ import { flattenTasks } from '../store/TaskTreeOps'
 import { wouldCreateCycle } from '../store/Scheduler'
 import { renderPropRow } from '../ui/FormField'
 import { PRIORITY_CHEVRONS } from '../ui/StatusBadge'
-import { isTerminalStatus, stringToColor } from '../utils'
+import { isTerminalStatus, projectStatuses, stringToColor } from '../utils'
 import { renderCustomFieldInput } from './CustomFieldInputs'
 import {
   renderSelectControl,
@@ -117,7 +117,12 @@ export function renderTaskFormFields(container: HTMLElement, ctx: TaskFormFields
       renderSelectControl({
         container: cell,
         value: task.status,
-        options: statuses.map((s) => ({ id: s.id, label: s.label, color: s.color, icon: s.icon || undefined })),
+        options: projectStatuses(project, statuses).map((s) => ({
+          id: s.id,
+          label: s.label,
+          color: s.color,
+          icon: s.icon || undefined
+        })),
         onChange: (id) => {
           task.status = id
           rerender()

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -884,3 +884,31 @@ describe('ProjectStore.importTaskForest', () => {
     expect(vault.getAbstractFileByPath('Notes/Old.md')).toBeInstanceOf(TFile)
   })
 })
+
+describe('per-project enabled statuses', () => {
+  it('round-trips enabledStatuses through the project file', async () => {
+    const { store, vault, app } = newStore()
+    const project = await store.createProject('Subset', 'Projects')
+    project.enabledStatuses = ['todo', 'done']
+    await store.saveProject(project)
+
+    const store2 = new ProjectStore(app, () => STATUSES)
+    const file = vault.getAbstractFileByPath(project.filePath)
+    if (!(file instanceof TFile)) throw new Error('project file missing')
+    const reloaded = expectDefined(await store2.loadProject(file))
+    expect(reloaded.enabledStatuses).toEqual(['todo', 'done'])
+  })
+
+  it('omits the frontmatter key when no subset is selected', async () => {
+    const { store, vault, app } = newStore()
+    const project = await store.createProject('All', 'Projects')
+    await store.saveProject(project)
+
+    const store2 = new ProjectStore(app, () => STATUSES)
+    const file = vault.getAbstractFileByPath(project.filePath)
+    if (!(file instanceof TFile)) throw new Error('project file missing')
+    expect(await vault.read(file)).not.toContain('enabledStatuses')
+    const reloaded = expectDefined(await store2.loadProject(file))
+    expect(reloaded.enabledStatuses).toBeUndefined()
+  })
+})

--- a/src/store/YamlHydrator.ts
+++ b/src/store/YamlHydrator.ts
@@ -119,6 +119,9 @@ export function hydrateProjectFromFrontmatter(
     updatedAt: (frontmatter.updatedAt as string) ?? new Date().toISOString(),
     filePath,
     savedViews: hydrateSavedViews((frontmatter.savedViews as unknown[]) ?? []),
+    enabledStatuses: Array.isArray(frontmatter.enabledStatuses)
+      ? [...(frontmatter.enabledStatuses as string[])]
+      : undefined,
     taskIndex: new Map()
   }
 }

--- a/src/store/YamlSerializer.ts
+++ b/src/store/YamlSerializer.ts
@@ -28,6 +28,9 @@ export function serializeProject(project: Project, statuses: StatusConfig[] = []
     createdAt: project.createdAt,
     updatedAt: project.updatedAt
   }
+  if (project.enabledStatuses?.length) {
+    fm.enabledStatuses = project.enabledStatuses
+  }
 
   const yamlLines: string[] = ['---']
   appendYaml(yamlLines, fm, 0)

--- a/src/styles/project-modal.css
+++ b/src/styles/project-modal.css
@@ -319,3 +319,22 @@
   font-size: 12px;
   color: var(--text-muted);
 }
+
+.pm-status-toggle-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.pm-status-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-ui-smaller);
+  cursor: pointer;
+}
+.pm-status-toggle-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,8 @@ export interface Project {
   updatedAt: string
   filePath: string // resolved vault path
   savedViews: SavedView[]
+  /** Status ids this project uses. Undefined or empty = all global statuses. */
+  enabledStatuses?: string[]
   /** Transient id → {task, parentId} index. Rebuilt on load, maintained by store mutators. Not serialized. */
   taskIndex: TaskIndex
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_STATUSES, makeProject, makeTask } from './types'
+import { projectStatuses } from './utils'
+
+function makeSubsetProject(enabled?: string[]) {
+  const project = makeProject('P', 'Projects/P.md')
+  project.enabledStatuses = enabled
+  return project
+}
+
+describe('projectStatuses', () => {
+  it('returns all global statuses when the project has no selection', () => {
+    expect(projectStatuses(makeSubsetProject(), DEFAULT_STATUSES)).toEqual(DEFAULT_STATUSES)
+    expect(projectStatuses(makeSubsetProject([]), DEFAULT_STATUSES)).toEqual(DEFAULT_STATUSES)
+  })
+
+  it('filters to the enabled subset in global order', () => {
+    const result = projectStatuses(makeSubsetProject(['done', 'todo']), DEFAULT_STATUSES)
+    expect(result.map((s) => s.id)).toEqual(['todo', 'done'])
+  })
+
+  it('keeps statuses that tasks still use even when disabled', () => {
+    const project = makeSubsetProject(['todo', 'done'])
+    project.tasks.push(makeTask({ status: 'blocked' }))
+    const result = projectStatuses(project, DEFAULT_STATUSES)
+    expect(result.map((s) => s.id)).toEqual(['todo', 'blocked', 'done'])
+  })
+
+  it('checks subtask statuses too', () => {
+    const project = makeSubsetProject(['todo'])
+    const parent = makeTask({ status: 'todo' })
+    parent.subtasks.push(makeTask({ status: 'review' }))
+    project.tasks.push(parent)
+    const result = projectStatuses(project, DEFAULT_STATUSES)
+    expect(result.map((s) => s.id)).toEqual(['todo', 'review'])
+  })
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import { Notice, setIcon } from 'obsidian'
-import type { Task, StatusConfig, PriorityConfig, TaskPriority } from './types'
+import type { Project, Task, StatusConfig, PriorityConfig, TaskPriority } from './types'
 import { today, parsePlainDate, Temporal } from './dates'
+import { flattenTasks } from './store/TaskTreeOps'
 
 /** Deterministic HSL color from a string (e.g. assignee name) */
 export function stringToColor(s: string): string {
@@ -44,6 +45,18 @@ export function getDefaultPriorityId(priorities: PriorityConfig[]): string {
 export function getCompleteStatusId(statuses: StatusConfig[]): string {
   const found = statuses.find((s) => s.complete)
   return found ? found.id : 'done'
+}
+
+/**
+ * Statuses available in a project: the enabled subset (all when the project has
+ * no selection), plus any status its tasks still use so nothing disappears.
+ * Terminal-status checks must keep using the full global list.
+ */
+export function projectStatuses(project: Project, statuses: StatusConfig[]): StatusConfig[] {
+  if (!project.enabledStatuses?.length) return statuses
+  const enabled = new Set(project.enabledStatuses)
+  const inUse = new Set(flattenTasks(project.tasks).map((f) => f.task.status))
+  return statuses.filter((s) => enabled.has(s.id) || inUse.has(s.id))
 }
 
 /** Returns the sort index of a status in the config array (999 for unknown) */

--- a/src/views/KanbanView.ts
+++ b/src/views/KanbanView.ts
@@ -3,7 +3,7 @@ import type PMPlugin from '../main'
 import { Project, Task, TaskStatus, FilterState } from '../types'
 import { flattenTasks, totalLoggedHours } from '../store/TaskTreeOps'
 import { matchesFilter } from '../store/TaskFilter'
-import { isTaskOverdue, isTerminalStatus, getPriorityConfig } from '../utils'
+import { isTaskOverdue, isTerminalStatus, getPriorityConfig, projectStatuses } from '../utils'
 import { openTaskModal } from '../ui/ModalFactory'
 import { buildTaskContextMenu } from '../ui/TaskContextMenu'
 import { KanbanColumn, type KanbanCardData } from '../ui/composites/KanbanColumn'
@@ -33,7 +33,7 @@ export class KanbanView implements SubView {
 
     const board = this.container.createDiv('pm-kanban-board')
 
-    for (const status of this.plugin.settings.statuses) {
+    for (const status of projectStatuses(this.project, this.plugin.settings.statuses)) {
       const tasks = this.getTasksForStatus(status.id)
       const cards = tasks.map((task) => this.buildCardData(task))
       new KanbanColumn(board, {

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -1,7 +1,7 @@
 import { ButtonComponent, ExtraButtonComponent, ItemView, WorkspaceLeaf, TFile, EventRef } from 'obsidian'
 import type PMPlugin from '../main'
 import { Project, ViewMode, FilterState, SavedView, makeDefaultFilter, makeId } from '../types'
-import { truncateTitle, safeAsync } from '../utils'
+import { truncateTitle, safeAsync, projectStatuses } from '../utils'
 import type { SubView } from './SubView'
 import { TableView } from './table/TableView'
 import type { TableViewState } from './table/TableView'
@@ -198,7 +198,7 @@ export class ProjectView extends ItemView {
     this.headerEl.empty()
     this.header = new ProjectHeader(this.headerEl, {
       project: this.project,
-      statuses: this.plugin.settings.statuses,
+      statuses: projectStatuses(this.project, this.plugin.settings.statuses),
       priorities: this.plugin.settings.priorities,
       filter: this.filter,
       activeSavedViewId: this.activeSavedViewId,

--- a/src/views/table/BulkActionBar.ts
+++ b/src/views/table/BulkActionBar.ts
@@ -2,7 +2,7 @@ import { ButtonComponent, ExtraButtonComponent, Menu } from 'obsidian'
 import type { Task, TaskStatus, TaskPriority } from '../../types'
 import { flattenTasks, collectAllAssignees, collectAllTags } from '../../store'
 import { findTaskById } from '../../store/TaskIndex'
-import { formatBadgeText } from '../../utils'
+import { formatBadgeText, projectStatuses } from '../../utils'
 import { today } from '../../dates'
 import { promptText } from '../../ui/ModalFactory'
 import { TaskPickerModal } from '../../modals/PickerModals'
@@ -62,7 +62,7 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
   // Status button
   new ButtonComponent(left).setButtonText('Set status').onClick((e) => {
     const menu = new Menu()
-    for (const s of ctx.plugin.settings.statuses) {
+    for (const s of projectStatuses(ctx.project, ctx.plugin.settings.statuses)) {
       menu.addItem((item) =>
         item.setTitle(formatBadgeText(s.icon, s.label)).onClick(() => onAction({ type: 'set-status', status: s.id }))
       )

--- a/src/views/table/TableRow.ts
+++ b/src/views/table/TableRow.ts
@@ -1,5 +1,12 @@
 import { Menu } from 'obsidian'
-import { getStatusConfig, isTaskOverdue, isTerminalStatus, safeAsync, stringifyCustomValue } from '../../utils'
+import {
+  getStatusConfig,
+  isTaskOverdue,
+  isTerminalStatus,
+  projectStatuses,
+  safeAsync,
+  stringifyCustomValue
+} from '../../utils'
 import { totalLoggedHours } from '../../store/TaskTreeOps'
 import { today, parsePlainDate } from '../../dates'
 import type { Task } from '../../types'
@@ -102,7 +109,7 @@ export function renderTaskRow(tbody: HTMLElement, task: Task, depth: number, ctx
 
   new StatusCell(row, {
     task,
-    statuses: ctx.plugin.settings.statuses,
+    statuses: projectStatuses(ctx.project, ctx.plugin.settings.statuses),
     onChange: safeAsync(async (status) => {
       await ctx.plugin.store.updateTask(ctx.project, task.id, { status })
       await ctx.onRefresh()


### PR DESCRIPTION
Closes #57.

Projects get a status checklist in the project modal. Kanban, pickers, and the status filter only offer the enabled ones, but statuses still in use by tasks always render so nothing disappears. Terminal-status logic (scheduling, done counts) keeps the full global list. No selection means all statuses, so existing projects don't change.