### PR TITLE
Feat: Add subtle Motion animations for board interactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": "10.4.1",
     "eslint-plugin-obsidianmd": "0.3.0",
     "lightningcss": "^1.32.0",
+    "motion": "^12.42.2",
     "npm-run-all2": "9.0.1",
     "obsidian": "1.12.3",
     "oxfmt": "0.54.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       lightningcss:
         specifier: ^1.32.0
         version: 1.32.0
+      motion:
+        specifier: ^12.42.2
+        version: 12.42.2
       npm-run-all2:
         specifier: 9.0.1
         version: 9.0.1
@@ -1297,6 +1300,20 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  framer-motion@12.42.2:
+    resolution: {integrity: sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1712,6 +1729,26 @@ packages:
 
   moment@2.29.4:
     resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
+
+  motion-dom@12.42.2:
+    resolution: {integrity: sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
+  motion@12.42.2:
+    resolution: {integrity: sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3645,6 +3682,12 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  framer-motion@12.42.2:
+    dependencies:
+      motion-dom: 12.42.2
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+
   fsevents@2.3.3:
     optional: true
 
@@ -4038,6 +4081,17 @@ snapshots:
   module-replacements@2.11.0: {}
 
   moment@2.29.4: {}
+
+  motion-dom@12.42.2:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
+
+  motion@12.42.2:
+    dependencies:
+      framer-motion: 12.42.2
+      tslib: 2.8.1
 
   ms@2.1.3: {}
 

--- a/src/modals/ProjectModal.ts
+++ b/src/modals/ProjectModal.ts
@@ -5,6 +5,7 @@ import { rebuildTaskIndex } from '../store'
 import { safeAsync } from '../utils'
 import { Avatar } from '../ui/primitives/Avatar'
 import { renderPriorityListEditor, renderStatusListEditor } from '../ui/PaletteListEditor'
+import { animateModalIn } from '../ui/motion'
 
 const PROJECT_COLORS = [
   '#8b72be',
@@ -53,6 +54,7 @@ export class ProjectModal extends Modal {
 
   onOpen(): void {
     this.modalEl.addClass('pm-modal', 'pm-modal--project')
+    animateModalIn(this.modalEl)
     const el = this.contentEl
     el.empty()
     el.addClass('pm-project-modal')

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -20,6 +20,7 @@ import { renderTaskFormFields } from './TaskFormFields'
 import { renderTimeTrackingPanel } from './TimeTrackingPanel'
 import { renderSubtasksPanel } from './SubtasksPanel'
 import { NoteLinkSuggest } from './NoteLinkSuggest'
+import { animateModalIn } from '../ui/motion'
 
 export class TaskModal extends Modal {
   private task: Task
@@ -69,6 +70,7 @@ export class TaskModal extends Modal {
     contentEl.empty()
     contentEl.addClass('pm-task-modal')
     this.modalEl.addClass('pm-modal', 'pm-modal--task')
+    animateModalIn(this.modalEl)
     this.render()
   }
 

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -210,7 +210,10 @@ button.pm-prop-add-btn {
   overflow: hidden;
   cursor: pointer;
   background: var(--pm-surface-raised);
-  transition: all 0.2s;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s,
+    background 0.2s;
   position: relative;
 }
 .pm-project-card:hover {

--- a/src/styles/kanban.css
+++ b/src/styles/kanban.css
@@ -81,10 +81,14 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  transition: background 0.15s;
+  border-radius: var(--pm-radius);
+  transition:
+    background 0.14s ease,
+    box-shadow 0.14s ease;
 }
 .pm-kanban-drop-target {
   background: var(--pm-accent-light);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--pm-accent) 62%, transparent);
 }
 
 .pm-kanban-card {
@@ -97,7 +101,10 @@
   border-radius: var(--pm-radius);
   overflow: hidden;
   cursor: pointer;
-  transition: all 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s,
+    background 0.15s;
   position: relative;
 }
 .pm-kanban-card:hover {
@@ -108,6 +115,9 @@
   box-shadow: 0 4px 16px var(--pm-shadow-ambient);
   border-color: var(--pm-accent);
   z-index: 100;
+}
+.pm-kanban-board--dragging .pm-kanban-card {
+  will-change: transform;
 }
 
 .pm-kanban-card-priority-bar {

--- a/src/ui/composites/KanbanCard.ts
+++ b/src/ui/composites/KanbanCard.ts
@@ -3,6 +3,7 @@ import { formatDateShort } from '../../utils'
 import { AvatarStack } from '../primitives/AvatarStack'
 import { Chip } from '../primitives/Chip'
 import { ProgressBar } from '../primitives/ProgressBar'
+import { animateDragEnd, animateDragStart, bindLiftMotion, setKanbanDragActive } from '../motion'
 import { renderTagChip } from './tagChip'
 
 export interface KanbanCardProps {
@@ -29,6 +30,7 @@ export class KanbanCard {
     card.draggable = true
     card.dataset.taskId = task.id
     this.el = card
+    bindLiftMotion(card, { disabledDuringKanbanDrag: true })
 
     if (props.priorityColor) {
       const priorityBar = card.createDiv('pm-kanban-card-priority-bar')
@@ -112,14 +114,23 @@ export class KanbanCard {
 
     card.addEventListener('dragstart', (e) => {
       e.dataTransfer?.setData('text/plain', task.id)
+      if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move'
       card.addClass('pm-kanban-card--dragging')
+      card.closest('.pm-kanban-board')?.addClass('pm-kanban-board--dragging')
       window.setTimeout(() => card.addClass('pm-dragging'), 0)
+      setKanbanDragActive(true)
+      animateDragStart(card)
       props.onDragStart()
     })
 
     card.addEventListener('dragend', () => {
       card.removeClass('pm-kanban-card--dragging')
       card.removeClass('pm-dragging')
+      activeDocument
+        .querySelectorAll('.pm-kanban-board--dragging')
+        .forEach((board) => board.removeClass('pm-kanban-board--dragging'))
+      setKanbanDragActive(false)
+      animateDragEnd(card)
       props.onDragEnd()
     })
 

--- a/src/ui/composites/KanbanColumn.ts
+++ b/src/ui/composites/KanbanColumn.ts
@@ -1,7 +1,21 @@
 import { setIcon } from 'obsidian'
 import type { Task } from '../../types'
 import { formatBadgeText, isIconName, safeAsync } from '../../utils'
+import { animateCardReorder, snapshotCardRects } from '../motion'
 import { KanbanCard } from './KanbanCard'
+
+let activeDropTarget: HTMLElement | null = null
+
+function setActiveDropTarget(next: HTMLElement | null): void {
+  if (activeDropTarget === next) return
+  if (activeDropTarget) {
+    activeDropTarget.removeClass('pm-kanban-drop-target')
+  }
+  activeDropTarget = next
+  if (activeDropTarget) {
+    activeDropTarget.addClass('pm-kanban-drop-target')
+  }
+}
 
 export interface KanbanColumnStatus {
   id: string
@@ -77,33 +91,39 @@ export class KanbanColumn {
         onClick: () => props.onCardClick(card.task),
         onContextMenu: (e) => props.onCardContextMenu(card.task, e),
         onDragStart: () => props.onCardDragStart(card.task),
-        onDragEnd: () => props.onCardDragEnd()
+        onDragEnd: () => {
+          setActiveDropTarget(null)
+          props.onCardDragEnd()
+        }
       })
     }
 
     cardsEl.addEventListener('dragover', (e) => {
       e.preventDefault()
-      cardsEl.addClass('pm-kanban-drop-target')
+      setActiveDropTarget(cardsEl)
       const afterEl = getDragAfterElement(cardsEl, e.clientY)
       const dragging = cardsEl.querySelector('.pm-kanban-card--dragging')
       if (dragging) {
+        if ((afterEl && dragging.nextSibling === afterEl) || (!afterEl && dragging === cardsEl.lastElementChild)) {
+          return
+        }
+        const before = snapshotCardRects(cardsEl)
         if (afterEl) {
           cardsEl.insertBefore(dragging, afterEl)
         } else {
           cardsEl.appendChild(dragging)
         }
+        animateCardReorder(cardsEl, before)
       }
     })
 
-    cardsEl.addEventListener('dragleave', () => {
-      cardsEl.removeClass('pm-kanban-drop-target')
-    })
+    cardsEl.addEventListener('dragend', () => setActiveDropTarget(null))
 
     cardsEl.addEventListener(
       'drop',
       safeAsync(async (e: DragEvent) => {
         e.preventDefault()
-        cardsEl.removeClass('pm-kanban-drop-target')
+        setActiveDropTarget(null)
         const taskId = e.dataTransfer?.getData('text/plain') ?? ''
         if (!taskId) return
         await props.onDrop(taskId, props.status.id)
@@ -119,7 +139,8 @@ function getDragAfterElement(container: HTMLElement, y: number): Element | null 
   for (const card of cards) {
     const box = card.getBoundingClientRect()
     const offset = y - box.top - box.height / 2
-    if (offset < 0 && offset > closestOffset) {
+    const deadZone = Math.min(10, box.height * 0.1)
+    if (offset < -deadZone && offset > closestOffset) {
       closestOffset = offset
       closest = card
     }

--- a/src/ui/composites/ProjectCard.ts
+++ b/src/ui/composites/ProjectCard.ts
@@ -1,4 +1,5 @@
 import { ProgressBar } from '../primitives/ProgressBar'
+import { animateSurfaceIn, bindLiftMotion } from '../motion'
 
 export interface ProjectCardProps {
   title: string
@@ -8,6 +9,7 @@ export interface ProjectCardProps {
   tasksTotal: number
   onClick: () => void
   onContextMenu: (e: MouseEvent) => void
+  motionIndex?: number
 }
 
 export class ProjectCard {
@@ -16,6 +18,8 @@ export class ProjectCard {
   constructor(parentEl: HTMLElement, props: ProjectCardProps) {
     const card = parentEl.createDiv('pm-project-card')
     this.el = card
+    animateSurfaceIn(card, props.motionIndex ?? 0)
+    bindLiftMotion(card, { y: -4, scale: 1.01 })
 
     const colorBar = card.createDiv('pm-project-card-bar')
     colorBar.setCssStyles({ background: props.color })

--- a/src/ui/motion.ts
+++ b/src/ui/motion.ts
@@ -1,0 +1,129 @@
+import { animate } from 'motion/mini'
+
+const enterEase = [0.22, 1, 0.36, 1] as [number, number, number, number]
+const moveEase = [0.2, 0, 0, 1] as [number, number, number, number]
+const quickEase = 'easeOut'
+const running = new WeakMap<Element, { stop: () => void }>()
+let kanbanDragActive = false
+
+function reducedMotion(): boolean {
+  if (typeof window === 'undefined') return true
+  return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+}
+
+function run(el: HTMLElement, keyframes: Parameters<typeof animate>[1], options: Parameters<typeof animate>[2]): void {
+  if (reducedMotion()) return
+  running.get(el)?.stop()
+  const controls = animate(el, keyframes, options)
+  running.set(el, controls)
+  void (async () => {
+    try {
+      await controls
+    } finally {
+      if (running.get(el) === controls) running.delete(el)
+    }
+  })()
+}
+
+export function setKanbanDragActive(active: boolean): void {
+  kanbanDragActive = active
+}
+
+export function animateSurfaceIn(el: HTMLElement, index = 0): void {
+  run(
+    el,
+    {
+      transform: ['translateY(6px) scale(0.99)', 'translateY(0) scale(1)']
+    },
+    {
+      delay: Math.min(index * 0.025, 0.2),
+      duration: 0.22,
+      ease: enterEase
+    }
+  )
+}
+
+export function bindLiftMotion(
+  el: HTMLElement,
+  opts: { y?: number; scale?: number; disabledDuringKanbanDrag?: boolean } = {}
+): void {
+  if (reducedMotion()) return
+  const y = opts.y ?? -3
+  const scale = opts.scale ?? 1.012
+
+  el.addEventListener('mouseenter', () => {
+    if (opts.disabledDuringKanbanDrag && kanbanDragActive) return
+    if (el.classList.contains('pm-dragging')) return
+    run(el, { opacity: 1, transform: `translateY(${y}px) scale(${scale})` }, { duration: 0.18, ease: quickEase })
+  })
+
+  el.addEventListener('mouseleave', () => {
+    if (opts.disabledDuringKanbanDrag && kanbanDragActive) return
+    if (el.classList.contains('pm-dragging')) return
+    run(el, { opacity: 1, transform: 'translateY(0) scale(1)' }, { duration: 0.16, ease: quickEase })
+  })
+}
+
+export function animateDragStart(el: HTMLElement): void {
+  run(
+    el,
+    {
+      opacity: 0.72,
+      transform: 'translateY(-4px) scale(1.025)'
+    },
+    { duration: 0.12, ease: quickEase }
+  )
+}
+
+export function animateDragEnd(el: HTMLElement): void {
+  run(
+    el,
+    {
+      opacity: 1,
+      transform: 'translateY(0) scale(1)'
+    },
+    { duration: 0.2, ease: enterEase }
+  )
+}
+
+export function snapshotCardRects(scope: HTMLElement): Map<HTMLElement, DOMRect> {
+  const rects = new Map<HTMLElement, DOMRect>()
+  if (reducedMotion()) return rects
+  scope.querySelectorAll<HTMLElement>('.pm-kanban-card:not(.pm-kanban-card--dragging)').forEach((card) => {
+    rects.set(card, card.getBoundingClientRect())
+  })
+  return rects
+}
+
+export function animateCardReorder(scope: HTMLElement, before: Map<HTMLElement, DOMRect>): void {
+  if (reducedMotion() || before.size === 0) return
+
+  scope.querySelectorAll<HTMLElement>('.pm-kanban-card:not(.pm-kanban-card--dragging)').forEach((card) => {
+    const oldRect = before.get(card)
+    if (!oldRect) return
+
+    const newRect = card.getBoundingClientRect()
+    const dx = oldRect.left - newRect.left
+    const dy = oldRect.top - newRect.top
+    if (Math.abs(dx) < 0.5 && Math.abs(dy) < 0.5) return
+
+    run(
+      card,
+      {
+        transform: [`translate3d(${dx}px, ${dy}px, 0)`, 'translate3d(0, 0, 0)']
+      },
+      { duration: 0.2, ease: moveEase }
+    )
+  })
+}
+
+export function animateModalIn(el: HTMLElement): void {
+  run(
+    el,
+    {
+      opacity: [0, 1],
+      transform: ['translateY(10px) scale(0.975)', 'translateY(0) scale(1)']
+    },
+    { duration: 0.24, ease: enterEase }
+  )
+}

--- a/src/views/ProjectListRenderer.ts
+++ b/src/views/ProjectListRenderer.ts
@@ -39,7 +39,7 @@ export async function renderProjectListContent(ctx: ProjectListContext): Promise
   }
 
   const grid = ctx.contentEl.createDiv('pm-project-grid')
-  for (const project of projects) {
+  for (const [index, project] of projects.entries()) {
     const statuses = ctx.plugin.store.configFor(project).statuses
     const total = countTasks(project.tasks, false, statuses)
     const done = countTasks(project.tasks, true, statuses)
@@ -49,6 +49,7 @@ export async function renderProjectListContent(ctx: ProjectListContext): Promise
       color: project.color,
       tasksDone: done,
       tasksTotal: total,
+      motionIndex: index,
       onClick: safeAsync(async () => {
         const file = ctx.plugin.app.vault.getAbstractFileByPath(project.filePath)
         if (file instanceof TFile) await ctx.openProjectFile(file)


### PR DESCRIPTION
## What this PR does

Adds a small Motion-based animation layer for existing UI interactions: Kanban card drag feedback, smooth card movement while dragging within a column, task/project modal entrance, and light hover feedback on cards. 

## Linked issue

Fixes #144

## Checklist

- [x] I discussed this change in an issue and got a thumbs-up before writing code.
- [x] `npm run build` passes with zero errors.
- [x] `npx eslint src/` passes with zero warnings — includes no inline styles, sentence-case UI text, no unnecessary non-null assertions.
- [x] New UI follows the Quiet Architect design system (no emojis, no hard corners, no 1px dividers, no pure black text, depth via tonal stacking).
- [x] New modals are created through `ModalFactory`, never instantiated directly.
- [x] No `element.style.*` assignments — CSS classes only.
- [x] No dynamic `await import()` — static imports only.
- [x] Dates use `YYYY-MM-DD` format; UTC operations only (`T00:00:00Z`, `setUTCDate()`).
- [x] This PR is focused on one logical change. Unrelated cleanup is in a separate PR.
