### PR TITLE
add a ui styleguide and consolidate duplicated ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove buttons in the task editor, project editor, and settings are icon buttons with tooltips
 - The import dialog uses Obsidian's native buttons
 - The Gantt zoom control uses Obsidian's native buttons
+- Filter and saved-view buttons match Obsidian's native buttons, with an accent tint when active
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Projects can define their own statuses and priorities in the project settings, replacing the global ones ([#57](https://github.com/StepanKropachev/obsidian-pm/issues/57))
 - Projects can override the default view, auto-scheduling, and the board display options in the project settings
 
+### Changed
+
+- Add buttons in the table, Gantt, project editor, and settings share one quiet style
+- Remove buttons in the task editor, project editor, and settings are icon buttons with tooltips
+- The import dialog uses Obsidian's native buttons
+- The Gantt zoom control uses Obsidian's native buttons
+
 ### Fixed
 
 - The import dialog offered the built-in statuses and priorities instead of the configured ones

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -159,10 +159,9 @@ No wrappers for these:
 
 These exist in the codebase; don't copy them. Each row has a follow-up todo; new code uses the replacement.
 
-| Ad-hoc pattern                          | Where                                     | Use instead                | Todo                               |
-| --------------------------------------- | ----------------------------------------- | -------------------------- | ---------------------------------- |
-| new `--pm-*` CSS variables              | `src/styles/variables.css` legacy aliases | Obsidian theme variables   | `todos/token-unification.md`       |
-| `.pm-pill` vs `.pm-chip` style overlap  | `src/styles/table.css`                    | one capsule base (planned) | `todos/chip-pill-consolidation.md` |
+| Ad-hoc pattern             | Where                                     | Use instead              | Todo                         |
+| -------------------------- | ----------------------------------------- | ------------------------ | ---------------------------- |
+| new `--pm-*` CSS variables | `src/styles/variables.css` legacy aliases | Obsidian theme variables | `todos/token-unification.md` |
 
 ## Live gallery
 

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -11,7 +11,7 @@ Before writing any new UI element, find your case here:
 - Need a small label, badge, or token (status, priority, tag, due date, count) -> `Chip`
 - Need a text button -> Obsidian `ButtonComponent`
 - Need an icon-only button -> `IconButton`
-- Need a toggleable filter button -> `Pill`
+- Need a compact button, toggleable or not -> `ChipButton`
 - Need a remove/x button on a token -> `Chip.setRemovable`
 - Need an "+ add" ghost row or button -> `renderAddButton`
 - Need mutually-exclusive options -> `SegmentedControl` (text) or `ViewSwitcher` (icons)
@@ -39,16 +39,16 @@ The unified label primitive: status, priority, tags, due dates, time, small badg
 - API: `new Chip(parent).setLabel(text).setVariant('solid'|'outline'|'plain').setColor(cssColor).setDot(bool).setLeadingIcon(lucide).setTag(bool).setStrong(bool).setShape('rounded'|'pill').setSize('md'|'sm').setTooltip(text).setRemovable(onRemove).onClick(handler)`
 - CSS: `pm-chip` + `--solid/--outline/--plain/--tag/--strong/--pill/--sm/--interactive`, parts `pm-chip-label/-icon/-dot/-rm`; color flows through `--pm-chip-color`
 - Use when: any small labeled token, clickable or not (`onClick` adds hover/click styling)
-- Not when: a toggleable filter button (`Pill`) or a text action button (`ButtonComponent`)
+- Not when: a real button (`ChipButton` when compact, `ButtonComponent` otherwise)
 
-### Pill - `Pill.ts`
+### ChipButton - `ChipButton.ts`
 
-Toggleable filter button: saved views, filter dropdowns, due/archived toggles. Wraps Obsidian's `ButtonComponent`, compacted; active carries the plugin's 12% accent-tint selection signature.
+The button sibling of `Chip`: a compact native button with an optional persistent active state. Wraps Obsidian's `ButtonComponent`; active carries the plugin's 12% accent-tint selection signature. Used by saved views, filter dropdowns, due/archived toggles, and the filter row's Clear.
 
-- API: `new Pill(parent).setLabel(text).setActive(bool).setShape('rounded'|'pill').setAriaLabel(text).onClick(h).onContextMenu(h)`
-- CSS: `button.pm-pill` (the `button` prefix outranks core button chrome), `--active`, `--pill`
-- Use when: a button whose pressed/active state persists (filters, saved views), or a one-shot action sitting in a pill row that must match its size (the filter row's Clear)
-- Not when: a non-interactive label (`Chip`) or a standalone action button (`ButtonComponent`)
+- API: `new ChipButton(parent).setLabel(text).setActive(bool).setShape('rounded'|'pill').setAriaLabel(text).onClick(h).onContextMenu(h)`
+- CSS: `button.pm-chip-btn` (the `button` prefix outranks core button chrome), `--active`, `--pill`
+- Use when: a compact button among chips/capsules, with or without persistent state
+- Not when: a non-interactive label (`Chip`) or a standalone full-size action button (`ButtonComponent`)
 
 ### Avatar / AvatarStack - `Avatar.ts`, `AvatarStack.ts`
 
@@ -129,7 +129,7 @@ Take resolved data + callbacks via props. No `plugin`, no `store`, no `onRefresh
 - **tagChip** - `tagChip.ts`. `renderTagChip(parent, tag, colored)` -> outline tag Chip with optional color dot. The only way to render a tag.
 - **timeChip** - `timeChip.ts`. `renderTimeChip(parent, logged, estimate, size?)` -> `logged/estimateh` Chip, red solid when logged exceeds the estimate; renders nothing when both are 0. The only way to render logged/estimate hours.
 - **dueChip** - `dueChip.ts`. `renderDueChip(parent, label, urgency, size?)` -> due-date Chip, orange when `urgency` is `'near'`, red solid when `'overdue'`. Caller formats the label (`formatDateLong` / `formatDateShort`). The only way to render a due date.
-- **ProjectHeader** - `ProjectHeader/`. Props: project, statuses, priorities, filter, activeSavedViewId + callbacks; methods `refresh`, `notifyMutation`, `setActiveSavedViewId`. Composes PrimaryRow (saved-view Pills, save button) and FilterRow (filter dropdowns, due/archived Pills).
+- **ProjectHeader** - `ProjectHeader/`. Props: project, statuses, priorities, filter, activeSavedViewId + callbacks; methods `refresh`, `notifyMutation`, `setActiveSavedViewId`. Composes PrimaryRow (saved-view ChipButtons, save button) and FilterRow (filter dropdowns, due/archived ChipButtons).
 - **Cells** - `cells/`. One `<td>` builder per column: StatusCell, PriorityCell, TitleCell, DueDateCell, TimeCell, ProgressCell, AssigneesCell, ExpandCell, ActionsCell, SelectCell, CustomFieldCell. `inlineEdit.ts` (`makeInlineEdit`) is the shared inline text/date editor. Adding a table column means adding a cell here, not inline DOM in the renderer.
 - **Property controls** - `properties/` (barrel `index.ts`): `renderSelectControl` (single-choice popover: status, priority, type, repeat, parent), `renderMultiSelect` (multi-choice: tags, assignees, dependencies), `renderDateControl` (date popover), `renderAddProperty` (progressive-disclosure "Add property" built on `renderAddButton`), `optionList.ts` helpers (`renderGlyph`, `renderOptionRow`). `src/modals/TaskFormFields.ts` shows the intended composition of these with `renderPropRow`.
 
@@ -137,7 +137,7 @@ Take resolved data + callbacks via props. No `plugin`, no `store`, no `onRefresh
 
 Richer than primitives, used across views. Avoid expanding this bucket; prefer composites/primitives when they fit.
 
-- **FilterDropdown** - `renderFilterDropdown(parent, label, selected, options, onChange)`: a Pill that opens a checkable Menu with a Clear item. Any multi-select filter control.
+- **FilterDropdown** - `renderFilterDropdown(parent, label, selected, options, onChange)`: a ChipButton that opens a checkable Menu with a Clear item. Any multi-select filter control.
 - **FormField** - `renderPropRow(container, label, valueBuilder, icon?)` (label + value form row), `renderChipList(container, items, { variant, shape, onRemove, onAdd?, ... })` (removable-token list with add affordance), `renderProgressSlider(container, value, onChange)`.
 - **StatusBadge** - `renderStatusBadge(container, task, statuses, onChange)` (solid dot-led Chip + picker Menu), `renderPriorityBadge(...)` (plain Chip with chevron icon + picker Menu), `renderStatusDot(container, status, statuses, cls?)` (bare colored dot), `PRIORITY_CHEVRONS`. The only way to render status/priority.
 - **TaskContextMenu** - `buildTaskContextMenu(menu, task, ctx)`: the task right-click menu.
@@ -169,7 +169,7 @@ uv run scripts/cdp.py eval 'document.querySelector("[data-sg=chip]").scrollIntoV
 uv run scripts/cdp.py shot styleguide-chip.png
 ```
 
-Each section has a `data-sg` attribute (`chip`, `pill`, `avatar`, `icon-button`, `progress`, `collapse`, `empty-state`, `segmented`, `view-switcher`, `popover`, `badges`, `form`, `time-due`, `cards`, `table`).
+Each section has a `data-sg` attribute (`chip`, `chip-button`, `avatar`, `icon-button`, `progress`, `collapse`, `empty-state`, `segmented`, `view-switcher`, `popover`, `badges`, `form`, `time-due`, `cards`, `table`).
 
 ## Maintenance
 

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -47,8 +47,8 @@ Toggleable filter button: saved views, filter dropdowns, due/archived toggles. W
 
 - API: `new Pill(parent).setLabel(text).setActive(bool).setShape('rounded'|'pill').setAriaLabel(text).onClick(h).onContextMenu(h)`
 - CSS: `button.pm-pill` (the `button` prefix outranks core button chrome), `--active`, `--pill`
-- Use when: a button whose pressed/active state persists (filters, saved views)
-- Not when: a non-interactive label (`Chip`) or a one-shot action (`ButtonComponent`)
+- Use when: a button whose pressed/active state persists (filters, saved views), or a one-shot action sitting in a pill row that must match its size (the filter row's Clear)
+- Not when: a non-interactive label (`Chip`) or a standalone action button (`ButtonComponent`)
 
 ### Avatar / AvatarStack - `Avatar.ts`, `AvatarStack.ts`
 

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -157,11 +157,9 @@ No wrappers for these:
 
 ## Deprecated patterns
 
-These exist in the codebase; don't copy them. Each row has a follow-up todo; new code uses the replacement.
+Empty right now. When a pattern gets deprecated, add a row (pattern, where, use instead, todo) so agents don't copy it; remove the row when the sweep lands.
 
-| Ad-hoc pattern             | Where                                     | Use instead              | Todo                         |
-| -------------------------- | ----------------------------------------- | ------------------------ | ---------------------------- |
-| new `--pm-*` CSS variables | `src/styles/variables.css` legacy aliases | Obsidian theme variables | `todos/token-unification.md` |
+Styling ground rules that keep this table empty: Obsidian theme variables only (no new `--pm-*`; the only plugin tokens are `--pm-ghost-border` / `--pm-shadow-ambient` plus per-component parameters like `--pm-chip-color`), radii from `--radius-s`/`--radius-m`, and no hand-rolled `<button>` styling.
 
 ## Live gallery
 

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -43,10 +43,10 @@ The unified label primitive: status, priority, tags, due dates, time, small badg
 
 ### Pill - `Pill.ts`
 
-Toggleable filter button (`<button>`): saved views, filter dropdowns, due/archived toggles.
+Toggleable filter button: saved views, filter dropdowns, due/archived toggles. Wraps Obsidian's `ButtonComponent`, compacted; active carries the plugin's 12% accent-tint selection signature.
 
 - API: `new Pill(parent).setLabel(text).setActive(bool).setShape('rounded'|'pill').setAriaLabel(text).onClick(h).onContextMenu(h)`
-- CSS: `pm-pill`, `--active`, `--pill`
+- CSS: `button.pm-pill` (the `button` prefix outranks core button chrome), `--active`, `--pill`
 - Use when: a button whose pressed/active state persists (filters, saved views)
 - Not when: a non-interactive label (`Chip`) or a one-shot action (`ButtonComponent`)
 
@@ -154,12 +154,6 @@ No wrappers for these:
 - `Menu` - context menus and flat pickers (`.addItem()`, `.showAtMouseEvent()`)
 - `SuggestModal` / `FuzzySuggestModal` - searchable pickers (via ModalFactory)
 - `setIcon(el, 'lucide-name')` - icons; size via `--icon-size` on the parent (width/height rules do not override `.svg-icon`)
-
-## Deprecated patterns
-
-Empty right now. When a pattern gets deprecated, add a row (pattern, where, use instead, todo) so agents don't copy it; remove the row when the sweep lands.
-
-Styling ground rules that keep this table empty: Obsidian theme variables only (no new `--pm-*`; the only plugin tokens are `--pm-ghost-border` / `--pm-shadow-ambient` plus per-component parameters like `--pm-chip-color`), radii from `--radius-s`/`--radius-m`, and no hand-rolled `<button>` styling.
 
 ## Live gallery
 

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -13,7 +13,7 @@ Before writing any new UI element, find your case here:
 - Need an icon-only button -> `IconButton`
 - Need a toggleable filter button -> `Pill`
 - Need a remove/x button on a token -> `Chip.setRemovable`
-- Need an "+ add" ghost row or button -> the `pm-prop-add` pattern (see `renderAddProperty` and `renderChipList`)
+- Need an "+ add" ghost row or button -> `renderAddButton`
 - Need mutually-exclusive options -> `SegmentedControl` (text) or `ViewSwitcher` (icons)
 - Need a floating panel with inputs -> `Popover` (never hand-rolled absolute positioning)
 - Need a flat action list at the cursor -> Obsidian `Menu`
@@ -98,9 +98,8 @@ Quiet empty placeholder: small icon, one line of muted text, optional CTA.
 
 Mutually-exclusive text options (e.g. the Task / Subtask / Milestone type picker).
 
-- API: `new SegmentedControl(parent, { options: [{id, label, cls?}], active, onChange })`
-- CSS: `pm-segmented`, `pm-segmented-btn`, `--active`
-- Note: hand-rolls `<button>`s; `todos/native-buttons.md` tracks migrating it to native components. Still the thing to use, don't roll your own
+- API: `new SegmentedControl(parent, { options: [{id, label}], active, onChange })`
+- CSS: `pm-segmented` (layout only); the buttons are native `ButtonComponent`s, active gets `setCta()`
 
 ### ViewSwitcher - `ViewSwitcher.ts`
 
@@ -126,12 +125,13 @@ Take resolved data + callbacks via props. No `plugin`, no `store`, no `onRefresh
 - **KanbanColumn** - `KanbanColumn.ts`. Props: status, cards + drag/drop and card callbacks. Composes KanbanCard.
 - **ProjectCard** - `ProjectCard.ts`. Props: title, icon, color, tasksDone, tasksTotal, onClick, onContextMenu. Composes ProgressBar.
 - **TaskRow** - `TaskRow.ts`. Props: taskId, depth, isDone, isArchived, isSelected, onRowClick. Bare `<tr>` with row-click routing that ignores interactive descendants; cells render into it.
+- **addButton** - `addButton.ts`. `renderAddButton(parent, label, onClick)` -> ghost "+ label" button (`pm-prop-add`). The only way to render an add button.
 - **tagChip** - `tagChip.ts`. `renderTagChip(parent, tag, colored)` -> outline tag Chip with optional color dot. The only way to render a tag.
 - **timeChip** - `timeChip.ts`. `renderTimeChip(parent, logged, estimate, size?)` -> `logged/estimateh` Chip, red solid when logged exceeds the estimate; renders nothing when both are 0. The only way to render logged/estimate hours.
 - **dueChip** - `dueChip.ts`. `renderDueChip(parent, label, urgency, size?)` -> due-date Chip, orange when `urgency` is `'near'`, red solid when `'overdue'`. Caller formats the label (`formatDateLong` / `formatDateShort`). The only way to render a due date.
 - **ProjectHeader** - `ProjectHeader/`. Props: project, statuses, priorities, filter, activeSavedViewId + callbacks; methods `refresh`, `notifyMutation`, `setActiveSavedViewId`. Composes PrimaryRow (saved-view Pills, save button) and FilterRow (filter dropdowns, due/archived Pills).
 - **Cells** - `cells/`. One `<td>` builder per column: StatusCell, PriorityCell, TitleCell, DueDateCell, TimeCell, ProgressCell, AssigneesCell, ExpandCell, ActionsCell, SelectCell, CustomFieldCell. `inlineEdit.ts` (`makeInlineEdit`) is the shared inline text/date editor. Adding a table column means adding a cell here, not inline DOM in the renderer.
-- **Property controls** - `properties/` (barrel `index.ts`): `renderSelectControl` (single-choice popover: status, priority, type, repeat, parent), `renderMultiSelect` (multi-choice: tags, assignees, dependencies), `renderDateControl` (date popover), `renderAddProperty` (progressive-disclosure "Add property" with the canonical `pm-prop-add` ghost button), `optionList.ts` helpers (`renderGlyph`, `renderOptionRow`). `src/modals/TaskFormFields.ts` shows the intended composition of these with `renderPropRow`.
+- **Property controls** - `properties/` (barrel `index.ts`): `renderSelectControl` (single-choice popover: status, priority, type, repeat, parent), `renderMultiSelect` (multi-choice: tags, assignees, dependencies), `renderDateControl` (date popover), `renderAddProperty` (progressive-disclosure "Add property" built on `renderAddButton`), `optionList.ts` helpers (`renderGlyph`, `renderOptionRow`). `src/modals/TaskFormFields.ts` shows the intended composition of these with `renderPropRow`.
 
 ## Shared widgets (`src/ui/*.ts`)
 
@@ -159,17 +159,10 @@ No wrappers for these:
 
 These exist in the codebase; don't copy them. Each row has a follow-up todo; new code uses the replacement.
 
-| Ad-hoc pattern                                                                           | Where                                                                             | Use instead                                     | Todo                                  |
-| ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------- |
-| `pm-gantt-label-dot` hand-rolled dot                                                     | `src/views/gantt/TaskLabelRenderer.ts:74`                                         | `renderStatusDot` (`src/ui/StatusBadge.ts`)     | `todos/ghost-button-consolidation.md` |
-| `pm-subtask-rm` remove buttons                                                           | `src/modals/SubtasksPanel.ts:55`, `src/modals/TimeTrackingPanel.ts:74`            | `IconButton` or `Chip.setRemovable`             | `todos/ghost-button-consolidation.md` |
-| hand-rolled `pm-chip-rm` button                                                          | `src/ui/composites/properties/MultiSelectControl.ts:106`                          | `Chip.setRemovable`                             | `todos/ghost-button-consolidation.md` |
-| `pm-settings-del` delete buttons                                                         | `src/modals/ProjectModal.ts:165`, `src/ui/PaletteListEditor.ts:120`               | `IconButton`                                    | `todos/ghost-button-consolidation.md` |
-| `pm-prop-add-btn`, `pm-table-add-btn`, `pm-gantt-add-task-btn`, `pm-gantt-label-add-btn` | `src/modals/ProjectModal.ts`, `src/views/table/TableRenderer.ts:245`, gantt       | the `pm-prop-add` pattern (`renderAddProperty`) | `todos/ghost-button-consolidation.md` |
-| `import-btn`, `import-btn--secondary`                                                    | `src/modals/ImportModal.ts:145`                                                   | `ButtonComponent`                               | `todos/ghost-button-consolidation.md` |
-| `pm-gantt-zoom-btn` bespoke segmented control                                            | `src/views/gantt/GanttView.ts:98`                                                 | `SegmentedControl`                              | `todos/native-buttons.md`             |
-| new `--pm-*` CSS variables                                                               | `src/styles/variables.css` legacy aliases                                         | Obsidian theme variables                        | `todos/token-unification.md`          |
-| `.pm-pill` vs `.pm-chip` style overlap                                                   | `src/styles/table.css`                                                            | one capsule base (planned)                      | `todos/chip-pill-consolidation.md`    |
+| Ad-hoc pattern                          | Where                                     | Use instead                | Todo                               |
+| --------------------------------------- | ----------------------------------------- | -------------------------- | ---------------------------------- |
+| new `--pm-*` CSS variables              | `src/styles/variables.css` legacy aliases | Obsidian theme variables   | `todos/token-unification.md`       |
+| `.pm-pill` vs `.pm-chip` style overlap  | `src/styles/table.css`                    | one capsule base (planned) | `todos/chip-pill-consolidation.md` |
 
 ## Live gallery
 

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -1,0 +1,191 @@
+# UI styleguide (component catalog)
+
+Read this before building or changing any UI. It's the component API catalog: what exists and what to reach for. The design language (color, typography, spacing, radii, shadows, voice) lives in `docs/design-system.md`. The layer rules (primitives / composites / orchestrators and what each may import) live in CLAUDE.md under "UI layers".
+
+The static HTML previews under `docs/design-system/project/preview/` are design references only; they misrender CSS because Obsidian's core `app.css` is absent. For visual verification use the live gallery (see "Live gallery" below).
+
+## Decision tree
+
+Before writing any new UI element, find your case here:
+
+- Need a small label, badge, or token (status, priority, tag, due date, count) -> `Chip`
+- Need a text button -> Obsidian `ButtonComponent`
+- Need an icon-only button -> `IconButton`
+- Need a toggleable filter button -> `Pill`
+- Need a remove/x button on a token -> `Chip.setRemovable`
+- Need an "+ add" ghost row or button -> the `pm-prop-add` pattern (see `renderAddProperty` and `renderChipList`)
+- Need mutually-exclusive options -> `SegmentedControl` (text) or `ViewSwitcher` (icons)
+- Need a floating panel with inputs -> `Popover` (never hand-rolled absolute positioning)
+- Need a flat action list at the cursor -> Obsidian `Menu`
+- Need a status or priority indicator -> `renderStatusBadge` / `renderPriorityBadge` / `renderStatusDot`
+- Need user initials -> `Avatar` / `AvatarStack`
+- Need a progress indicator -> `ProgressBar`
+- Need an empty placeholder -> `EmptyState`
+- Need a label + value form row -> `renderPropRow`
+- Need a removable-token list -> `renderChipList`
+
+Nothing fits? Extend an existing primitive with a new setter or variant instead of adding a new class or one-off element. Adding a brand-new primitive requires updating this file and `src/views/styleguide/StyleguideView.ts` in the same change.
+
+## Primitives (`src/ui/primitives/`)
+
+Chained-setter API modeled on Obsidian's `ButtonComponent`. Constructor takes `parentEl`; the root element is exposed as `.el`. Primitives import nothing from `store/` or `main`.
+
+### Chip - `Chip.ts`
+
+The unified label primitive: status, priority, tags, due dates, time, small badges.
+
+- API: `new Chip(parent).setLabel(text).setVariant('solid'|'outline'|'plain').setColor(cssColor).setDot(bool).setLeadingIcon(lucide).setTag(bool).setStrong(bool).setShape('rounded'|'pill').setSize('md'|'sm').setTooltip(text).setRemovable(onRemove).onClick(handler)`
+- CSS: `pm-chip` + `--solid/--outline/--plain/--tag/--strong/--pill/--sm/--interactive`, parts `pm-chip-label/-icon/-dot/-rm`; color flows through `--pm-chip-color`
+- Use when: any small labeled token, clickable or not (`onClick` adds hover/click styling)
+- Not when: a toggleable filter button (`Pill`) or a text action button (`ButtonComponent`)
+
+### Pill - `Pill.ts`
+
+Toggleable filter button (`<button>`): saved views, filter dropdowns, due/archived toggles.
+
+- API: `new Pill(parent).setLabel(text).setActive(bool).setShape('rounded'|'pill').setAriaLabel(text).onClick(h).onContextMenu(h)`
+- CSS: `pm-pill`, `--active`, `--pill`
+- Use when: a button whose pressed/active state persists (filters, saved views)
+- Not when: a non-interactive label (`Chip`) or a one-shot action (`ButtonComponent`)
+
+### Avatar / AvatarStack - `Avatar.ts`, `AvatarStack.ts`
+
+Initials disc for a person; the stack renders several with a `+N` overflow badge.
+
+- API: `new Avatar(parent).setName(raw).setSize('md'|'sm')`; `new AvatarStack(parent).setNames(string[]).setMax(n).setSize('md'|'sm')`
+- `displayName(raw)` (exported from `Avatar.ts`) resolves `[[wikilink|alias]]` names; `setName` applies it automatically
+- CSS: `pm-avatar`, `--sm`, `--more`; `pm-avatar-stack`; background from `stringToColor`
+- Use when: any assignee/member display
+- Not when: you need the raw name as text (use `displayName` yourself)
+
+### IconButton - `IconButton.ts`
+
+Icon-only button; wraps Obsidian's `ExtraButtonComponent`.
+
+- API: `new IconButton(parent).setIcon(lucide).setTooltip(text).setRevealOnHover(bool).onClick(h)`
+- CSS: `pm-icon-btn`, `--hover-only`
+- Use when: row actions, delete/remove buttons, hover-revealed actions
+- Not when: the button carries a text label (`ButtonComponent`)
+
+### ProgressBar - `ProgressBar.ts`
+
+Horizontal progress track with optional percent label.
+
+- API: `new ProgressBar(parent).setValue(0-100).setColor(cssColor).setSize('sm'|'md').setShowLabel(bool)`
+- CSS: `pm-progress`, `-track`, `-fill`, `-label`, `--sm`; color via `--pm-progress-color`
+- Use when: task/project completion display
+- Not when: user-editable progress (use `renderProgressSlider` from `FormField.ts`)
+
+### CollapseToggle - `CollapseToggle.ts`
+
+Obsidian-native collapse triangle for tree rows.
+
+- API: `new CollapseToggle(parent, { collapsed, onToggle })` (constructor-only)
+- CSS: `tree-item-icon collapse-icon pm-collapse-toggle`, `is-collapsed`
+- Use when: expanding/collapsing subtask trees
+
+### EmptyState - `EmptyState.ts`
+
+Quiet empty placeholder: small icon, one line of muted text, optional CTA.
+
+- API: `new EmptyState(parent).setIcon(text).setTitle(text).setBody(text).setAction(label, onClick)`
+- CSS: `pm-empty-state`, `pm-empty-icon`, `pm-empty-action`; the action is a native CTA `ButtonComponent`
+- Use when: a view or list has nothing to show
+
+### SegmentedControl - `SegmentedControl.ts`
+
+Mutually-exclusive text options (e.g. the Task / Subtask / Milestone type picker).
+
+- API: `new SegmentedControl(parent, { options: [{id, label, cls?}], active, onChange })`
+- CSS: `pm-segmented`, `pm-segmented-btn`, `--active`
+- Note: hand-rolls `<button>`s; `todos/native-buttons.md` tracks migrating it to native components. Still the thing to use, don't roll your own
+
+### ViewSwitcher - `ViewSwitcher.ts`
+
+Mutually-exclusive icon options (the Table / Gantt / Kanban switcher).
+
+- API: `new ViewSwitcher(parent, { options: [{id, icon, label}], active, onChange })`
+- CSS: `pm-view-switcher`, `pm-view-btn`, `--active`
+
+### Popover - `Popover.ts`
+
+Floating panel anchored to a trigger, for content Obsidian's `Menu` can't host (date inputs, search fields). Renders as a bottom sheet on phones; handles outside-click, Escape, scroll/resize repositioning, and modal focus-trap quirks. Read its JSDoc before use.
+
+- API: `new Popover({ anchor, host?, align?: 'left'|'right', width?, onClose? })`; fill `.contentEl`, then `open()` / `close()`; `isOpen` getter
+- CSS: `pm-pop`, `pm-pop-body`, `--sheet`; position via `--pop-top/--pop-left/--pop-width`
+- Use when: an anchored panel needs focusable inputs
+- Not when: a flat list of actions suffices (Obsidian `Menu`)
+
+## Composites (`src/ui/composites/`)
+
+Take resolved data + callbacks via props. No `plugin`, no `store`, no `onRefresh`. If a composite needs `plugin`, it's the wrong shape; push the store access up to the orchestrator view.
+
+- **KanbanCard** - `KanbanCard.ts`. Props: task, priorityColor, descriptionPreview, parentTitle, subtaskProgress, loggedHours, overdue, showTagColors + onClick/onContextMenu/onDragStart/onDragEnd. Composes Chip (milestone/subtask/time/due badges), AvatarStack, ProgressBar, renderTagChip.
+- **KanbanColumn** - `KanbanColumn.ts`. Props: status, cards + drag/drop and card callbacks. Composes KanbanCard.
+- **ProjectCard** - `ProjectCard.ts`. Props: title, icon, color, tasksDone, tasksTotal, onClick, onContextMenu. Composes ProgressBar.
+- **TaskRow** - `TaskRow.ts`. Props: taskId, depth, isDone, isArchived, isSelected, onRowClick. Bare `<tr>` with row-click routing that ignores interactive descendants; cells render into it.
+- **tagChip** - `tagChip.ts`. `renderTagChip(parent, tag, colored)` -> outline tag Chip with optional color dot. The only way to render a tag.
+- **ProjectHeader** - `ProjectHeader/`. Props: project, statuses, priorities, filter, activeSavedViewId + callbacks; methods `refresh`, `notifyMutation`, `setActiveSavedViewId`. Composes PrimaryRow (saved-view Pills, save button) and FilterRow (filter dropdowns, due/archived Pills).
+- **Cells** - `cells/`. One `<td>` builder per column: StatusCell, PriorityCell, TitleCell, DueDateCell, TimeCell, ProgressCell, AssigneesCell, ExpandCell, ActionsCell, SelectCell, CustomFieldCell. `inlineEdit.ts` (`makeInlineEdit`) is the shared inline text/date editor. Adding a table column means adding a cell here, not inline DOM in the renderer.
+- **Property controls** - `properties/` (barrel `index.ts`): `renderSelectControl` (single-choice popover: status, priority, type, repeat, parent), `renderMultiSelect` (multi-choice: tags, assignees, dependencies), `renderDateControl` (date popover), `renderAddProperty` (progressive-disclosure "Add property" with the canonical `pm-prop-add` ghost button), `optionList.ts` helpers (`renderGlyph`, `renderOptionRow`). `src/modals/TaskFormFields.ts` shows the intended composition of these with `renderPropRow`.
+
+## Shared widgets (`src/ui/*.ts`)
+
+Richer than primitives, used across views. Avoid expanding this bucket; prefer composites/primitives when they fit.
+
+- **FilterDropdown** - `renderFilterDropdown(parent, label, selected, options, onChange)`: a Pill that opens a checkable Menu with a Clear item. Any multi-select filter control.
+- **FormField** - `renderPropRow(container, label, valueBuilder, icon?)` (label + value form row), `renderChipList(container, items, { variant, shape, onRemove, onAdd?, ... })` (removable-token list with add affordance), `renderProgressSlider(container, value, onChange)`.
+- **StatusBadge** - `renderStatusBadge(container, task, statuses, onChange)` (solid dot-led Chip + picker Menu), `renderPriorityBadge(...)` (plain Chip with chevron icon + picker Menu), `renderStatusDot(container, status, statuses, cls?)` (bare colored dot), `PRIORITY_CHEVRONS`. The only way to render status/priority.
+- **TaskContextMenu** - `buildTaskContextMenu(menu, task, ctx)`: the task right-click menu.
+- **ModalFactory** - all modal opening: `openTaskModal`, `openProjectModal`, `openProjectPicker`, `openTaskPicker`, `openImportModal`, `confirmDialog`, `confirmDuplicateSubtasks`, `promptText`. Never instantiate a modal directly from a view.
+- **PaletteListEditor** - `renderStatusListEditor` / `renderPriorityListEditor` for settings-style palette editing, plus `attachIconSuggest`, `wireRowDragReorder`.
+
+## Native Obsidian components to use directly
+
+No wrappers for these:
+
+- `ButtonComponent` - any text button (`.setButtonText().setCta().onClick()`)
+- `ExtraButtonComponent` - icon button when `IconButton`'s extras are not needed
+- `Setting` - settings rows and section headings (`.setName().setHeading()`)
+- `Menu` - context menus and flat pickers (`.addItem()`, `.showAtMouseEvent()`)
+- `SuggestModal` / `FuzzySuggestModal` - searchable pickers (via ModalFactory)
+- `setIcon(el, 'lucide-name')` - icons; size via `--icon-size` on the parent (width/height rules do not override `.svg-icon`)
+
+## Deprecated patterns
+
+These exist in the codebase; don't copy them. Each row has a follow-up todo; new code uses the replacement.
+
+| Ad-hoc pattern                                                                           | Where                                                                             | Use instead                                     | Todo                                  |
+| ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------- |
+| `pm-gantt-label-dot` hand-rolled dot                                                     | `src/views/gantt/TaskLabelRenderer.ts:74`                                         | `renderStatusDot` (`src/ui/StatusBadge.ts`)     | `todos/ghost-button-consolidation.md` |
+| `pm-subtask-rm` remove buttons                                                           | `src/modals/SubtasksPanel.ts:55`, `src/modals/TimeTrackingPanel.ts:74`            | `IconButton` or `Chip.setRemovable`             | `todos/ghost-button-consolidation.md` |
+| hand-rolled `pm-chip-rm` button                                                          | `src/ui/composites/properties/MultiSelectControl.ts:106`                          | `Chip.setRemovable`                             | `todos/ghost-button-consolidation.md` |
+| `pm-settings-del` delete buttons                                                         | `src/modals/ProjectModal.ts:165`, `src/ui/PaletteListEditor.ts:120`               | `IconButton`                                    | `todos/ghost-button-consolidation.md` |
+| `pm-prop-add-btn`, `pm-table-add-btn`, `pm-gantt-add-task-btn`, `pm-gantt-label-add-btn` | `src/modals/ProjectModal.ts`, `src/views/table/TableRenderer.ts:245`, gantt       | the `pm-prop-add` pattern (`renderAddProperty`) | `todos/ghost-button-consolidation.md` |
+| `import-btn`, `import-btn--secondary`                                                    | `src/modals/ImportModal.ts:145`                                                   | `ButtonComponent`                               | `todos/ghost-button-consolidation.md` |
+| `pm-gantt-zoom-btn` bespoke segmented control                                            | `src/views/gantt/GanttView.ts:98`                                                 | `SegmentedControl`                              | `todos/native-buttons.md`             |
+| copy-pasted time/due chip logic                                                          | `cells/TimeCell.ts` vs `KanbanCard.ts`; `cells/DueDateCell.ts` vs `KanbanCard.ts` | shared helper (to be extracted)                 | `todos/timechip-duechip-helpers.md`   |
+| new `--pm-*` CSS variables                                                               | `src/styles/variables.css` legacy aliases                                         | Obsidian theme variables                        | `todos/token-unification.md`          |
+| `.pm-pill` vs `.pm-chip` style overlap                                                   | `src/styles/table.css`                                                            | one capsule base (planned)                      | `todos/chip-pill-consolidation.md`    |
+
+## Live gallery
+
+A dev-only view renders every primitive and key composite in all variants: `src/views/styleguide/StyleguideView.ts`, command "Open styleguide gallery".
+
+- The view is compiled in only when `__STYLEGUIDE__` is true: dev builds (`pnpm dev`) always include it; production builds exclude it unless `STYLEGUIDE=1` is set.
+- The `/live-dev` deploy builds with `PRODUCTION=1`, so use `STYLEGUIDE=1 .claude/skills/live-dev/deploy.sh` or the gallery will be missing from the deployed build.
+- To open and screenshot it over CDP (see `docs/live-inspection.md`):
+
+```
+uv run scripts/cdp.py eval 'app.commands.executeCommandById("project-manager:open-styleguide")'
+uv run scripts/cdp.py eval 'document.querySelector("[data-sg=chip]").scrollIntoView()'
+uv run scripts/cdp.py shot styleguide-chip.png
+```
+
+Each section has a `data-sg` attribute (`chip`, `pill`, `avatar`, `icon-button`, `progress`, `collapse`, `empty-state`, `segmented`, `view-switcher`, `popover`, `badges`, `form`, `cards`, `table`).
+
+## Maintenance
+
+- Adding or changing a component: update its entry here and its section in `StyleguideView.ts` in the same change.
+- Removing a component: delete its entry and gallery section, and check `src/styles/` for now-orphaned classes.
+- Consolidating a deprecated pattern: remove its row from the table above and close the todo.

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -18,6 +18,8 @@ Before writing any new UI element, find your case here:
 - Need a floating panel with inputs -> `Popover` (never hand-rolled absolute positioning)
 - Need a flat action list at the cursor -> Obsidian `Menu`
 - Need a status or priority indicator -> `renderStatusBadge` / `renderPriorityBadge` / `renderStatusDot`
+- Need a logged/estimate hours chip -> `renderTimeChip`
+- Need a due-date chip with urgency colors -> `renderDueChip`
 - Need user initials -> `Avatar` / `AvatarStack`
 - Need a progress indicator -> `ProgressBar`
 - Need an empty placeholder -> `EmptyState`
@@ -120,11 +122,13 @@ Floating panel anchored to a trigger, for content Obsidian's `Menu` can't host (
 
 Take resolved data + callbacks via props. No `plugin`, no `store`, no `onRefresh`. If a composite needs `plugin`, it's the wrong shape; push the store access up to the orchestrator view.
 
-- **KanbanCard** - `KanbanCard.ts`. Props: task, priorityColor, descriptionPreview, parentTitle, subtaskProgress, loggedHours, overdue, showTagColors + onClick/onContextMenu/onDragStart/onDragEnd. Composes Chip (milestone/subtask/time/due badges), AvatarStack, ProgressBar, renderTagChip.
+- **KanbanCard** - `KanbanCard.ts`. Props: task, priorityColor, descriptionPreview, parentTitle, subtaskProgress, loggedHours, overdue, showTagColors + onClick/onContextMenu/onDragStart/onDragEnd. Composes Chip (milestone/subtask/recurring badges), renderTimeChip, renderDueChip, AvatarStack, ProgressBar, renderTagChip.
 - **KanbanColumn** - `KanbanColumn.ts`. Props: status, cards + drag/drop and card callbacks. Composes KanbanCard.
 - **ProjectCard** - `ProjectCard.ts`. Props: title, icon, color, tasksDone, tasksTotal, onClick, onContextMenu. Composes ProgressBar.
 - **TaskRow** - `TaskRow.ts`. Props: taskId, depth, isDone, isArchived, isSelected, onRowClick. Bare `<tr>` with row-click routing that ignores interactive descendants; cells render into it.
 - **tagChip** - `tagChip.ts`. `renderTagChip(parent, tag, colored)` -> outline tag Chip with optional color dot. The only way to render a tag.
+- **timeChip** - `timeChip.ts`. `renderTimeChip(parent, logged, estimate, size?)` -> `logged/estimateh` Chip, red solid when logged exceeds the estimate; renders nothing when both are 0. The only way to render logged/estimate hours.
+- **dueChip** - `dueChip.ts`. `renderDueChip(parent, label, urgency, size?)` -> due-date Chip, orange when `urgency` is `'near'`, red solid when `'overdue'`. Caller formats the label (`formatDateLong` / `formatDateShort`). The only way to render a due date.
 - **ProjectHeader** - `ProjectHeader/`. Props: project, statuses, priorities, filter, activeSavedViewId + callbacks; methods `refresh`, `notifyMutation`, `setActiveSavedViewId`. Composes PrimaryRow (saved-view Pills, save button) and FilterRow (filter dropdowns, due/archived Pills).
 - **Cells** - `cells/`. One `<td>` builder per column: StatusCell, PriorityCell, TitleCell, DueDateCell, TimeCell, ProgressCell, AssigneesCell, ExpandCell, ActionsCell, SelectCell, CustomFieldCell. `inlineEdit.ts` (`makeInlineEdit`) is the shared inline text/date editor. Adding a table column means adding a cell here, not inline DOM in the renderer.
 - **Property controls** - `properties/` (barrel `index.ts`): `renderSelectControl` (single-choice popover: status, priority, type, repeat, parent), `renderMultiSelect` (multi-choice: tags, assignees, dependencies), `renderDateControl` (date popover), `renderAddProperty` (progressive-disclosure "Add property" with the canonical `pm-prop-add` ghost button), `optionList.ts` helpers (`renderGlyph`, `renderOptionRow`). `src/modals/TaskFormFields.ts` shows the intended composition of these with `renderPropRow`.
@@ -164,7 +168,6 @@ These exist in the codebase; don't copy them. Each row has a follow-up todo; new
 | `pm-prop-add-btn`, `pm-table-add-btn`, `pm-gantt-add-task-btn`, `pm-gantt-label-add-btn` | `src/modals/ProjectModal.ts`, `src/views/table/TableRenderer.ts:245`, gantt       | the `pm-prop-add` pattern (`renderAddProperty`) | `todos/ghost-button-consolidation.md` |
 | `import-btn`, `import-btn--secondary`                                                    | `src/modals/ImportModal.ts:145`                                                   | `ButtonComponent`                               | `todos/ghost-button-consolidation.md` |
 | `pm-gantt-zoom-btn` bespoke segmented control                                            | `src/views/gantt/GanttView.ts:98`                                                 | `SegmentedControl`                              | `todos/native-buttons.md`             |
-| copy-pasted time/due chip logic                                                          | `cells/TimeCell.ts` vs `KanbanCard.ts`; `cells/DueDateCell.ts` vs `KanbanCard.ts` | shared helper (to be extracted)                 | `todos/timechip-duechip-helpers.md`   |
 | new `--pm-*` CSS variables                                                               | `src/styles/variables.css` legacy aliases                                         | Obsidian theme variables                        | `todos/token-unification.md`          |
 | `.pm-pill` vs `.pm-chip` style overlap                                                   | `src/styles/table.css`                                                            | one capsule base (planned)                      | `todos/chip-pill-consolidation.md`    |
 
@@ -182,7 +185,7 @@ uv run scripts/cdp.py eval 'document.querySelector("[data-sg=chip]").scrollIntoV
 uv run scripts/cdp.py shot styleguide-chip.png
 ```
 
-Each section has a `data-sg` attribute (`chip`, `pill`, `avatar`, `icon-button`, `progress`, `collapse`, `empty-state`, `segmented`, `view-switcher`, `popover`, `badges`, `form`, `cards`, `table`).
+Each section has a `data-sg` attribute (`chip`, `pill`, `avatar`, `icon-button`, `progress`, `collapse`, `empty-state`, `segmented`, `view-switcher`, `popover`, `badges`, `form`, `time-due`, `cards`, `table`).
 
 ## Maintenance
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,8 @@ export default defineConfig([
     files: ['src/**/*.ts'],
     languageOptions: {
       parser: tsparser,
-      parserOptions: { project: './tsconfig.json' }
+      parserOptions: { project: './tsconfig.json' },
+      globals: { __STYLEGUIDE__: 'readonly' }
     }
   },
   {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,2 @@
+/** Build-time constant from tsdown `define`: true in dev builds, false in production unless STYLEGUIDE=1. */
+declare const __STYLEGUIDE__: boolean

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import type { TaskSource } from './store'
 import { PMSettingTab } from './settings'
 import { ProjectView, PM_PROJECT_VIEW_TYPE } from './views/ProjectView'
 import { DashboardView, PM_DASHBOARD_VIEW_TYPE } from './views/DashboardView'
+import { registerStyleguide } from './views/styleguide/StyleguideView'
 import { PMViewRouter } from './views/PMViewRouter'
 import { openProjectModal, openTaskModal, openProjectPicker, openTaskPicker, openImportModal } from './ui/ModalFactory'
 import { Notifier } from './components/Notifier'
@@ -51,6 +52,7 @@ export default class PMPlugin extends Plugin {
 
     this.registerView(PM_PROJECT_VIEW_TYPE, (leaf) => new ProjectView(leaf, this))
     this.registerView(PM_DASHBOARD_VIEW_TYPE, (leaf) => new DashboardView(leaf, this))
+    if (__STYLEGUIDE__) registerStyleguide(this)
 
     this.app.workspace.onLayoutReady(
       safeAsync(async () => {

--- a/src/modals/ImportModal.ts
+++ b/src/modals/ImportModal.ts
@@ -1,4 +1,4 @@
-import { App, Modal, TFile, Notice } from 'obsidian'
+import { App, ButtonComponent, Modal, TFile, Notice } from 'obsidian'
 import type PMPlugin from '../main'
 import type { PriorityConfig, Project, StatusConfig, TaskStatus, TaskPriority } from '../types'
 import { getDefaultStatusId, getDefaultPriorityId } from '../utils'
@@ -23,7 +23,7 @@ export class ImportModal extends Modal {
   private selectedCount = 0
   private searchInput: HTMLInputElement | null = null
   private selectAllCheckbox: HTMLInputElement | null = null
-  private nextButton: HTMLButtonElement | null = null
+  private nextButton: ButtonComponent | null = null
   private fileListContainer: HTMLDivElement | null = null
   private counterLabel: HTMLDivElement | null = null
 
@@ -142,13 +142,13 @@ export class ImportModal extends Modal {
     // ── Footer with Next button ────────────────────────────────────────────
     const footer = contentEl.createDiv('import-modal-footer')
 
-    const cancelButton = footer.createEl('button', { text: 'Cancel', cls: 'import-btn import-btn--secondary' })
-    cancelButton.addEventListener('click', () => this.close())
+    new ButtonComponent(footer).setButtonText('Cancel').onClick(() => this.close())
 
-    this.nextButton = footer.createEl('button', { text: 'Next', cls: 'mod-cta import-btn' })
-    this.nextButton.toggleClass('import-btn--disabled', this.selectedCount === 0)
-    this.nextButton.disabled = this.selectedCount === 0
-    this.nextButton.addEventListener('click', () => this.handleNext())
+    this.nextButton = new ButtonComponent(footer)
+      .setButtonText('Next')
+      .setCta()
+      .setDisabled(this.selectedCount === 0)
+      .onClick(() => this.handleNext())
   }
 
   private renderPhase2(): void {
@@ -229,14 +229,10 @@ export class ImportModal extends Modal {
     // ── Footer ───────────────────────────────────────────────────────────────
     const footer = contentEl.createDiv('import-modal-footer')
 
-    const backButton = footer.createEl('button', { text: 'Back', cls: 'import-btn import-btn--secondary' })
-    backButton.addEventListener('click', () => this.handleBack())
+    new ButtonComponent(footer).setButtonText('Back').onClick(() => this.handleBack())
 
-    const importButton = footer.createEl('button', {
-      text: `Import (${this.selectedCount})`,
-      cls: 'mod-cta import-btn'
-    })
-    importButton.addEventListener('click', () => {
+    const importButton = new ButtonComponent(footer).setButtonText(`Import (${this.selectedCount})`).setCta()
+    importButton.onClick(() => {
       void this.handleImport()
     })
   }
@@ -315,9 +311,7 @@ export class ImportModal extends Modal {
   }
 
   private updateNextButton(): void {
-    if (!this.nextButton) return
-    this.nextButton.disabled = this.selectedCount === 0
-    this.nextButton.toggleClass('import-btn--disabled', this.selectedCount === 0)
+    this.nextButton?.setDisabled(this.selectedCount === 0)
   }
 
   private handleNext(): void {

--- a/src/modals/ProjectModal.ts
+++ b/src/modals/ProjectModal.ts
@@ -4,6 +4,7 @@ import { Project, ProjectConfig, CustomFieldDef, makeId, makeProject } from '../
 import { rebuildTaskIndex } from '../store'
 import { safeAsync } from '../utils'
 import { Avatar } from '../ui/primitives/Avatar'
+import { IconButton } from '../ui/primitives/IconButton'
 import { renderPriorityListEditor, renderStatusListEditor } from '../ui/PaletteListEditor'
 
 const PROJECT_COLORS = [
@@ -162,11 +163,13 @@ export class ProjectModal extends Modal {
           this.project.teamMembers[i] = input.value
           renderMembers()
         })
-        const rm = row.createEl('button', { text: '✕', cls: 'pm-settings-del' })
-        rm.addEventListener('click', () => {
-          this.project.teamMembers.splice(i, 1)
-          renderMembers()
-        })
+        new IconButton(row)
+          .setIcon('x')
+          .setTooltip('Remove member')
+          .onClick(() => {
+            this.project.teamMembers.splice(i, 1)
+            renderMembers()
+          })
       }
       const addBtn = memberWrap.createEl('button', {
         text: '+ add member',
@@ -428,11 +431,13 @@ export class ProjectModal extends Modal {
       rerender()
     })
 
-    const rmBtn = row.createEl('button', { text: '✕', cls: 'pm-settings-del' })
-    rmBtn.addEventListener('click', () => {
-      this.project.customFields.splice(index, 1)
-      rerender()
-    })
+    new IconButton(row)
+      .setIcon('x')
+      .setTooltip('Remove field')
+      .onClick(() => {
+        this.project.customFields.splice(index, 1)
+        rerender()
+      })
 
     if (cf.type === 'select' || cf.type === 'multiselect') {
       const optionsWrap = row.createDiv('pm-cf-options')
@@ -451,12 +456,14 @@ export class ProjectModal extends Modal {
             opts[j] = optInput.value
             cf.options = opts
           })
-          const rmOptBtn = optRow.createEl('button', { text: '✕', cls: 'pm-settings-del' })
-          rmOptBtn.addEventListener('click', () => {
-            opts.splice(j, 1)
-            cf.options = opts
-            renderOpts()
-          })
+          new IconButton(optRow)
+            .setIcon('x')
+            .setTooltip('Remove option')
+            .onClick(() => {
+              opts.splice(j, 1)
+              cf.options = opts
+              renderOpts()
+            })
         }
         const addOptBtn = optionsWrap.createEl('button', {
           text: '+ option',

--- a/src/modals/ProjectModal.ts
+++ b/src/modals/ProjectModal.ts
@@ -3,6 +3,7 @@ import type PMPlugin from '../main'
 import { Project, ProjectConfig, CustomFieldDef, makeId, makeProject } from '../types'
 import { rebuildTaskIndex } from '../store'
 import { safeAsync } from '../utils'
+import { renderAddButton } from '../ui/composites/addButton'
 import { Avatar } from '../ui/primitives/Avatar'
 import { IconButton } from '../ui/primitives/IconButton'
 import { renderPriorityListEditor, renderStatusListEditor } from '../ui/PaletteListEditor'
@@ -171,11 +172,7 @@ export class ProjectModal extends Modal {
             renderMembers()
           })
       }
-      const addBtn = memberWrap.createEl('button', {
-        text: '+ add member',
-        cls: 'pm-prop-add-btn'
-      })
-      addBtn.addEventListener('click', () => {
+      renderAddButton(memberWrap, 'Add member', () => {
         this.project.teamMembers.push('')
         renderMembers()
         window.setTimeout(() => {
@@ -198,11 +195,7 @@ export class ProjectModal extends Modal {
       for (let i = 0; i < this.project.customFields.length; i++) {
         this.renderCustomFieldEditor(cfList, this.project.customFields[i], i, renderCFs)
       }
-      const addCFBtn = cfList.createEl('button', {
-        text: '+ add custom field',
-        cls: 'pm-prop-add-btn'
-      })
-      addCFBtn.addEventListener('click', () => {
+      renderAddButton(cfList, 'Add custom field', () => {
         this.project.customFields.push({
           id: makeId(),
           name: 'New Field',
@@ -219,7 +212,7 @@ export class ProjectModal extends Modal {
       heading: 'Statuses',
       hint: 'The workflow for this project',
       toggleLabel: 'Use custom statuses instead of the global ones',
-      addLabel: '+ add status',
+      addLabel: 'Add status',
       get: () => this.project.config?.statuses,
       set: (statuses) => this.patchConfig('statuses', statuses),
       copyGlobal: () => this.plugin.settings.statuses.map((s) => ({ ...s })),
@@ -244,7 +237,7 @@ export class ProjectModal extends Modal {
       heading: 'Priorities',
       hint: 'The priority scale for this project',
       toggleLabel: 'Use custom priorities instead of the global ones',
-      addLabel: '+ add priority',
+      addLabel: 'Add priority',
       get: () => this.project.config?.priorities,
       set: (priorities) => this.patchConfig('priorities', priorities),
       copyGlobal: () => this.plugin.settings.priorities.map((p) => ({ ...p })),
@@ -356,8 +349,7 @@ export class ProjectModal extends Modal {
       const own = opts.get()
       if (!own?.length) return
       opts.renderEditor(editor, own)
-      const addBtn = footer.createEl('button', { text: opts.addLabel, cls: 'pm-prop-add-btn' })
-      addBtn.addEventListener('click', () => {
+      renderAddButton(footer, opts.addLabel, () => {
         own.push(opts.makeEntry())
         renderEditor()
       })
@@ -465,11 +457,7 @@ export class ProjectModal extends Modal {
               renderOpts()
             })
         }
-        const addOptBtn = optionsWrap.createEl('button', {
-          text: '+ option',
-          cls: 'pm-prop-add-btn pm-prop-add-btn--sm'
-        })
-        addOptBtn.addEventListener('click', () => {
+        renderAddButton(optionsWrap, 'Add option', () => {
           opts.push('')
           cf.options = opts
           renderOpts()

--- a/src/modals/SubtasksPanel.ts
+++ b/src/modals/SubtasksPanel.ts
@@ -1,7 +1,7 @@
-import { setIcon } from 'obsidian'
 import type PMPlugin from '../main'
 import type { StatusConfig, Task } from '../types'
 import { makeTask } from '../types'
+import { IconButton } from '../ui/primitives/IconButton'
 import { isTerminalStatus, getCompleteStatusId, getDefaultStatusId } from '../utils'
 
 /**
@@ -52,13 +52,15 @@ export function renderSubtasksPanel(
         sub.title = titleEl.textContent?.trim() ?? sub.title
       })
 
-      const rm = row.createEl('button', { cls: 'pm-subtask-rm' })
-      setIcon(rm, 'x')
-      rm.addEventListener('click', () => {
-        task.subtasks = task.subtasks.filter((s) => s.id !== sub.id)
-        renderSubtasks()
-        renderCount()
-      })
+      new IconButton(row)
+        .setIcon('x')
+        .setTooltip('Remove subtask')
+        .setRevealOnHover(true)
+        .onClick(() => {
+          task.subtasks = task.subtasks.filter((s) => s.id !== sub.id)
+          renderSubtasks()
+          renderCount()
+        })
     }
   }
 

--- a/src/modals/TimeTrackingPanel.ts
+++ b/src/modals/TimeTrackingPanel.ts
@@ -1,7 +1,7 @@
-import { setIcon } from 'obsidian'
 import type { Task } from '../types'
 import { totalLoggedHours } from '../store/TaskTreeOps'
 import { today } from '../dates'
+import { renderAddButton } from '../ui/composites/addButton'
 import { IconButton } from '../ui/primitives/IconButton'
 import { ProgressBar } from '../ui/primitives/ProgressBar'
 
@@ -83,10 +83,7 @@ export function renderTimeTrackingPanel(container: HTMLElement, task: Task): voi
   }
   renderLogs()
 
-  const addLogBtn = timeSection.createEl('button', { cls: 'pm-prop-add' })
-  setIcon(addLogBtn.createSpan({ cls: 'pm-glyph-icon' }), 'plus')
-  addLogBtn.createSpan({ cls: 'pm-prop-add-label', text: 'Log time' })
-  addLogBtn.addEventListener('click', () => {
+  renderAddButton(timeSection, 'Log time', () => {
     if (!task.timeLogs) task.timeLogs = []
     task.timeLogs.push({
       date: today().toString(),

--- a/src/modals/TimeTrackingPanel.ts
+++ b/src/modals/TimeTrackingPanel.ts
@@ -2,6 +2,7 @@ import { setIcon } from 'obsidian'
 import type { Task } from '../types'
 import { totalLoggedHours } from '../store/TaskTreeOps'
 import { today } from '../dates'
+import { IconButton } from '../ui/primitives/IconButton'
 import { ProgressBar } from '../ui/primitives/ProgressBar'
 
 /**
@@ -71,12 +72,13 @@ export function renderTimeTrackingPanel(container: HTMLElement, task: Task): voi
         log.note = noteInput.value
       })
 
-      const rmBtn = row.createEl('button', { cls: 'pm-subtask-rm' })
-      setIcon(rmBtn, 'x')
-      rmBtn.addEventListener('click', () => {
-        logs.splice(i, 1)
-        renderLogs()
-      })
+      new IconButton(row)
+        .setIcon('x')
+        .setTooltip('Remove log')
+        .onClick(() => {
+          logs.splice(i, 1)
+          renderLogs()
+        })
     }
   }
   renderLogs()

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,7 @@ import { PMSettings, DEFAULT_SETTINGS, makeId } from './types'
 import { flattenTasks } from './store/TaskTreeOps'
 import { getTaskNotesApi, importTaskNotesPalettes, isTaskNotesInstalled } from './integrations/tasknotes'
 import { renderPriorityListEditor, renderStatusListEditor } from './ui/PaletteListEditor'
+import { IconButton } from './ui/primitives/IconButton'
 
 export type { PMSettings }
 export { DEFAULT_SETTINGS }
@@ -274,13 +275,14 @@ export class PMSettingTab extends PluginSettingTab {
         this.plugin.settings.globalTeamMembers[i] = input.value
         void this.plugin.saveSettings()
       })
-      const del = row.createEl('button', { text: '✕' })
-      del.addClass('pm-settings-del')
-      del.addEventListener('click', () => {
-        this.plugin.settings.globalTeamMembers.splice(i, 1)
-        void this.plugin.saveSettings()
-        this.renderMembersList(container)
-      })
+      new IconButton(row)
+        .setIcon('x')
+        .setTooltip('Remove member')
+        .onClick(() => {
+          this.plugin.settings.globalTeamMembers.splice(i, 1)
+          void this.plugin.saveSettings()
+          this.renderMembersList(container)
+        })
     })
   }
 

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -72,7 +72,7 @@
   align-items: center;
   gap: 12px;
   padding: 10px 16px;
-  background: var(--pm-surface-raised);
+  background: var(--background-secondary);
   flex-shrink: 0;
   flex-wrap: wrap;
 }
@@ -96,7 +96,7 @@
   cursor: pointer;
   line-height: 1;
   padding: 2px;
-  border-radius: var(--pm-radius-sm);
+  border-radius: var(--radius-s);
   transition: transform 0.15s;
 }
 .pm-toolbar-icon:hover {
@@ -108,7 +108,7 @@
   font-weight: 700;
   margin: 0;
   padding: 2px 6px;
-  border-radius: var(--pm-radius-sm);
+  border-radius: var(--radius-s);
   outline: none;
   min-width: 40px;
   white-space: nowrap;
@@ -117,8 +117,8 @@
   max-width: 340px;
 }
 .pm-toolbar-title:focus {
-  background: var(--pm-bg3);
-  box-shadow: 0 0 0 2px var(--pm-accent);
+  background: var(--background-modifier-hover);
+  box-shadow: 0 0 0 2px var(--interactive-accent);
 }
 
 /* -- View switcher --------------------------------------------------------- */
@@ -165,7 +165,7 @@
   justify-content: center;
   height: 100%;
   gap: 12px;
-  color: var(--pm-text-muted);
+  color: var(--text-muted);
   padding: 40px;
 }
 .pm-empty-icon {
@@ -187,16 +187,16 @@
 
 .pm-project-card {
   border: 1px solid var(--pm-ghost-border);
-  border-radius: var(--pm-radius-lg);
+  border-radius: var(--radius-m);
   overflow: hidden;
   cursor: pointer;
-  background: var(--pm-surface-raised);
+  background: var(--background-secondary);
   transition: all 0.2s;
   position: relative;
 }
 .pm-project-card:hover {
   box-shadow: 0 4px 16px var(--pm-shadow-ambient);
-  border-color: var(--pm-border);
+  border-color: var(--background-modifier-border);
 }
 
 .pm-project-card-bar {
@@ -225,5 +225,5 @@
 }
 .pm-project-card-tasks {
   font-size: 12px;
-  color: var(--pm-text-muted);
+  color: var(--text-muted);
 }

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -150,25 +150,6 @@
   color: var(--text-normal);
 }
 
-/* `button` prefix outranks Obsidian's core button chrome (grey fill + inset shadow),
-   which otherwise overrides this transparent dashed-button look. */
-button.pm-prop-add-btn {
-  background: transparent;
-  box-shadow: none;
-  border: 1px dashed var(--pm-border);
-  color: var(--pm-text-muted);
-  padding: 3px 10px;
-  border-radius: var(--pm-radius-sm);
-  cursor: pointer;
-  font-size: 12px;
-  transition: all 0.15s;
-}
-.pm-prop-add-btn:hover {
-  border-color: var(--pm-accent);
-  color: var(--pm-accent);
-  background: var(--pm-accent-light);
-}
-
 /* -- Content --------------------------------------------------------------- */
 .pm-content {
   flex: 1;

--- a/src/styles/gantt.css
+++ b/src/styles/gantt.css
@@ -13,9 +13,9 @@
   align-items: center;
   gap: 6px;
   padding: 8px 16px;
-  border-bottom: 1px solid var(--pm-border);
+  border-bottom: 1px solid var(--background-modifier-border);
   flex-shrink: 0;
-  background: var(--pm-bg);
+  background: var(--background-primary);
   flex-wrap: wrap;
 }
 .pm-gantt-sep {
@@ -35,7 +35,7 @@
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  background: var(--pm-surface-raised);
+  background: var(--background-secondary);
   z-index: 5;
 }
 
@@ -43,9 +43,9 @@
   display: flex;
   align-items: flex-end;
   padding: 0 12px 10px;
-  box-shadow: inset 0 -2px 0 var(--pm-border);
+  box-shadow: inset 0 -2px 0 var(--background-modifier-border);
   flex-shrink: 0;
-  background: var(--pm-bg);
+  background: var(--background-primary);
   box-sizing: border-box;
 }
 .pm-gantt-left-header-label {
@@ -53,7 +53,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--pm-text-muted);
+  color: var(--text-muted);
 }
 
 .pm-gantt-left-body {
@@ -66,13 +66,13 @@
   align-items: center;
   gap: 6px;
   padding-right: 8px;
-  box-shadow: inset 0 -1px 0 var(--pm-border);
+  box-shadow: inset 0 -1px 0 var(--background-modifier-border);
   cursor: default;
   transition: background 0.1s;
   box-sizing: border-box;
 }
 .pm-gantt-label-row:hover {
-  background: var(--pm-bg3);
+  background: var(--background-modifier-hover);
 }
 
 .pm-gantt-label-spacer {
@@ -96,12 +96,12 @@
   cursor: pointer;
 }
 .pm-gantt-label-title:hover {
-  color: var(--pm-accent);
+  color: var(--interactive-accent);
 }
 
 .pm-gantt-label-progress {
   font-size: 11px;
-  color: var(--pm-text-muted);
+  color: var(--text-muted);
   flex-shrink: 0;
   margin-right: 8px;
 }
@@ -118,7 +118,7 @@
 }
 .pm-gantt-resize-handle:hover,
 .pm-gantt-resize-handle:active {
-  background: var(--pm-accent);
+  background: var(--interactive-accent);
 }
 
 /* Right panel: scrollable SVG */
@@ -148,7 +148,7 @@
 
 /* SVG elements */
 .pm-gantt-header-bg {
-  fill: var(--pm-bg2);
+  fill: var(--background-secondary);
 }
 .pm-gantt-band-even {
   fill: rgba(0, 0, 0, 0);
@@ -279,12 +279,12 @@
 /* Dependency arrows */
 .pm-gantt-arrow {
   fill: none;
-  stroke: var(--pm-accent);
+  stroke: var(--interactive-accent);
   stroke-width: 1.5;
   stroke-dasharray: 4 3;
   opacity: 0.4;
 }
 .pm-gantt-arrowhead {
-  fill: var(--pm-accent);
+  fill: var(--interactive-accent);
   opacity: 0.5;
 }

--- a/src/styles/gantt.css
+++ b/src/styles/gantt.css
@@ -22,27 +22,6 @@
   flex: 1;
 }
 
-.pm-gantt-zoom-btn {
-  padding: 4px 12px;
-  border: 1px solid var(--pm-border);
-  border-radius: var(--pm-radius-sm);
-  background: transparent;
-  color: var(--pm-text-muted);
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 500;
-  transition: all 0.15s;
-}
-.pm-gantt-zoom-btn:hover {
-  background: var(--pm-bg3);
-  color: var(--pm-text);
-}
-.pm-gantt-zoom-btn--active {
-  background: var(--pm-accent);
-  color: var(--text-on-accent);
-  border-color: var(--pm-accent);
-}
-
 /* Main Gantt layout */
 .pm-gantt-wrapper {
   display: flex;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -8,3 +8,4 @@
 @import './widgets.css';
 @import './task-editor.css';
 @import './utilities.css';
+@import './styleguide.css';

--- a/src/styles/kanban.css
+++ b/src/styles/kanban.css
@@ -30,8 +30,8 @@
   width: 280px;
   min-width: 280px;
   height: 100%;
-  background: var(--pm-bg2);
-  border-radius: var(--pm-radius-lg);
+  background: var(--background-secondary);
+  border-radius: var(--radius-m);
   overflow: hidden;
 }
 
@@ -65,12 +65,12 @@
   gap: 6px;
 }
 .pm-kanban-col-count {
-  background: var(--pm-bg3);
+  background: var(--background-modifier-hover);
   border-radius: 99px;
   padding: 1px 8px;
   font-size: 12px;
   font-weight: 700;
-  color: var(--pm-text-muted);
+  color: var(--text-muted);
 }
 
 .pm-kanban-cards {
@@ -84,7 +84,7 @@
   transition: background 0.15s;
 }
 .pm-kanban-drop-target {
-  background: var(--pm-accent-light);
+  background: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
 }
 
 .pm-kanban-card {
@@ -92,9 +92,9 @@
   display: flex;
   flex-direction: column;
   min-height: 112px;
-  background: var(--pm-bg);
+  background: var(--background-primary);
   border: 1px solid var(--pm-ghost-border);
-  border-radius: var(--pm-radius);
+  border-radius: var(--radius-m);
   overflow: hidden;
   cursor: pointer;
   transition: all 0.15s;
@@ -102,11 +102,11 @@
 }
 .pm-kanban-card:hover {
   box-shadow: 0 2px 12px var(--pm-shadow-ambient);
-  border-color: var(--pm-border);
+  border-color: var(--background-modifier-border);
 }
 .pm-kanban-card--dragging {
   box-shadow: 0 4px 16px var(--pm-shadow-ambient);
-  border-color: var(--pm-accent);
+  border-color: var(--interactive-accent);
   z-index: 100;
 }
 
@@ -159,7 +159,7 @@
 
 .pm-kanban-card-subtasks {
   font-size: 11px;
-  color: var(--pm-text-muted);
+  color: var(--text-muted);
 }
 .pm-kanban-card-parent {
   font-size: 10px;

--- a/src/styles/project-modal.css
+++ b/src/styles/project-modal.css
@@ -284,18 +284,6 @@
 .pm-settings-status-label {
   flex: 1;
 }
-.pm-settings-del {
-  background: transparent;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  padding: 3px 6px;
-  border-radius: 4px;
-}
-.pm-settings-del:hover {
-  background: color-mix(in srgb, var(--color-red) 10%, transparent);
-  color: var(--pm-danger);
-}
 .pm-settings-drag-handle {
   cursor: grab;
   color: var(--text-muted);

--- a/src/styles/project-modal.css
+++ b/src/styles/project-modal.css
@@ -48,9 +48,6 @@
   font-weight: 500;
   padding: 10px 14px;
 }
-.pm-prop-add-btn--sm {
-  font-size: 11px;
-}
 .pm-modal-hint {
   margin: 0;
   font-size: 12px;

--- a/src/styles/project-modal.css
+++ b/src/styles/project-modal.css
@@ -36,7 +36,7 @@
 }
 .pm-project-modal-header-icon {
   font-size: 18px;
-  color: var(--pm-accent);
+  color: var(--interactive-accent);
 }
 .pm-project-modal-section {
   display: flex;
@@ -51,7 +51,7 @@
 .pm-modal-hint {
   margin: 0;
   font-size: 12px;
-  color: var(--pm-text-muted);
+  color: var(--text-muted);
 }
 
 .pm-project-top-row {
@@ -67,25 +67,25 @@
 }
 .pm-icon-picker-btn {
   font-size: 32px;
-  background: var(--pm-bg2);
-  border: 1px solid var(--pm-border);
-  border-radius: var(--pm-radius);
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
   padding: 6px 10px;
   cursor: pointer;
   transition: background 0.15s;
   line-height: 1;
 }
 .pm-icon-picker-btn:hover {
-  background: var(--pm-bg3);
+  background: var(--background-modifier-hover);
 }
 .pm-icon-grid {
   position: absolute;
   top: calc(100% + 4px);
   left: 0;
   z-index: 200;
-  background: var(--pm-bg);
-  border: 1px solid var(--pm-border);
-  border-radius: var(--pm-radius);
+  background: var(--background-primary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
   padding: 8px;
   display: grid;
   grid-template-columns: repeat(6, 1fr);
@@ -97,13 +97,13 @@
   padding: 4px;
   border: none;
   background: transparent;
-  border-radius: var(--pm-radius-sm);
+  border-radius: var(--radius-s);
   cursor: pointer;
   transition: background 0.1s;
   line-height: 1;
 }
 .pm-icon-option:hover {
-  background: var(--pm-bg3);
+  background: var(--background-modifier-hover);
 }
 
 .pm-project-title-wrap {
@@ -134,14 +134,14 @@
   transform: scale(1.15);
 }
 .pm-color-swatch--selected {
-  border-color: var(--pm-text);
-  box-shadow: 0 0 0 2px var(--pm-bg);
+  border-color: var(--text-normal);
+  box-shadow: 0 0 0 2px var(--background-primary);
 }
 .pm-color-custom {
   width: 26px;
   height: 26px;
   border-radius: 50%;
-  border: 1px solid var(--pm-border);
+  border: 1px solid var(--background-modifier-border);
   cursor: pointer;
   padding: 0;
   overflow: hidden;
@@ -162,14 +162,14 @@
   width: 100%;
   padding: 7px 10px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: var(--pm-radius-sm);
+  border-radius: var(--radius-s);
   background: var(--background-secondary);
   color: var(--text-normal);
   font-size: 13px;
   box-sizing: border-box;
 }
 .pm-input:focus {
-  border-color: var(--pm-accent);
+  border-color: var(--interactive-accent);
   outline: none;
 }
 .pm-select {
@@ -209,9 +209,9 @@
   gap: 8px;
   align-items: flex-start;
   padding: 10px;
-  background: var(--pm-bg2);
-  border-radius: var(--pm-radius);
-  border: 1px solid var(--pm-border);
+  background: var(--background-secondary);
+  border-radius: var(--radius-m);
+  border: 1px solid var(--background-modifier-border);
   flex-wrap: wrap;
 }
 .pm-cf-name {

--- a/src/styles/styleguide.css
+++ b/src/styles/styleguide.css
@@ -1,0 +1,48 @@
+/* Layout for the dev-only styleguide gallery (src/views/styleguide/StyleguideView.ts).
+   The view is compiled out of prod builds, but these rules still ship as dead CSS
+   since Obsidian only loads one styles.css. */
+
+.pm-styleguide {
+  padding: var(--size-4-4);
+  overflow-y: auto;
+}
+
+.pm-sg-group {
+  font-size: var(--font-ui-large);
+  font-weight: 700;
+  margin-top: var(--size-4-8);
+}
+
+.pm-sg-section {
+  margin-bottom: var(--size-4-6);
+  padding-top: var(--size-4-4);
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.pm-sg-title {
+  font-size: var(--font-ui-small);
+  font-weight: 600;
+  margin-bottom: var(--size-4-2);
+}
+
+.pm-sg-caption {
+  font-size: var(--font-ui-smaller);
+  color: var(--text-faint);
+  margin: var(--size-4-2) 0 var(--size-4-1);
+}
+
+.pm-sg-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: var(--size-4-2);
+}
+
+/* These normally get their width from a table cell or kanban column; give them one here. */
+.pm-sg-row .pm-progress {
+  width: 160px;
+}
+
+.pm-sg-row .pm-kanban-card {
+  width: 280px;
+}

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -284,7 +284,8 @@
   transition: opacity 0.15s;
 }
 .pm-table-row:hover .pm-icon-btn--hover-only,
-.pm-modal-subtask-row:hover .pm-icon-btn--hover-only {
+.pm-modal-subtask-row:hover .pm-icon-btn--hover-only,
+.pm-gantt-label-row:hover .pm-icon-btn--hover-only {
   opacity: 1;
 }
 .pm-icon-btn--hover-only:focus-visible {
@@ -407,17 +408,4 @@ button.pm-chip-rm {
 /* Add task row */
 .pm-table-add-row td {
   padding: 8px 10px;
-}
-.pm-table-add-btn {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  color: var(--pm-text-muted);
-  font-size: 13px;
-  padding: 4px 8px;
-  border-radius: var(--pm-radius-sm);
-}
-.pm-table-add-btn:hover {
-  background: var(--pm-bg3);
-  color: var(--pm-text);
 }

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -14,9 +14,9 @@
   justify-content: space-between;
   padding: 6px 12px;
   margin: 0 16px 6px;
-  background: color-mix(in srgb, var(--pm-accent) 8%, var(--pm-surface-raised));
-  border: 1px dashed var(--pm-border);
-  border-radius: var(--pm-radius);
+  background: color-mix(in srgb, var(--interactive-accent) 8%, var(--background-secondary));
+  border: 1px dashed var(--background-modifier-border);
+  border-radius: var(--radius-m);
   flex-shrink: 0;
   animation: pm-bulk-bar-in 0.15s ease-out;
 }
@@ -42,7 +42,7 @@
 .pm-bulk-bar-count {
   font-size: 12px;
   font-weight: 600;
-  color: var(--pm-accent);
+  color: var(--interactive-accent);
   padding-right: 4px;
 }
 
@@ -86,8 +86,8 @@
 
 /* -- Selected Row ----------------------------------------------------------- */
 .pm-table-row--selected {
-  background: color-mix(in srgb, var(--pm-accent) 10%, transparent);
-  box-shadow: inset 3px 0 0 var(--pm-accent);
+  background: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
+  box-shadow: inset 3px 0 0 var(--interactive-accent);
 }
 
 .pm-table-wrapper {
@@ -104,15 +104,15 @@
 .pm-table thead th {
   position: sticky;
   top: 0;
-  background: var(--pm-bg);
-  border-bottom: 2px solid var(--pm-border);
+  background: var(--background-primary);
+  border-bottom: 2px solid var(--background-modifier-border);
   padding: 8px 10px;
   text-align: left;
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--pm-text-muted);
+  color: var(--text-muted);
   white-space: nowrap;
   z-index: 10;
   user-select: none;
@@ -121,15 +121,15 @@
   cursor: pointer;
 }
 .pm-table-th-sortable:hover {
-  color: var(--pm-text);
+  color: var(--text-normal);
 }
 
 .pm-table-row {
-  border-bottom: 1px solid var(--pm-border);
+  border-bottom: 1px solid var(--background-modifier-border);
   transition: background 0.1s;
 }
 .pm-table-row:not(.pm-table-row--selected):hover {
-  background: color-mix(in srgb, var(--pm-accent) 5%, transparent);
+  background: color-mix(in srgb, var(--interactive-accent) 5%, transparent);
 }
 .pm-table-row--done {
   opacity: 0.55;
@@ -210,7 +210,7 @@
   line-height: 1.4;
 }
 .pm-task-title-text:hover {
-  color: var(--pm-accent);
+  color: var(--interactive-accent);
 }
 
 .pm-table-tags {

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -46,15 +46,21 @@
   padding-right: 4px;
 }
 
-/* -- Pill ------------------------------------------------------------------- */
-.pm-pill {
+/* -- Capsule base shared by Pill and Chip ------------------------------------ */
+.pm-pill,
+.pm-chip {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
   border-radius: var(--radius-s);
   font-size: var(--font-ui-smaller);
   font-weight: 500;
+  white-space: nowrap;
+}
+
+/* -- Pill (toggleable filter button) ------------------------------------------ */
+.pm-pill {
+  gap: 4px;
+  padding: 4px 10px;
   cursor: pointer;
   border: 1px solid var(--background-modifier-border);
   background: transparent;
@@ -63,7 +69,6 @@
     background 0.15s,
     color 0.15s,
     border-color 0.15s;
-  white-space: nowrap;
 }
 .pm-pill:hover {
   background: var(--background-modifier-hover);
@@ -77,9 +82,6 @@
   background: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
   border-color: color-mix(in srgb, var(--interactive-accent) 40%, transparent);
   color: var(--text-accent);
-}
-.pm-pill--pill {
-  border-radius: 99px;
 }
 
 /* -- Selected Row ----------------------------------------------------------- */
@@ -295,15 +297,9 @@
 /* -- Chip (unified label primitive: status, priority, tags, due, badges) -- */
 .pm-chip {
   --pm-chip-color: var(--text-muted);
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
   padding: 2px 9px;
-  border-radius: var(--radius-s);
-  font-size: var(--font-ui-smaller);
-  font-weight: 500;
   line-height: 1.5;
-  white-space: nowrap;
   color: var(--pm-chip-color);
   background: transparent;
   border: 1px solid transparent;
@@ -340,7 +336,8 @@
   font-size: 10px;
   font-weight: 600;
 }
-.pm-chip--pill {
+.pm-chip--pill,
+.pm-pill--pill {
   border-radius: 99px;
 }
 .pm-chip--strong {

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -283,7 +283,8 @@
   opacity: 0;
   transition: opacity 0.15s;
 }
-.pm-table-row:hover .pm-icon-btn--hover-only {
+.pm-table-row:hover .pm-icon-btn--hover-only,
+.pm-modal-subtask-row:hover .pm-icon-btn--hover-only {
   opacity: 1;
 }
 .pm-icon-btn--hover-only:focus-visible {

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -47,7 +47,8 @@
 }
 
 /* -- Capsule base shared by Pill and Chip ------------------------------------ */
-.pm-pill,
+/* `button` prefix on the pill selectors outranks core button chrome (see pm-prop-add) */
+button.pm-pill,
 .pm-chip {
   display: inline-flex;
   align-items: center;
@@ -58,30 +59,26 @@
 }
 
 /* -- Pill (toggleable filter button) ------------------------------------------ */
-.pm-pill {
-  gap: 4px;
+/* A compact native button: the etched input-shadow chrome comes from app.css.
+   Active carries the plugin's 12% accent-tint selection signature. */
+button.pm-pill {
+  height: auto;
   padding: 4px 10px;
-  cursor: pointer;
-  border: 1px solid var(--background-modifier-border);
-  background: transparent;
   color: var(--text-muted);
   transition:
-    background 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background 0.1s,
+    color 0.1s;
 }
-.pm-pill:hover {
-  background: var(--background-modifier-hover);
-  color: var(--text-normal);
-}
-.pm-pill:focus-visible {
+button.pm-pill:focus-visible {
   outline: 2px solid var(--interactive-accent);
   outline-offset: 2px;
 }
-.pm-pill--active {
+button.pm-pill--active {
   background: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
-  border-color: color-mix(in srgb, var(--interactive-accent) 40%, transparent);
   color: var(--text-accent);
+}
+button.pm-pill--active:hover {
+  background: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
 }
 
 /* -- Selected Row ----------------------------------------------------------- */
@@ -337,7 +334,7 @@
   font-weight: 600;
 }
 .pm-chip--pill,
-.pm-pill--pill {
+button.pm-pill--pill {
   border-radius: 99px;
 }
 .pm-chip--strong {

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -46,9 +46,9 @@
   padding-right: 4px;
 }
 
-/* -- Capsule base shared by Pill and Chip ------------------------------------ */
-/* `button` prefix on the pill selectors outranks core button chrome (see pm-prop-add) */
-button.pm-pill,
+/* -- Capsule base shared by ChipButton and Chip ------------------------------- */
+/* `button` prefix on the chip-btn selectors outranks core button chrome (see pm-prop-add) */
+button.pm-chip-btn,
 .pm-chip {
   display: inline-flex;
   align-items: center;
@@ -58,10 +58,10 @@ button.pm-pill,
   white-space: nowrap;
 }
 
-/* -- Pill (toggleable filter button) ------------------------------------------ */
+/* -- ChipButton ---------------------------------------------------------------- */
 /* A compact native button: the etched input-shadow chrome comes from app.css.
    Active carries the plugin's 12% accent-tint selection signature. */
-button.pm-pill {
+button.pm-chip-btn {
   height: auto;
   padding: 4px 10px;
   color: var(--text-muted);
@@ -69,15 +69,15 @@ button.pm-pill {
     background 0.1s,
     color 0.1s;
 }
-button.pm-pill:focus-visible {
+button.pm-chip-btn:focus-visible {
   outline: 2px solid var(--interactive-accent);
   outline-offset: 2px;
 }
-button.pm-pill--active {
+button.pm-chip-btn--active {
   background: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
   color: var(--text-accent);
 }
-button.pm-pill--active:hover {
+button.pm-chip-btn--active:hover {
   background: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
 }
 
@@ -334,7 +334,7 @@ button.pm-pill--active:hover {
   font-weight: 600;
 }
 .pm-chip--pill,
-button.pm-pill--pill {
+button.pm-chip-btn--pill {
   border-radius: 99px;
 }
 .pm-chip--strong {

--- a/src/styles/task-modal.css
+++ b/src/styles/task-modal.css
@@ -134,8 +134,6 @@
   outline: none;
 }
 
-.pm-prop-assignees,
-.pm-prop-tags,
 .pm-prop-deps {
   flex-wrap: wrap;
 }

--- a/src/styles/task-modal.css
+++ b/src/styles/task-modal.css
@@ -226,35 +226,6 @@ textarea.pm-modal-description:focus {
   background: var(--pm-bg3);
 }
 
-/* `button` prefix outranks core button chrome (grey fill + inset shadow + fixed
-   height), which otherwise paints over this ghost icon button. */
-button.pm-subtask-rm {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: auto;
-  padding: 2px;
-  border: none;
-  border-radius: var(--pm-radius-sm);
-  background: transparent;
-  box-shadow: none;
-  color: var(--pm-text-muted);
-  cursor: pointer;
-  transition: opacity 0.15s;
-  --icon-size: 14px;
-}
-/* Subtask rows reveal the remove button on hover; time-log rows keep it shown.
-   The row-scoped selectors (0,2,0) outrank the element-prefixed base (0,1,1). */
-.pm-modal-subtask-row .pm-subtask-rm {
-  opacity: 0;
-}
-.pm-modal-subtask-row:hover .pm-subtask-rm {
-  opacity: 1;
-}
-.pm-subtask-rm:hover {
-  color: var(--pm-danger);
-}
-
 /* Modal footer */
 .pm-modal-footer {
   display: flex;

--- a/src/styles/task-modal.css
+++ b/src/styles/task-modal.css
@@ -2,25 +2,7 @@
    TASK MODAL
    --------------------------------------------------------------------------- */
 .pm-modal {
-  /* Inherit CSS variables since modals render outside .pm-root */
-  --pm-radius: 0.375rem;
-  --pm-radius-sm: 0.25rem;
-  --pm-radius-lg: 0.5rem;
-  --pm-font: var(--font-interface);
-  --pm-mono: var(--font-monospace);
-  --pm-bg: var(--background-primary);
-  --pm-bg2: var(--background-secondary);
-  --pm-bg3: var(--background-modifier-hover);
-  --pm-border: var(--background-modifier-border);
-  --pm-text: var(--text-normal);
-  --pm-text-muted: var(--text-muted);
-  --pm-text-faint: var(--text-faint);
-  --pm-accent: var(--interactive-accent);
-  --pm-accent-dim: var(--interactive-accent-hover);
-  --pm-accent-light: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
-  --pm-danger: var(--color-red);
-  --pm-success: var(--color-green);
-  --pm-warning: var(--color-yellow);
+  /* Modals render outside .pm-root, so the two plugin tokens are re-declared here */
   --pm-ghost-border: rgba(0, 0, 0, 0.06);
   --pm-shadow-ambient: rgba(0, 0, 0, 0.06);
 
@@ -62,7 +44,7 @@
 }
 .pm-prop-label {
   font-size: 12px;
-  color: var(--pm-text-muted);
+  color: var(--text-muted);
   font-weight: 500;
   white-space: nowrap;
 }
@@ -85,7 +67,7 @@
   appearance: none;
   height: 6px;
   border-radius: 99px;
-  background: var(--pm-bg3);
+  background: var(--background-modifier-hover);
   cursor: pointer;
 }
 .pm-progress-slider::-webkit-slider-thumb {
@@ -93,44 +75,44 @@
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  background: var(--pm-accent);
+  background: var(--interactive-accent);
   cursor: pointer;
   box-shadow: 0 1px 4px color-mix(in srgb, var(--interactive-accent) 40%, transparent);
 }
 .pm-progress-slider-label {
   font-size: 12px;
-  color: var(--pm-text-muted);
+  color: var(--text-muted);
   min-width: 32px;
   text-align: right;
 }
 
 .pm-prop-date {
   padding: 4px 8px;
-  border: 1px solid var(--pm-border);
-  border-radius: var(--pm-radius-sm);
-  background: var(--pm-bg2);
-  color: var(--pm-text);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s);
+  background: var(--background-secondary);
+  color: var(--text-normal);
   font-size: 13px;
   cursor: pointer;
 }
 .pm-prop-date:focus {
-  border-color: var(--pm-accent);
+  border-color: var(--interactive-accent);
   outline: none;
 }
 
 .pm-prop-text,
 .pm-prop-select {
   padding: 5px 8px;
-  border: 1px solid var(--pm-border);
-  border-radius: var(--pm-radius-sm);
-  background: var(--pm-bg2);
-  color: var(--pm-text);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s);
+  background: var(--background-secondary);
+  color: var(--text-normal);
   font-size: 13px;
   width: 100%;
 }
 .pm-prop-text:focus,
 .pm-prop-select:focus {
-  border-color: var(--pm-accent);
+  border-color: var(--interactive-accent);
   outline: none;
 }
 
@@ -141,7 +123,7 @@
 /* Modal sections */
 .pm-modal-section {
   padding: 14px 24px;
-  border-top: 1px solid var(--pm-border);
+  border-top: 1px solid var(--background-modifier-border);
 }
 .pm-modal-section-header {
   display: flex;
@@ -154,7 +136,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--pm-text-muted);
+  color: var(--text-muted);
   margin: 0 0 10px;
 }
 .pm-modal-section-header .pm-modal-section-title {
@@ -168,9 +150,9 @@
   height: var(--desc-height, auto);
   padding: 6px 8px;
   border: 1px solid transparent;
-  border-radius: var(--pm-radius-sm);
+  border-radius: var(--radius-s);
   background: transparent;
-  color: var(--pm-text);
+  color: var(--text-normal);
   font-size: 13px;
   line-height: 1.6;
   resize: none;
@@ -202,11 +184,11 @@ textarea.pm-modal-description:focus {
   align-items: center;
   gap: 8px;
   padding: 5px 8px;
-  border-radius: var(--pm-radius-sm);
+  border-radius: var(--radius-s);
   transition: background 0.1s;
 }
 .pm-modal-subtask-row:hover {
-  background: var(--pm-bg3);
+  background: var(--background-modifier-hover);
 }
 
 .pm-subtask-dot {
@@ -223,7 +205,7 @@ textarea.pm-modal-description:focus {
   padding: 1px 3px;
 }
 .pm-subtask-title:focus {
-  background: var(--pm-bg3);
+  background: var(--background-modifier-hover);
 }
 
 /* Modal footer */
@@ -232,8 +214,8 @@ textarea.pm-modal-description:focus {
   align-items: center;
   gap: 8px;
   padding: 14px 24px;
-  border-top: 1px solid var(--pm-border);
-  background: var(--pm-bg2);
+  border-top: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
   position: sticky;
   bottom: 0;
 }

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -52,10 +52,10 @@ body.pm-resize-active * {
   opacity: 0.4;
 }
 .pm-gantt-label-row--drop-before {
-  box-shadow: inset 0 2px 0 var(--pm-accent);
+  box-shadow: inset 0 2px 0 var(--interactive-accent);
 }
 .pm-gantt-label-row--drop-after {
-  box-shadow: inset 0 -2px 0 var(--pm-accent);
+  box-shadow: inset 0 -2px 0 var(--interactive-accent);
 }
 
 /* -- Import Modal ----------------------------------------------------------- */

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -130,20 +130,6 @@ body.pm-resize-active * {
   justify-content: flex-end;
   gap: 0.75rem;
 }
-.import-btn {
-  padding: 0.5rem 1rem;
-  border-radius: 0.25rem;
-  cursor: pointer;
-}
-.import-btn--secondary {
-  border: 1px solid var(--background-modifier-border);
-  background-color: var(--background-primary);
-  color: var(--text-normal);
-}
-.import-btn--disabled {
-  cursor: not-allowed;
-}
-
 .import-options-content {
   padding: 1.5rem;
   display: flex;

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -58,38 +58,6 @@ body.pm-resize-active * {
   box-shadow: inset 0 -2px 0 var(--pm-accent);
 }
 
-/* -- Gantt label "+" subtask button ------------------------------------ */
-.pm-gantt-label-add-btn {
-  appearance: none;
-  background: none;
-  border: none;
-  margin: 0;
-  padding: 0;
-  font: inherit;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 700;
-  color: var(--pm-text-muted);
-  width: 20px;
-  height: 20px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 4px;
-  flex-shrink: 0;
-  opacity: 0;
-  transition:
-    opacity 0.15s,
-    background 0.15s;
-}
-.pm-gantt-label-row:hover .pm-gantt-label-add-btn {
-  opacity: 1;
-}
-.pm-gantt-label-add-btn:hover {
-  background: var(--pm-bg3);
-  color: var(--pm-accent);
-}
-
 /* -- Import Modal ----------------------------------------------------------- */
 /* Note: modals render outside .pm-root, so use Obsidian native vars only.   */
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,35 +1,12 @@
-/* CSS custom properties and root layout */
+/* Root layout plus the two plugin tokens with no Obsidian equivalent
+   (theme-dependent, overridden for dark mode in widgets.css). Everything
+   else uses Obsidian theme variables directly. */
 .pm-root {
-  --pm-radius: 0.375rem;
-  --pm-radius-sm: 0.25rem;
-  --pm-radius-lg: 0.5rem;
-  --pm-font: var(--font-interface);
-  --pm-mono: var(--font-monospace);
-
-  --pm-bg: var(--background-primary);
-  --pm-bg2: var(--background-secondary);
-  --pm-bg3: var(--background-modifier-hover);
-  --pm-border: var(--background-modifier-border);
-  --pm-text: var(--text-normal);
-  --pm-text-muted: var(--text-muted);
-  --pm-text-faint: var(--text-faint);
-
-  --pm-accent: var(--interactive-accent);
-  --pm-accent-dim: var(--interactive-accent-hover);
-  --pm-accent-light: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
-  --pm-danger: var(--color-red);
-  --pm-success: var(--color-green);
-  --pm-warning: var(--color-yellow);
-
-  /* Surfaces - no glassmorphism, use tonal stacking */
-  --pm-surface: var(--background-primary);
-  --pm-surface-raised: var(--background-secondary);
-  --pm-surface-overlay: var(--background-secondary);
   --pm-ghost-border: rgba(0, 0, 0, 0.06);
   --pm-shadow-ambient: rgba(0, 0, 0, 0.06);
 
-  font-family: var(--pm-font);
-  color: var(--pm-text);
+  font-family: var(--font-interface);
+  color: var(--text-normal);
   display: flex;
   flex-direction: column;
   height: 100%;

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -19,11 +19,11 @@
 .pm-kanban-cards::-webkit-scrollbar-thumb,
 .pm-task-modal::-webkit-scrollbar-thumb,
 .pm-project-modal::-webkit-scrollbar-thumb {
-  background: var(--pm-border);
+  background: var(--background-modifier-border);
   border-radius: 99px;
 }
 .pm-gantt-right::-webkit-scrollbar-thumb:hover {
-  background: var(--pm-text-muted);
+  background: var(--text-muted);
 }
 
 /* ---------------------------------------------------------------------------
@@ -45,7 +45,7 @@
 }
 .pm-time-label {
   font-size: 12px;
-  color: var(--pm-text-muted);
+  color: var(--text-muted);
 }
 .pm-time-est-input {
   width: 80px;
@@ -62,8 +62,8 @@
   gap: 6px;
   align-items: center;
   padding: 5px 6px;
-  border-radius: var(--pm-radius-sm);
-  background: var(--pm-bg3);
+  border-radius: var(--radius-s);
+  background: var(--background-modifier-hover);
   border: 1px solid var(--pm-ghost-border);
 }
 .pm-time-log-date {
@@ -94,10 +94,10 @@
 /* -- Inline edit input --------------------------------------------------- */
 .pm-inline-edit {
   padding: 3px 6px;
-  border: 1px solid var(--pm-accent);
-  border-radius: var(--pm-radius-sm);
-  background: var(--pm-bg2);
-  color: var(--pm-text);
+  border: 1px solid var(--interactive-accent);
+  border-radius: var(--radius-s);
+  background: var(--background-secondary);
+  color: var(--text-normal);
   font-size: 13px;
   outline: none;
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--interactive-accent) 20%, transparent);
@@ -126,7 +126,7 @@
 /* -- Gantt link dots (dependency connectors) ---------------------------- */
 .pm-gantt-link-dot {
   fill: transparent;
-  stroke: var(--pm-accent);
+  stroke: var(--interactive-accent);
   stroke-width: 1.5;
   opacity: 0;
   transition:
@@ -139,13 +139,13 @@
 }
 .pm-gantt-bar-group .pm-gantt-link-dot:hover {
   opacity: 1;
-  fill: var(--pm-accent);
+  fill: var(--interactive-accent);
 }
 .pm-gantt-bar-group .pm-gantt-link-dot--active {
   opacity: 1;
-  fill: var(--pm-accent);
+  fill: var(--interactive-accent);
   stroke-width: 2;
-  filter: drop-shadow(0 0 3px var(--pm-accent));
+  filter: drop-shadow(0 0 3px var(--interactive-accent));
 }
 
 /* -- Gantt milestone ----------------------------------------------------- */
@@ -178,10 +178,7 @@
   --pm-shadow-ambient: rgba(0, 0, 0, 0.15);
 }
 
-/* -- Properties container ---------------------------------------------- */
-.pm-modal-props-container {
-  padding: 0 24px;
-}
+/* -- Description section ------------------------------------------------ */
 .pm-modal-desc-section {
   border-top: none;
   position: relative;
@@ -189,7 +186,7 @@
 .pm-modal-desc-preview {
   padding: 6px 8px;
   background: transparent;
-  border-radius: var(--pm-radius-sm);
+  border-radius: var(--radius-s);
   border: 1px solid transparent;
   font-size: 13px;
   line-height: 1.6;
@@ -228,9 +225,9 @@
   width: 280px;
   max-height: 240px;
   overflow-y: auto;
-  background: var(--pm-bg);
-  border: 1px solid var(--pm-border);
-  border-radius: var(--pm-radius);
+  background: var(--background-primary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
   box-shadow: 0 4px 16px var(--pm-shadow-ambient);
   padding: 4px;
   display: none;
@@ -251,15 +248,15 @@
   display: flex;
   flex-direction: column;
   padding: 6px 10px;
-  border-radius: var(--pm-radius-sm);
+  border-radius: var(--radius-s);
   cursor: pointer;
   transition: background 0.1s;
 }
 .pm-note-suggest-item:hover {
-  background: var(--pm-bg3);
+  background: var(--background-modifier-hover);
 }
 .pm-note-suggest-item--active {
-  background: var(--pm-accent-light);
+  background: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
 }
 .pm-note-suggest-name-row {
   display: flex;
@@ -270,7 +267,7 @@
 .pm-note-suggest-name {
   font-size: 13px;
   font-weight: 500;
-  color: var(--pm-text);
+  color: var(--text-normal);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -281,14 +278,14 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  color: var(--pm-text-faint);
-  background: var(--pm-bg3);
+  color: var(--text-faint);
+  background: var(--background-modifier-hover);
   padding: 1px 5px;
-  border-radius: var(--pm-radius-sm);
+  border-radius: var(--radius-s);
 }
 .pm-note-suggest-path {
   font-size: 11px;
-  color: var(--pm-text-faint);
+  color: var(--text-faint);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -52,47 +52,8 @@
 .pm-segmented-btn:hover {
   background: var(--pm-bg3);
 }
-.pm-segmented-btn--milestone {
-  background: color-mix(in srgb, var(--interactive-accent) 15%, transparent);
-  border-color: color-mix(in srgb, var(--interactive-accent) 40%, transparent);
-  color: var(--text-accent);
-}
-.pm-segmented-btn--subtask {
-  background: color-mix(in srgb, var(--color-green) 15%, transparent);
-  border-color: color-mix(in srgb, var(--color-green) 40%, transparent);
-  color: var(--color-green);
-}
 .pm-segmented-btn--active {
   box-shadow: 0 0 0 2px var(--pm-accent);
-}
-
-/* -- Recurrence picker --------------------------------------------------- */
-.pm-prop-recurrence {
-  flex-wrap: wrap;
-  gap: 6px;
-}
-.pm-recur-every {
-  width: 52px;
-  text-align: center;
-}
-.pm-recur-interval {
-  width: 110px;
-}
-.pm-recur-end {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-.pm-recur-label {
-  font-size: 12px;
-  color: var(--pm-text-muted);
-}
-.pm-recur-end-input {
-  width: 130px;
-}
-.pm-prop-add-btn.pm-recur-rm {
-  color: var(--pm-danger);
-  border-color: color-mix(in srgb, var(--color-red) 30%, transparent);
 }
 
 /* -- Time tracking ------------------------------------------------------- */

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -314,22 +314,7 @@
   text-overflow: ellipsis;
 }
 
-/* -- Gantt add task button --------------------------------------------- */
-.pm-gantt-add-task-btn {
-  appearance: none;
-  background: none;
-  border: none;
-  margin: 0;
-  font: inherit;
-  cursor: pointer;
-  font-size: 12px;
-  color: var(--pm-text-muted);
-  padding: 4px 8px;
+/* -- Gantt add task row -------------------------------------------------- */
+.pm-gantt-add-row .pm-prop-add {
   margin-left: 20px;
-  border-radius: var(--pm-radius-sm);
-  transition: all 0.15s;
-}
-.pm-gantt-add-task-btn:hover {
-  background: var(--pm-bg3);
-  color: var(--pm-accent);
 }

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -35,26 +35,6 @@
   display: flex;
   gap: 6px;
 }
-.pm-segmented-btn {
-  appearance: none;
-  background: none;
-  margin: 0;
-  font: inherit;
-  cursor: pointer;
-  padding: 4px 12px;
-  border-radius: var(--pm-radius-sm);
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--pm-text-muted);
-  border: 1px solid var(--pm-border);
-  transition: all 0.15s;
-}
-.pm-segmented-btn:hover {
-  background: var(--pm-bg3);
-}
-.pm-segmented-btn--active {
-  box-shadow: 0 0 0 2px var(--pm-accent);
-}
 
 /* -- Time tracking ------------------------------------------------------- */
 .pm-time-est-row {

--- a/src/ui/FilterDropdown.ts
+++ b/src/ui/FilterDropdown.ts
@@ -1,5 +1,5 @@
 import { Menu } from 'obsidian'
-import { Pill } from './primitives/Pill'
+import { ChipButton } from './primitives/ChipButton'
 
 export function renderFilterDropdown(
   parent: HTMLElement,
@@ -8,15 +8,15 @@ export function renderFilterDropdown(
   options: { id: string; label: string }[],
   onChange: (selected: string[]) => void
 ): HTMLElement {
-  const pill = new Pill(parent).setAriaLabel(`Filter by ${label}`)
+  const btn = new ChipButton(parent).setAriaLabel(`Filter by ${label}`)
 
-  const updatePill = () => {
+  const updateLabel = () => {
     const has = selected.length > 0
-    pill.setLabel(has ? `${label}: ${selected.length}` : label).setActive(has)
+    btn.setLabel(has ? `${label}: ${selected.length}` : label).setActive(has)
   }
-  updatePill()
+  updateLabel()
 
-  pill.onClick((e) => {
+  btn.onClick((e) => {
     const menu = new Menu()
     for (const opt of options) {
       menu.addItem((item) =>
@@ -28,7 +28,7 @@ export function renderFilterDropdown(
             if (idx >= 0) selected.splice(idx, 1)
             else selected.push(opt.id)
             onChange(selected)
-            updatePill()
+            updateLabel()
           })
       )
     }
@@ -38,13 +38,13 @@ export function renderFilterDropdown(
         item.setTitle('Clear').onClick(() => {
           selected.length = 0
           onChange(selected)
-          updatePill()
+          updateLabel()
         })
       )
     }
     menu.showAtMouseEvent(e)
   })
 
-  pill.el.setAttribute('role', 'combobox')
-  return pill.el
+  btn.el.setAttribute('role', 'combobox')
+  return btn.el
 }

--- a/src/ui/PaletteListEditor.ts
+++ b/src/ui/PaletteListEditor.ts
@@ -1,5 +1,6 @@
 import { AbstractInputSuggest, App, Notice, getIconIds, setIcon } from 'obsidian'
 import type { PriorityConfig, StatusConfig } from '../types'
+import { IconButton } from './primitives/IconButton'
 
 /** Suggests Lucide icon ids for the status/priority icon inputs. Typed emoji are kept as-is. */
 class IconSuggest extends AbstractInputSuggest<string> {
@@ -116,18 +117,19 @@ function renderPaletteListEditor<T extends PaletteEntry>(container: HTMLElement,
 
     opts.renderExtra?.(row, item)
 
-    // Delete button
-    const del = row.createEl('button', { text: '✕', cls: 'pm-settings-del' })
-    del.addEventListener('click', () => {
-      if (opts.items.length <= 1) {
-        new Notice(opts.minOneMessage)
-        return
-      }
-      opts.items.splice(i, 1)
-      opts.onChanged()
-      rerender()
-      opts.onDeleted?.(item)
-    })
+    new IconButton(row)
+      .setIcon('x')
+      .setTooltip('Remove')
+      .onClick(() => {
+        if (opts.items.length <= 1) {
+          new Notice(opts.minOneMessage)
+          return
+        }
+        opts.items.splice(i, 1)
+        opts.onChanged()
+        rerender()
+        opts.onDeleted?.(item)
+      })
   })
 }
 

--- a/src/ui/composites/KanbanCard.ts
+++ b/src/ui/composites/KanbanCard.ts
@@ -3,7 +3,9 @@ import { formatDateShort } from '../../utils'
 import { AvatarStack } from '../primitives/AvatarStack'
 import { Chip } from '../primitives/Chip'
 import { ProgressBar } from '../primitives/ProgressBar'
+import { renderDueChip } from './dueChip'
 import { renderTagChip } from './tagChip'
+import { renderTimeChip } from './timeChip'
 
 export interface KanbanCardProps {
   task: Task
@@ -72,14 +74,7 @@ export class KanbanCard {
       body.createDiv({ cls: 'pm-kanban-card-description', text: props.descriptionPreview })
     }
 
-    const est = task.timeEstimate ?? 0
-    if (props.loggedHours > 0 || est > 0) {
-      const label = est > 0 ? `${props.loggedHours}/${est}h` : `${props.loggedHours}h`
-      const timeChip = new Chip(body).setLabel(label).setSize('sm')
-      if (est > 0 && props.loggedHours > est) {
-        timeChip.setVariant('solid').setColor('var(--color-red)').setStrong()
-      }
-    }
+    renderTimeChip(body, props.loggedHours, task.timeEstimate ?? 0, 'sm')
 
     if (task.tags.length) {
       const tagsEl = body.createDiv('pm-kanban-card-tags')
@@ -104,10 +99,7 @@ export class KanbanCard {
     new AvatarStack(footer).setNames(task.assignees).setMax(3).setSize('sm')
 
     if (task.due) {
-      const dueChip = new Chip(footer).setLabel(formatDateShort(task.due)).setSize('sm')
-      if (props.overdue) {
-        dueChip.setVariant('solid').setColor('var(--color-red)').setStrong()
-      }
+      renderDueChip(footer, formatDateShort(task.due), props.overdue ? 'overdue' : 'normal', 'sm')
     }
 
     card.addEventListener('dragstart', (e) => {

--- a/src/ui/composites/ProjectHeader/FilterRow.ts
+++ b/src/ui/composites/ProjectHeader/FilterRow.ts
@@ -1,4 +1,4 @@
-import { ButtonComponent, Menu } from 'obsidian'
+import { Menu } from 'obsidian'
 import type { Project, FilterState, StatusConfig, PriorityConfig, DueDateFilter } from '../../../types'
 import { collectAllAssignees, collectAllTags } from '../../../store'
 import { countActiveFilters } from '../../../store/TaskFilter'
@@ -25,7 +25,7 @@ const DUE_LABELS: Record<DueDateFilter, string> = {
 
 export class FilterRow {
   el: HTMLElement
-  private clearBtn: ButtonComponent | null = null
+  private clearBtn: Pill | null = null
 
   constructor(
     parentEl: HTMLElement,
@@ -142,7 +142,7 @@ export class FilterRow {
       this.clearBtn = null
       return
     }
-    this.clearBtn = new ButtonComponent(this.el).setButtonText(`Clear (${count})`).onClick(() => {
+    this.clearBtn = new Pill(this.el).setLabel(`Clear (${count})`).onClick(() => {
       this.props.onClear()
     })
   }
@@ -153,7 +153,7 @@ export class FilterRow {
 
   private updateClearButton(): void {
     if (this.clearBtn) {
-      this.clearBtn.buttonEl.remove()
+      this.clearBtn.el.remove()
       this.clearBtn = null
     }
     this.renderClearButton()

--- a/src/ui/composites/ProjectHeader/FilterRow.ts
+++ b/src/ui/composites/ProjectHeader/FilterRow.ts
@@ -3,7 +3,7 @@ import type { Project, FilterState, StatusConfig, PriorityConfig, DueDateFilter 
 import { collectAllAssignees, collectAllTags } from '../../../store'
 import { countActiveFilters } from '../../../store/TaskFilter'
 import { renderFilterDropdown } from '../../FilterDropdown'
-import { Pill } from '../../primitives/Pill'
+import { ChipButton } from '../../primitives/ChipButton'
 import { formatBadgeText } from '../../../utils'
 
 export interface FilterRowProps {
@@ -25,7 +25,7 @@ const DUE_LABELS: Record<DueDateFilter, string> = {
 
 export class FilterRow {
   el: HTMLElement
-  private clearBtn: Pill | null = null
+  private clearBtn: ChipButton | null = null
 
   constructor(
     parentEl: HTMLElement,
@@ -94,20 +94,20 @@ export class FilterRow {
       )
     }
 
-    this.renderDueDatePill(notify)
-    this.renderArchivedPill(notify)
+    this.renderDueDateButton(notify)
+    this.renderArchivedButton(notify)
     this.renderClearButton()
   }
 
-  private renderDueDatePill(notify: () => void): void {
+  private renderDueDateButton(notify: () => void): void {
     const { filter } = this.props
-    const pill = new Pill(this.el)
+    const btn = new ChipButton(this.el)
     const updateLabel = () => {
       const current = filter.dueDateFilter
-      pill.setLabel(current !== 'any' ? `Due: ${DUE_LABELS[current]}` : DUE_LABELS.any).setActive(current !== 'any')
+      btn.setLabel(current !== 'any' ? `Due: ${DUE_LABELS[current]}` : DUE_LABELS.any).setActive(current !== 'any')
     }
     updateLabel()
-    pill.onClick((e) => {
+    btn.onClick((e) => {
       const menu = new Menu()
       const opts: DueDateFilter[] = ['any', 'overdue', 'this-week', 'this-month', 'no-date']
       for (const opt of opts) {
@@ -126,12 +126,12 @@ export class FilterRow {
     })
   }
 
-  private renderArchivedPill(notify: () => void): void {
+  private renderArchivedButton(notify: () => void): void {
     const { filter } = this.props
-    const pill = new Pill(this.el).setLabel('Archived').setActive(filter.showArchived)
-    pill.onClick(() => {
+    const btn = new ChipButton(this.el).setLabel('Archived').setActive(filter.showArchived)
+    btn.onClick(() => {
       filter.showArchived = !filter.showArchived
-      pill.setActive(filter.showArchived)
+      btn.setActive(filter.showArchived)
       notify()
     })
   }
@@ -142,7 +142,7 @@ export class FilterRow {
       this.clearBtn = null
       return
     }
-    this.clearBtn = new Pill(this.el).setLabel(`Clear (${count})`).onClick(() => {
+    this.clearBtn = new ChipButton(this.el).setLabel(`Clear (${count})`).onClick(() => {
       this.props.onClear()
     })
   }

--- a/src/ui/composites/ProjectHeader/PrimaryRow.ts
+++ b/src/ui/composites/ProjectHeader/PrimaryRow.ts
@@ -156,6 +156,7 @@ export class PrimaryRow {
       this.props.filterRowExpanded || isFilterActive(this.props.filter) || this.props.filter.showArchived
     const pill = new Pill(parent)
       .setLabel('Filter')
+      .setShape('pill')
       .setActive(isFilterRowVisible)
       .setAriaLabel('Toggle filter row')
       .onClick(() => {

--- a/src/ui/composites/ProjectHeader/PrimaryRow.ts
+++ b/src/ui/composites/ProjectHeader/PrimaryRow.ts
@@ -1,6 +1,6 @@
 import { ButtonComponent, Menu } from 'obsidian'
 import type { Project, FilterState, SavedView } from '../../../types'
-import { Pill } from '../../primitives/Pill'
+import { ChipButton } from '../../primitives/ChipButton'
 import { isFilterActive } from '../../../store/TaskFilter'
 import { safeAsync } from '../../../utils'
 
@@ -64,7 +64,7 @@ export class PrimaryRow {
   private renderSavedViewPills(parent: HTMLElement): void {
     const wrap = parent.createDiv('pm-project-header-saved-views')
 
-    new Pill(wrap)
+    new ChipButton(wrap)
       .setLabel('All')
       .setShape('pill')
       .setActive(!this.props.activeSavedViewId)
@@ -78,7 +78,7 @@ export class PrimaryRow {
   }
 
   private renderSavedViewPill(parent: HTMLElement, sv: SavedView): void {
-    new Pill(parent)
+    new ChipButton(parent)
       .setLabel(sv.name)
       .setShape('pill')
       .setActive(this.props.activeSavedViewId === sv.id)
@@ -154,7 +154,7 @@ export class PrimaryRow {
   private renderFilterToggle(parent: HTMLElement): void {
     const isFilterRowVisible =
       this.props.filterRowExpanded || isFilterActive(this.props.filter) || this.props.filter.showArchived
-    const pill = new Pill(parent)
+    const btn = new ChipButton(parent)
       .setLabel('Filter')
       .setShape('pill')
       .setActive(isFilterRowVisible)
@@ -162,6 +162,6 @@ export class PrimaryRow {
       .onClick(() => {
         this.props.onToggleFilterRow()
       })
-    pill.el.addClass('pm-project-header-filter-toggle')
+    btn.el.addClass('pm-project-header-filter-toggle')
   }
 }

--- a/src/ui/composites/addButton.ts
+++ b/src/ui/composites/addButton.ts
@@ -1,0 +1,14 @@
+import { setIcon } from 'obsidian'
+
+/** Ghost "+ label" add button, the pm-prop-add pattern shared by every add row. */
+export function renderAddButton(
+  parent: HTMLElement,
+  label: string,
+  onClick: (e: MouseEvent) => void
+): HTMLButtonElement {
+  const btn = parent.createEl('button', { cls: 'pm-prop-add' })
+  setIcon(btn.createSpan({ cls: 'pm-glyph-icon' }), 'plus')
+  btn.createSpan({ cls: 'pm-prop-add-label', text: label })
+  btn.addEventListener('click', onClick)
+  return btn
+}

--- a/src/ui/composites/cells/DueDateCell.ts
+++ b/src/ui/composites/cells/DueDateCell.ts
@@ -1,11 +1,13 @@
 import type { Task } from '../../../types'
 import { formatDateLong } from '../../../utils'
+import type { DueUrgency } from '../dueChip'
+import { renderDueChip } from '../dueChip'
 import { Chip } from '../../primitives/Chip'
 import { makeInlineEdit } from './inlineEdit'
 
 export interface DueDateCellProps {
   task: Task
-  urgency: 'normal' | 'near' | 'overdue'
+  urgency: DueUrgency
   onSave: (newDate: string) => Promise<void>
 }
 
@@ -37,12 +39,7 @@ export class DueDateCell {
       return
     }
 
-    const chip = new Chip(this.el).setLabel(formatDateLong(task.due))
-    if (props.urgency === 'near') {
-      chip.setVariant('solid').setColor('var(--color-orange)')
-    } else if (props.urgency === 'overdue') {
-      chip.setVariant('solid').setColor('var(--color-red)').setStrong()
-    }
+    const chip = renderDueChip(this.el, formatDateLong(task.due), props.urgency)
     chip.onClick((e) => {
       e.stopPropagation()
       startEdit(chip.el)

--- a/src/ui/composites/cells/TimeCell.ts
+++ b/src/ui/composites/cells/TimeCell.ts
@@ -1,4 +1,4 @@
-import { Chip } from '../../primitives/Chip'
+import { renderTimeChip } from '../timeChip'
 
 export interface TimeCellProps {
   logged: number
@@ -10,13 +10,6 @@ export class TimeCell {
 
   constructor(parentRow: HTMLElement, props: TimeCellProps) {
     this.el = parentRow.createEl('td', { cls: 'pm-table-cell pm-table-cell-time' })
-    const { logged, estimate } = props
-    if (logged <= 0 && estimate <= 0) return
-
-    const label = estimate > 0 ? `${logged}/${estimate}h` : `${logged}h`
-    const chip = new Chip(this.el).setLabel(label)
-    if (estimate > 0 && logged > estimate) {
-      chip.setVariant('solid').setColor('var(--color-red)').setStrong()
-    }
+    renderTimeChip(this.el, props.logged, props.estimate)
   }
 }

--- a/src/ui/composites/dueChip.ts
+++ b/src/ui/composites/dueChip.ts
@@ -1,0 +1,14 @@
+import { Chip } from '../primitives/Chip'
+
+export type DueUrgency = 'normal' | 'near' | 'overdue'
+
+/** Due-date chip; orange when the date is near, red solid when overdue. The caller formats the label. */
+export function renderDueChip(parent: HTMLElement, label: string, urgency: DueUrgency, size: 'md' | 'sm' = 'md'): Chip {
+  const chip = new Chip(parent).setLabel(label).setSize(size)
+  if (urgency === 'near') {
+    chip.setVariant('solid').setColor('var(--color-orange)')
+  } else if (urgency === 'overdue') {
+    chip.setVariant('solid').setColor('var(--color-red)').setStrong()
+  }
+  return chip
+}

--- a/src/ui/composites/properties/AddProperty.ts
+++ b/src/ui/composites/properties/AddProperty.ts
@@ -1,4 +1,5 @@
 import { setIcon } from 'obsidian'
+import { renderAddButton } from '../addButton'
 import { Popover } from '../../primitives/Popover'
 
 export interface HiddenProperty {
@@ -17,13 +18,8 @@ export function renderAddProperty(
   onShow: (id: string) => void
 ): void {
   if (hidden.length === 0) return
-  const btn = container.createEl('button', { cls: 'pm-prop-add' })
-  const icon = btn.createSpan({ cls: 'pm-glyph-icon' })
-  setIcon(icon, 'plus')
-  btn.createSpan({ cls: 'pm-prop-add-label', text: 'Add property' })
-
   let pop: Popover | null = null
-  btn.addEventListener('click', () => {
+  const btn = renderAddButton(container, 'Add property', () => {
     if (pop?.isOpen) {
       pop.close()
       return

--- a/src/ui/composites/properties/MultiSelectControl.ts
+++ b/src/ui/composites/properties/MultiSelectControl.ts
@@ -2,6 +2,7 @@ import { setIcon } from 'obsidian'
 import { Popover } from '../../primitives/Popover'
 import { Chip } from '../../primitives/Chip'
 import { Avatar } from '../../primitives/Avatar'
+import { IconButton } from '../../primitives/IconButton'
 import { renderOptionRow } from './optionList'
 
 export interface PickerItem {
@@ -103,12 +104,13 @@ export function renderMultiSelect(opts: MultiSelectOpts): void {
       setIcon(row.createSpan({ cls: 'pm-dep-icon' }), 'link-2')
       row.createSpan({ cls: 'pm-dep-id', text: id })
       row.createSpan({ cls: 'pm-dep-title', text: labelOf(id) })
-      const rm = row.createEl('button', { cls: 'pm-chip-rm' })
-      setIcon(rm, 'x')
-      rm.addEventListener('click', () => {
-        opts.remove(id)
-        renderValues()
-      })
+      new IconButton(row)
+        .setIcon('x')
+        .setTooltip('Remove dependency')
+        .onClick(() => {
+          opts.remove(id)
+          renderValues()
+        })
     }
   }
 

--- a/src/ui/composites/timeChip.ts
+++ b/src/ui/composites/timeChip.ts
@@ -1,0 +1,17 @@
+import { Chip } from '../primitives/Chip'
+
+/** Logged/estimate hours chip; goes red solid when logged exceeds the estimate. */
+export function renderTimeChip(
+  parent: HTMLElement,
+  logged: number,
+  estimate: number,
+  size: 'md' | 'sm' = 'md'
+): Chip | null {
+  if (logged <= 0 && estimate <= 0) return null
+  const label = estimate > 0 ? `${logged}/${estimate}h` : `${logged}h`
+  const chip = new Chip(parent).setLabel(label).setSize(size)
+  if (estimate > 0 && logged > estimate) {
+    chip.setVariant('solid').setColor('var(--color-red)').setStrong()
+  }
+  return chip
+}

--- a/src/ui/primitives/ChipButton.ts
+++ b/src/ui/primitives/ChipButton.ts
@@ -1,13 +1,13 @@
 import { ButtonComponent } from 'obsidian'
 
-export class Pill {
+export class ChipButton {
   el: HTMLButtonElement
   private button: ButtonComponent
 
   constructor(parentEl: HTMLElement) {
     this.button = new ButtonComponent(parentEl)
     this.el = this.button.buttonEl
-    this.el.addClass('pm-pill')
+    this.el.addClass('pm-chip-btn')
   }
 
   setLabel(text: string): this {
@@ -16,12 +16,12 @@ export class Pill {
   }
 
   setActive(active: boolean): this {
-    this.el.toggleClass('pm-pill--active', active)
+    this.el.toggleClass('pm-chip-btn--active', active)
     return this
   }
 
   setShape(shape: 'rounded' | 'pill'): this {
-    this.el.toggleClass('pm-pill--pill', shape === 'pill')
+    this.el.toggleClass('pm-chip-btn--pill', shape === 'pill')
     return this
   }
 

--- a/src/ui/primitives/Pill.ts
+++ b/src/ui/primitives/Pill.ts
@@ -1,12 +1,17 @@
+import { ButtonComponent } from 'obsidian'
+
 export class Pill {
   el: HTMLButtonElement
+  private button: ButtonComponent
 
   constructor(parentEl: HTMLElement) {
-    this.el = parentEl.createEl('button', { cls: 'pm-pill' })
+    this.button = new ButtonComponent(parentEl)
+    this.el = this.button.buttonEl
+    this.el.addClass('pm-pill')
   }
 
   setLabel(text: string): this {
-    this.el.setText(text)
+    this.button.setButtonText(text)
     return this
   }
 
@@ -26,7 +31,7 @@ export class Pill {
   }
 
   onClick(handler: (e: MouseEvent) => unknown): this {
-    this.el.addEventListener('click', handler)
+    this.button.onClick(handler)
     return this
   }
 

--- a/src/ui/primitives/SegmentedControl.ts
+++ b/src/ui/primitives/SegmentedControl.ts
@@ -1,7 +1,8 @@
+import { ButtonComponent } from 'obsidian'
+
 export interface SegmentedOption<T extends string> {
   id: T
   label: string
-  cls?: string
 }
 
 export interface SegmentedControlProps<T extends string> {
@@ -15,15 +16,17 @@ export class SegmentedControl<T extends string> {
 
   constructor(parentEl: HTMLElement, props: SegmentedControlProps<T>) {
     this.el = parentEl.createDiv('pm-segmented')
+    const buttons = new Map<T, ButtonComponent>()
     for (const opt of props.options) {
-      const btn = this.el.createEl('button', { cls: 'pm-segmented-btn', text: opt.label })
-      if (opt.cls) btn.addClass(opt.cls)
-      if (opt.id === props.active) btn.addClass('pm-segmented-btn--active')
-      btn.addEventListener('click', () => {
-        this.el.querySelectorAll('.pm-segmented-btn').forEach((b) => b.removeClass('pm-segmented-btn--active'))
-        btn.addClass('pm-segmented-btn--active')
+      const btn = new ButtonComponent(this.el).setButtonText(opt.label).onClick(() => {
+        for (const [id, b] of buttons) {
+          if (id === opt.id) b.setCta()
+          else b.removeCta()
+        }
         props.onChange(opt.id)
       })
+      if (opt.id === props.active) btn.setCta()
+      buttons.set(opt.id, btn)
     }
   }
 }

--- a/src/views/gantt/GanttView.ts
+++ b/src/views/gantt/GanttView.ts
@@ -4,6 +4,7 @@ import type { Project, Task, GanttGranularity, FilterState } from '../../types'
 import { type FlatTask, flattenTasks } from '../../store/TaskTreeOps'
 import { applyTaskFilterPromote } from '../../store/TaskFilter'
 import { openTaskModal } from '../../ui/ModalFactory'
+import { renderAddButton } from '../../ui/composites/addButton'
 import type { SubView } from '../SubView'
 import type { TimelineCfg } from './TimelineConfig'
 import { buildTimelineConfig, dateToX, xToDate, HEADER_HEIGHT, ROW_HEIGHT, LABEL_WIDTH } from './TimelineConfig'
@@ -236,8 +237,7 @@ export class GanttView implements SubView {
     // Add task button
     const addRow = leftBody.createDiv('pm-gantt-label-row pm-gantt-add-row')
     addRow.style.height = `${ROW_HEIGHT}px`
-    const addBtn = addRow.createEl('button', { text: '+ add task', cls: 'pm-gantt-add-task-btn' })
-    addBtn.addEventListener('click', () => {
+    renderAddButton(addRow, 'Add task', () => {
       openTaskModal(this.plugin, this.project, { onSave: () => this.onRefresh() })
     })
 

--- a/src/views/gantt/GanttView.ts
+++ b/src/views/gantt/GanttView.ts
@@ -5,6 +5,7 @@ import { type FlatTask, flattenTasks } from '../../store/TaskTreeOps'
 import { applyTaskFilterPromote } from '../../store/TaskFilter'
 import { openTaskModal } from '../../ui/ModalFactory'
 import { renderAddButton } from '../../ui/composites/addButton'
+import { SegmentedControl } from '../../ui/primitives/SegmentedControl'
 import type { SubView } from '../SubView'
 import type { TimelineCfg } from './TimelineConfig'
 import { buildTimelineConfig, dateToX, xToDate, HEADER_HEIGHT, ROW_HEIGHT, LABEL_WIDTH } from './TimelineConfig'
@@ -95,16 +96,16 @@ export class GanttView implements SubView {
     const levels: GanttGranularity[] = ['day', 'week', 'month', 'quarter']
     const labels: Record<GanttGranularity, string> = { day: 'Day', week: 'Week', month: 'Month', quarter: 'Quarter' }
 
-    for (const level of levels) {
-      const btn = bar.createEl('button', { text: labels[level], cls: 'pm-gantt-zoom-btn' })
-      if (level === this.granularity) btn.addClass('pm-gantt-zoom-btn--active')
-      btn.addEventListener('click', () => {
+    new SegmentedControl<GanttGranularity>(bar, {
+      options: levels.map((level) => ({ id: level, label: labels[level] })),
+      active: this.granularity,
+      onChange: (level) => {
         this.granularity = level
         this.plugin.settings.ganttGranularity = level
         void this.plugin.saveSettings()
         this.render()
-      })
-    }
+      }
+    })
 
     bar.createSpan({ cls: 'pm-gantt-sep' })
     new ButtonComponent(bar).setButtonText('Today').onClick(() => this.scrollToToday())

--- a/src/views/gantt/TaskLabelRenderer.ts
+++ b/src/views/gantt/TaskLabelRenderer.ts
@@ -1,8 +1,10 @@
 import type PMPlugin from '../../main'
 import type { Project, StatusConfig, Task } from '../../types'
 import { CollapseToggle } from '../../ui/primitives/CollapseToggle'
+import { IconButton } from '../../ui/primitives/IconButton'
 import { openTaskModal } from '../../ui/ModalFactory'
-import { getStatusConfig, safeAsync } from '../../utils'
+import { renderStatusDot } from '../../ui/StatusBadge'
+import { safeAsync } from '../../utils'
 import { ROW_HEIGHT } from './TimelineConfig'
 
 export interface LabelContext {
@@ -71,9 +73,7 @@ export function renderTaskLabel(
   }
 
   // Color dot
-  const statusConfig = getStatusConfig(ctx.statuses, task.status)
-  const dot = el.createSpan({ cls: 'pm-gantt-label-dot' })
-  dot.style.background = statusConfig?.color ?? 'var(--text-muted)'
+  renderStatusDot(el, task.status, ctx.statuses, 'pm-gantt-label-dot')
 
   // Title
   const titleEl = el.createSpan({ text: task.title, cls: 'pm-gantt-label-title' })
@@ -87,10 +87,12 @@ export function renderTaskLabel(
   }
 
   // "+" button to add subtask (hover-visible)
-  const addSubBtn = el.createEl('button', { text: '+', cls: 'pm-gantt-label-add-btn' })
-  addSubBtn.title = 'Add subtask'
-  addSubBtn.addEventListener('click', (e) => {
-    e.stopPropagation()
-    openTaskModal(ctx.plugin, ctx.project, { parentId: task.id, onSave: () => ctx.onRefresh() })
-  })
+  new IconButton(el)
+    .setIcon('plus')
+    .setTooltip('Add subtask')
+    .setRevealOnHover(true)
+    .onClick((e) => {
+      e.stopPropagation()
+      openTaskModal(ctx.plugin, ctx.project, { parentId: task.id, onSave: () => ctx.onRefresh() })
+    })
 }

--- a/src/views/styleguide/StyleguideView.ts
+++ b/src/views/styleguide/StyleguideView.ts
@@ -27,7 +27,7 @@ import { Chip } from '../../ui/primitives/Chip'
 import { CollapseToggle } from '../../ui/primitives/CollapseToggle'
 import { EmptyState } from '../../ui/primitives/EmptyState'
 import { IconButton } from '../../ui/primitives/IconButton'
-import { Pill } from '../../ui/primitives/Pill'
+import { ChipButton } from '../../ui/primitives/ChipButton'
 import { Popover } from '../../ui/primitives/Popover'
 import { ProgressBar } from '../../ui/primitives/ProgressBar'
 import { SegmentedControl } from '../../ui/primitives/SegmentedControl'
@@ -71,7 +71,7 @@ export class StyleguideView extends ItemView {
     root.addClass('pm-root', 'pm-styleguide')
     this.group('Primitives')
     this.renderChips()
-    this.renderPills()
+    this.renderChipButtons()
     this.renderAvatars()
     this.renderIconButtons()
     this.renderProgress()
@@ -123,12 +123,12 @@ export class StyleguideView extends ItemView {
     new Chip(mods).setLabel('interactive').setVariant('outline').onClick(noop)
   }
 
-  private renderPills(): void {
-    const sec = this.section('Pill', 'pill')
+  private renderChipButtons(): void {
+    const sec = this.section('ChipButton', 'chip-button')
     const row = this.row(sec, 'default / active / pill shape')
-    new Pill(row).setLabel('Saved view')
-    new Pill(row).setLabel('Active view').setActive(true)
-    new Pill(row).setLabel('Due: 3').setShape('pill').setActive(true)
+    new ChipButton(row).setLabel('Saved view')
+    new ChipButton(row).setLabel('Active view').setActive(true)
+    new ChipButton(row).setLabel('Due: 3').setShape('pill').setActive(true)
     const filterRow = this.row(sec, 'renderFilterDropdown')
     renderFilterDropdown(
       filterRow,

--- a/src/views/styleguide/StyleguideView.ts
+++ b/src/views/styleguide/StyleguideView.ts
@@ -1,0 +1,396 @@
+import { ButtonComponent, ItemView, WorkspaceLeaf } from 'obsidian'
+import type PMPlugin from '../../main'
+import type { Task } from '../../types'
+import { DEFAULT_PRIORITIES, DEFAULT_STATUSES, makeTask } from '../../types'
+import { renderTagChip } from '../../ui/composites/tagChip'
+import { ActionsCell } from '../../ui/composites/cells/ActionsCell'
+import { AssigneesCell } from '../../ui/composites/cells/AssigneesCell'
+import { DueDateCell } from '../../ui/composites/cells/DueDateCell'
+import { ExpandCell } from '../../ui/composites/cells/ExpandCell'
+import { PriorityCell } from '../../ui/composites/cells/PriorityCell'
+import { ProgressCell } from '../../ui/composites/cells/ProgressCell'
+import { SelectCell } from '../../ui/composites/cells/SelectCell'
+import { StatusCell } from '../../ui/composites/cells/StatusCell'
+import { TimeCell } from '../../ui/composites/cells/TimeCell'
+import { KanbanCard } from '../../ui/composites/KanbanCard'
+import { ProjectCard } from '../../ui/composites/ProjectCard'
+import { TaskRow } from '../../ui/composites/TaskRow'
+import { renderAddProperty } from '../../ui/composites/properties'
+import { renderChipList, renderPropRow } from '../../ui/FormField'
+import { renderFilterDropdown } from '../../ui/FilterDropdown'
+import { Avatar } from '../../ui/primitives/Avatar'
+import { AvatarStack } from '../../ui/primitives/AvatarStack'
+import { Chip } from '../../ui/primitives/Chip'
+import { CollapseToggle } from '../../ui/primitives/CollapseToggle'
+import { EmptyState } from '../../ui/primitives/EmptyState'
+import { IconButton } from '../../ui/primitives/IconButton'
+import { Pill } from '../../ui/primitives/Pill'
+import { Popover } from '../../ui/primitives/Popover'
+import { ProgressBar } from '../../ui/primitives/ProgressBar'
+import { SegmentedControl } from '../../ui/primitives/SegmentedControl'
+import { ViewSwitcher } from '../../ui/primitives/ViewSwitcher'
+import { renderPriorityBadge, renderStatusBadge, renderStatusDot } from '../../ui/StatusBadge'
+import { safeAsync } from '../../utils'
+
+export const PM_STYLEGUIDE_VIEW_TYPE = 'pm-styleguide'
+
+const noop = (): void => undefined
+const noopAsync = (): Promise<void> => Promise.resolve()
+const PEOPLE = ['Ada Lovelace', 'Grace Hopper', 'Alan Turing', 'Margaret Hamilton', 'Edsger Dijkstra']
+const WIKILINK_PERSON = '[[People/Alan Turing|Alan]]'
+
+/**
+ * Dev-only gallery of every primitive and key composite in all their variants,
+ * rendered in a real Obsidian pane so the CSS cascade (app.css included) is the
+ * one users actually get. Only compiled in when `__STYLEGUIDE__` is true.
+ * Catalog: docs/styleguide.md. Mock data only, no store or vault access.
+ */
+export class StyleguideView extends ItemView {
+  constructor(leaf: WorkspaceLeaf) {
+    super(leaf)
+    this.navigation = false
+  }
+
+  getViewType(): string {
+    return PM_STYLEGUIDE_VIEW_TYPE
+  }
+  getDisplayText(): string {
+    return 'Styleguide'
+  }
+  getIcon(): string {
+    return 'palette'
+  }
+
+  onOpen(): Promise<void> {
+    this.containerEl.addClass('pm-view')
+    const root = this.contentEl
+    root.empty()
+    root.addClass('pm-root', 'pm-styleguide')
+    this.group('Primitives')
+    this.renderChips()
+    this.renderPills()
+    this.renderAvatars()
+    this.renderIconButtons()
+    this.renderProgress()
+    this.renderCollapse()
+    this.renderEmptyState()
+    this.renderSegmented()
+    this.renderViewSwitcher()
+    this.renderPopover()
+    this.group('Shared widgets')
+    this.renderBadges()
+    this.renderForm()
+    this.group('Composites')
+    this.renderCards()
+    this.renderTable()
+    return Promise.resolve()
+  }
+
+  private group(title: string): void {
+    this.contentEl.createDiv({ cls: 'pm-sg-group', text: title })
+  }
+
+  private section(title: string, id: string): HTMLElement {
+    const sec = this.contentEl.createDiv({ cls: 'pm-sg-section', attr: { 'data-sg': id } })
+    sec.createDiv({ cls: 'pm-sg-title', text: title })
+    return sec
+  }
+
+  private row(sec: HTMLElement, caption: string): HTMLElement {
+    sec.createDiv({ cls: 'pm-sg-caption', text: caption })
+    return sec.createDiv('pm-sg-row')
+  }
+
+  private renderChips(): void {
+    const sec = this.section('Chip', 'chip')
+    for (const variant of ['solid', 'outline', 'plain'] as const) {
+      const row = this.row(sec, variant)
+      for (const status of DEFAULT_STATUSES) {
+        new Chip(row).setLabel(status.label).setVariant(variant).setColor(status.color).setDot()
+      }
+    }
+    const mods = this.row(sec, 'modifiers')
+    new Chip(mods).setLabel('leading icon').setVariant('outline').setLeadingIcon('calendar')
+    new Chip(mods).setLabel('tag').setVariant('outline').setTag()
+    new Chip(mods).setLabel('strong').setVariant('solid').setColor('var(--color-red)').setStrong()
+    new Chip(mods).setLabel('pill shape').setVariant('outline').setShape('pill')
+    new Chip(mods).setLabel('small').setVariant('solid').setColor('var(--interactive-accent)').setSize('sm')
+    new Chip(mods).setLabel('removable').setVariant('outline').setRemovable(noop)
+    new Chip(mods).setLabel('interactive').setVariant('outline').onClick(noop)
+  }
+
+  private renderPills(): void {
+    const sec = this.section('Pill', 'pill')
+    const row = this.row(sec, 'default / active / pill shape')
+    new Pill(row).setLabel('Saved view')
+    new Pill(row).setLabel('Active view').setActive(true)
+    new Pill(row).setLabel('Due: 3').setShape('pill').setActive(true)
+    const filterRow = this.row(sec, 'renderFilterDropdown')
+    renderFilterDropdown(
+      filterRow,
+      'Status',
+      ['todo'],
+      DEFAULT_STATUSES.map((s) => ({ id: s.id, label: s.label })),
+      noop
+    )
+  }
+
+  private renderAvatars(): void {
+    const sec = this.section('Avatar', 'avatar')
+    const row = this.row(sec, 'md / sm / wikilink alias')
+    new Avatar(row).setName(PEOPLE[0])
+    new Avatar(row).setName(PEOPLE[1]).setSize('sm')
+    new Avatar(row).setName(WIKILINK_PERSON)
+    const stack = this.row(sec, 'AvatarStack with overflow (max 3)')
+    new AvatarStack(stack).setNames(PEOPLE)
+  }
+
+  private renderIconButtons(): void {
+    const sec = this.section('IconButton', 'icon-button')
+    const row = this.row(sec, 'plain / reveal on hover (hover this row)')
+    new IconButton(row).setIcon('pencil').setTooltip('Edit').onClick(noop)
+    new IconButton(row).setIcon('trash-2').setTooltip('Delete').onClick(noop)
+    new IconButton(row).setIcon('more-horizontal').setTooltip('Hidden until hover').setRevealOnHover(true).onClick(noop)
+  }
+
+  private renderProgress(): void {
+    const sec = this.section('ProgressBar', 'progress')
+    const row = this.row(sec, '0 / 50 / 100, sm, label, color')
+    new ProgressBar(row).setValue(0)
+    new ProgressBar(row).setValue(50)
+    new ProgressBar(row).setValue(100)
+    new ProgressBar(row).setValue(50).setSize('sm')
+    new ProgressBar(row).setValue(75).setShowLabel(true)
+    new ProgressBar(row).setValue(60).setColor('var(--color-green)')
+  }
+
+  private renderCollapse(): void {
+    const sec = this.section('CollapseToggle', 'collapse')
+    const row = this.row(sec, 'expanded / collapsed')
+    new CollapseToggle(row, { collapsed: false, onToggle: noop })
+    new CollapseToggle(row, { collapsed: true, onToggle: noop })
+  }
+
+  private renderEmptyState(): void {
+    const sec = this.section('EmptyState', 'empty-state')
+    const row = this.row(sec, 'icon, title, body, action')
+    new EmptyState(row)
+      .setIcon('📋')
+      .setTitle('No projects yet')
+      .setBody('Create your first project to get started.')
+      .setAction('+ new project', noop)
+  }
+
+  private renderSegmented(): void {
+    const sec = this.section('SegmentedControl', 'segmented')
+    const row = this.row(sec, 'text options')
+    new SegmentedControl(row, {
+      options: [
+        { id: 'task', label: 'Task' },
+        { id: 'subtask', label: 'Subtask' },
+        { id: 'milestone', label: 'Milestone' }
+      ],
+      active: 'task',
+      onChange: noop
+    })
+  }
+
+  private renderViewSwitcher(): void {
+    const sec = this.section('ViewSwitcher', 'view-switcher')
+    const row = this.row(sec, 'icon options')
+    new ViewSwitcher(row, {
+      options: [
+        { id: 'table', icon: 'table', label: 'Table' },
+        { id: 'gantt', icon: 'chart-gantt', label: 'Gantt' },
+        { id: 'kanban', icon: 'kanban', label: 'Kanban' }
+      ],
+      active: 'table',
+      onChange: noop
+    })
+  }
+
+  private renderPopover(): void {
+    const sec = this.section('Popover', 'popover')
+    const row = this.row(sec, 'anchored panel (bottom sheet on phones)')
+    let pop: Popover | null = null
+    const btn = new ButtonComponent(row).setButtonText('Open popover')
+    btn.onClick(() => {
+      if (pop?.isOpen) {
+        pop.close()
+        return
+      }
+      pop = new Popover({ anchor: btn.buttonEl, width: 220, onClose: () => (pop = null) })
+      pop.contentEl.createDiv({ text: 'Popover content: anything Menu cannot host.' })
+      const search = pop.contentEl.createEl('input', { type: 'text' })
+      search.placeholder = 'A focusable input'
+      pop.open()
+    })
+  }
+
+  private renderBadges(): void {
+    const sec = this.section('Status and priority', 'badges')
+    const statusRow = this.row(sec, 'renderStatusBadge (opens a picker menu)')
+    for (const status of DEFAULT_STATUSES) {
+      renderStatusBadge(statusRow, makeTask({ status: status.id }), DEFAULT_STATUSES, noop)
+    }
+    const prioRow = this.row(sec, 'renderPriorityBadge')
+    for (const priority of DEFAULT_PRIORITIES) {
+      renderPriorityBadge(prioRow, makeTask({ priority: priority.id }), DEFAULT_PRIORITIES, noop)
+    }
+    const dotRow = this.row(sec, 'renderStatusDot')
+    for (const status of DEFAULT_STATUSES) {
+      renderStatusDot(dotRow, status.id, DEFAULT_STATUSES)
+    }
+    const tagRow = this.row(sec, 'renderTagChip (plain / colored)')
+    renderTagChip(tagRow, 'design', false)
+    renderTagChip(tagRow, 'design', true)
+    renderTagChip(tagRow, 'backend', true)
+  }
+
+  private renderForm(): void {
+    const sec = this.section('Form patterns', 'form')
+    const propRow = this.row(sec, 'renderPropRow')
+    renderPropRow(
+      propRow,
+      'Due date',
+      () => {
+        const value = createDiv()
+        new Chip(value).setLabel('Jul 20, 2026').setVariant('outline')
+        return value
+      },
+      'calendar'
+    )
+    const chipListRow = this.row(sec, 'renderChipList')
+    renderChipList(chipListRow, ['design', 'frontend'], { onRemove: noop, onAdd: noop })
+    const addRow = this.row(sec, 'renderAddProperty (the canonical add button)')
+    renderAddProperty(addRow, [{ id: 'due', label: 'Due date', icon: 'calendar' }], noop)
+  }
+
+  private renderCards(): void {
+    const sec = this.section('Cards', 'cards')
+    const projectRow = this.row(sec, 'ProjectCard')
+    new ProjectCard(projectRow, {
+      title: 'Website relaunch',
+      icon: '📋',
+      color: '#8b72be',
+      tasksDone: 4,
+      tasksTotal: 10,
+      onClick: noop,
+      onContextMenu: noop
+    })
+    const kanbanRow = this.row(sec, 'KanbanCard: plain / overdue milestone with everything')
+    new KanbanCard(kanbanRow, {
+      task: makeTask({ title: 'Write the launch announcement' }),
+      loggedHours: 0,
+      overdue: false,
+      showTagColors: true,
+      onClick: noop,
+      onContextMenu: noop,
+      onDragStart: noop,
+      onDragEnd: noop
+    })
+    new KanbanCard(kanbanRow, {
+      task: makeTask({
+        title: 'Ship the redesign',
+        type: 'milestone',
+        priority: 'critical',
+        due: '2026-06-20',
+        assignees: ['Ada Lovelace', 'Grace Hopper'],
+        tags: ['design', 'frontend']
+      }),
+      priorityColor: '#c47070',
+      descriptionPreview: 'Everything that must land before the announcement goes out.',
+      parentTitle: 'Website relaunch',
+      subtaskProgress: { done: 2, total: 5 },
+      loggedHours: 11,
+      overdue: true,
+      showTagColors: true,
+      onClick: noop,
+      onContextMenu: noop,
+      onDragStart: noop,
+      onDragEnd: noop
+    })
+  }
+
+  private renderTable(): void {
+    const sec = this.section('Table row and cells', 'table')
+    sec.createDiv({ cls: 'pm-sg-caption', text: 'TaskRow + one of each cell composite' })
+    const table = sec.createEl('table', { cls: 'pm-table' })
+    const tbody = table.createEl('tbody')
+    const rows: {
+      task: Task
+      props: { depth: number; isDone: boolean; isSelected: boolean }
+      urgency: 'normal' | 'near' | 'overdue'
+      time: { logged: number; estimate: number }
+    }[] = [
+      {
+        task: makeTask({
+          title: 'Design the settings screen',
+          status: 'in-progress',
+          priority: 'high',
+          due: '2026-07-20',
+          progress: 60,
+          assignees: ['Ada Lovelace', 'Grace Hopper'],
+          subtasks: [makeTask({ title: 'Pick a layout' })]
+        }),
+        props: { depth: 0, isDone: false, isSelected: false },
+        urgency: 'normal',
+        time: { logged: 5, estimate: 10 }
+      },
+      {
+        task: makeTask({
+          title: 'Fix the overdue banner',
+          status: 'blocked',
+          priority: 'critical',
+          due: '2026-06-20',
+          progress: 20,
+          assignees: ['Alan Turing']
+        }),
+        props: { depth: 1, isDone: false, isSelected: true },
+        urgency: 'overdue',
+        time: { logged: 6, estimate: 4 }
+      },
+      {
+        task: makeTask({ title: 'Archive old sprints', status: 'done', progress: 100 }),
+        props: { depth: 0, isDone: true, isSelected: false },
+        urgency: 'normal',
+        time: { logged: 0, estimate: 0 }
+      }
+    ]
+    for (const { task, props, urgency, time } of rows) {
+      const tr = new TaskRow(tbody, {
+        taskId: task.id,
+        depth: props.depth,
+        isDone: props.isDone,
+        isArchived: false,
+        isSelected: props.isSelected,
+        onRowClick: noop
+      })
+      new ExpandCell(tr.el, { hasSubtasks: task.subtasks.length > 0, collapsed: false, onToggle: noop })
+      new SelectCell(tr.el, { checked: props.isSelected, onClick: noop })
+      tr.el.createEl('td', { cls: 'pm-table-cell-title', text: task.title })
+      new StatusCell(tr.el, { task, statuses: DEFAULT_STATUSES, onChange: noop })
+      new PriorityCell(tr.el, { task, priorities: DEFAULT_PRIORITIES, onChange: noop })
+      new DueDateCell(tr.el, { task, urgency, onSave: noopAsync })
+      new TimeCell(tr.el, time)
+      new ProgressCell(tr.el, { value: task.progress, color: 'var(--interactive-accent)' })
+      new AssigneesCell(tr.el, task.assignees)
+      new ActionsCell(tr.el, { onClick: noop })
+    }
+  }
+}
+
+export function registerStyleguide(plugin: PMPlugin): void {
+  plugin.registerView(PM_STYLEGUIDE_VIEW_TYPE, (leaf) => new StyleguideView(leaf))
+  plugin.addCommand({
+    id: 'open-styleguide',
+    name: 'Open styleguide gallery',
+    callback: safeAsync(async () => {
+      // Opened directly rather than via plugin.router so no styleguide code
+      // ends up in prod builds.
+      const leaf = plugin.app.workspace.getLeaf('tab')
+      await leaf.setViewState({ type: PM_STYLEGUIDE_VIEW_TYPE, state: {} })
+      await plugin.app.workspace.revealLeaf(leaf)
+    })
+  })
+}

--- a/src/views/styleguide/StyleguideView.ts
+++ b/src/views/styleguide/StyleguideView.ts
@@ -17,6 +17,7 @@ import { TimeCell } from '../../ui/composites/cells/TimeCell'
 import { KanbanCard } from '../../ui/composites/KanbanCard'
 import { ProjectCard } from '../../ui/composites/ProjectCard'
 import { TaskRow } from '../../ui/composites/TaskRow'
+import { renderAddButton } from '../../ui/composites/addButton'
 import { renderAddProperty } from '../../ui/composites/properties'
 import { renderChipList, renderPropRow } from '../../ui/FormField'
 import { renderFilterDropdown } from '../../ui/FilterDropdown'
@@ -265,7 +266,8 @@ export class StyleguideView extends ItemView {
     )
     const chipListRow = this.row(sec, 'renderChipList')
     renderChipList(chipListRow, ['design', 'frontend'], { onRemove: noop, onAdd: noop })
-    const addRow = this.row(sec, 'renderAddProperty (the canonical add button)')
+    const addRow = this.row(sec, 'renderAddButton / renderAddProperty')
+    renderAddButton(addRow, 'Add member', noop)
     renderAddProperty(addRow, [{ id: 'due', label: 'Due date', icon: 'calendar' }], noop)
   }
 

--- a/src/views/styleguide/StyleguideView.ts
+++ b/src/views/styleguide/StyleguideView.ts
@@ -2,7 +2,9 @@ import { ButtonComponent, ItemView, WorkspaceLeaf } from 'obsidian'
 import type PMPlugin from '../../main'
 import type { Task } from '../../types'
 import { DEFAULT_PRIORITIES, DEFAULT_STATUSES, makeTask } from '../../types'
+import { renderDueChip } from '../../ui/composites/dueChip'
 import { renderTagChip } from '../../ui/composites/tagChip'
+import { renderTimeChip } from '../../ui/composites/timeChip'
 import { ActionsCell } from '../../ui/composites/cells/ActionsCell'
 import { AssigneesCell } from '../../ui/composites/cells/AssigneesCell'
 import { DueDateCell } from '../../ui/composites/cells/DueDateCell'
@@ -81,6 +83,7 @@ export class StyleguideView extends ItemView {
     this.renderBadges()
     this.renderForm()
     this.group('Composites')
+    this.renderDerivedChips()
     this.renderCards()
     this.renderTable()
     return Promise.resolve()
@@ -264,6 +267,18 @@ export class StyleguideView extends ItemView {
     renderChipList(chipListRow, ['design', 'frontend'], { onRemove: noop, onAdd: noop })
     const addRow = this.row(sec, 'renderAddProperty (the canonical add button)')
     renderAddProperty(addRow, [{ id: 'due', label: 'Due date', icon: 'calendar' }], noop)
+  }
+
+  private renderDerivedChips(): void {
+    const sec = this.section('Time and due chips', 'time-due')
+    const timeRow = this.row(sec, 'renderTimeChip: logged only / within estimate / over estimate')
+    renderTimeChip(timeRow, 3, 0)
+    renderTimeChip(timeRow, 5, 10)
+    renderTimeChip(timeRow, 6, 4)
+    const dueRow = this.row(sec, 'renderDueChip: normal / near / overdue')
+    renderDueChip(dueRow, 'Jul 20, 2026', 'normal')
+    renderDueChip(dueRow, 'Jul 6, 2026', 'near')
+    renderDueChip(dueRow, 'Jun 20, 2026', 'overdue')
   }
 
   private renderCards(): void {

--- a/src/views/table/TableRenderer.ts
+++ b/src/views/table/TableRenderer.ts
@@ -4,6 +4,7 @@ import { type FlatTask, flattenTasks } from '../../store/TaskTreeOps'
 import { findTaskById } from '../../store/TaskIndex'
 import { applyTaskFilterFlat, isFilterActive } from '../../store/TaskFilter'
 import { openTaskModal } from '../../ui/ModalFactory'
+import { renderAddButton } from '../../ui/composites/addButton'
 import { compareTask } from './TableFilters'
 import { renderTaskRow, updateSelectedRow, updateSelectAllCheckbox } from './TableRow'
 
@@ -242,8 +243,7 @@ function renderWindowRows(ctx: TableContext): void {
   // "Add task" row
   const addRow = tbody.createEl('tr', { cls: 'pm-table-add-row' })
   const addCell = addRow.createEl('td', { attr: { colspan: String(colCount) } })
-  const addBtn = addCell.createEl('button', { text: '+ add task', cls: 'pm-table-add-btn' })
-  addBtn.addEventListener('click', () => {
+  renderAddButton(addCell, 'Add task', () => {
     openTaskModal(ctx.plugin, ctx.project, { onSave: () => ctx.onRefresh() })
   })
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
   clean: false,
   hash: false,
   outExtensions: () => ({ js: '.js' }),
+  define: {
+    __STYLEGUIDE__: JSON.stringify(!prod || Boolean(process.env['STYLEGUIDE']))
+  },
   deps: {
     neverBundle: [
       'obsidian',


### PR DESCRIPTION
Every feature pass kept spawning new variants of the same UI bits, so this adds a styleguide and cleans up the drift we already had.

docs/styleguide.md is the component catalog (per-component API, decision tree, usage rules). There's also a dev-only gallery view that renders every primitive and composite in all variants inside Obsidian; it's compiled out of prod builds (STYLEGUIDE=1 to keep it).

Cleanup that came out of it: deleted orphaned CSS, extracted shared time/due chips, replaced all hand-rolled remove/add/import/zoom buttons with IconButton, one shared add button, or native ButtonComponents, merged chip/pill styles onto one capsule base, retired the --pm-* alias layer in favor of Obsidian theme vars, and reworked filter pills as compact native buttons (Pill is now ChipButton). Bundled CSS is ~2.5 KB smaller.