### PR TITLE
Adding custom fileld filters with test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 main.js
 styles.css
+data.json
+package-lock.json
 .claude/
 preview/
 CLAUDE.md

--- a/src/modals/ProjectModal.ts
+++ b/src/modals/ProjectModal.ts
@@ -200,7 +200,8 @@ export class ProjectModal extends Modal {
           id: makeId(),
           name: 'New Field',
           type: 'text',
-          options: []
+          options: [],
+          filterable: false
         })
         renderCFs()
       })
@@ -421,6 +422,14 @@ export class ProjectModal extends Modal {
     typeSelect.addEventListener('change', () => {
       this.project.customFields[index].type = typeSelect.value as CustomFieldDef['type']
       rerender()
+    })
+
+    const filterToggle = row.createEl('label', { cls: 'pm-cf-filter-toggle' })
+    const filterCheckbox = filterToggle.createEl('input', { type: 'checkbox' })
+    filterCheckbox.checked = !!cf.filterable
+    filterToggle.createSpan({ text: 'Filterable' })
+    filterCheckbox.addEventListener('change', () => {
+      this.project.customFields[index].filterable = filterCheckbox.checked
     })
 
     new IconButton(row)

--- a/src/store/TaskFilter.test.ts
+++ b/src/store/TaskFilter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { DEFAULT_STATUSES, makeDefaultFilter, makeTask, type FilterState, type Task } from '../types'
+import { DEFAULT_STATUSES, makeDefaultFilter, makeTask, type CustomFieldFilterSelection, type FilterState, type Task } from '../types'
 import {
   applyTaskFilter,
   applyTaskFilterFlat,
@@ -36,6 +36,10 @@ describe('isFilterActive', () => {
 
   it('returns true when dueDateFilter is not "any"', () => {
     expect(isFilterActive(filter({ dueDateFilter: 'overdue' }))).toBe(true)
+  })
+
+  it('returns true when a custom field filter is active', () => {
+    expect(isFilterActive(filter({ customFields: { impact: { value: 'high', type: 'text' } } } as never))).toBe(true)
   })
 
   it('ignores showArchived (matches legacy semantics)', () => {
@@ -96,6 +100,18 @@ describe('matchesFilter', () => {
   it('treats no-date dueDateFilter correctly', () => {
     expect(matchesFilter(task({ id: 'a', due: '' }), filter({ dueDateFilter: 'no-date' }))).toBe(true)
     expect(matchesFilter(task({ id: 'b', due: '2026-01-01' }), filter({ dueDateFilter: 'no-date' }))).toBe(false)
+  })
+
+  it('matches custom field filters by value', () => {
+    const taskWithField = task({ id: 'a', customFields: { impact: 'high' } })
+    expect(matchesFilter(taskWithField, filter({ customFields: { impact: { value: 'high', type: 'text' } } } as never))).toBe(true)
+    expect(matchesFilter(taskWithField, filter({ customFields: { impact: { value: 'low', type: 'text' } } } as never))).toBe(false)
+  })
+
+  it('matches custom field filters by multiselect selection', () => {
+    const taskWithField = task({ id: 'a', customFields: { impact: ['high', 'urgent'] } })
+    expect(matchesFilter(taskWithField, filter({ customFields: { impact: { value: ['high'], type: 'multiselect' } } } as never))).toBe(true)
+    expect(matchesFilter(taskWithField, filter({ customFields: { impact: { value: ['low'], type: 'multiselect' } } } as never))).toBe(false)
   })
 })
 

--- a/src/store/TaskFilter.test.ts
+++ b/src/store/TaskFilter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { DEFAULT_STATUSES, makeDefaultFilter, makeTask, type CustomFieldFilterSelection, type FilterState, type Task } from '../types'
+import { DEFAULT_STATUSES, makeDefaultFilter, makeTask, type FilterState, type Task } from '../types'
 import {
   applyTaskFilter,
   applyTaskFilterFlat,

--- a/src/store/TaskFilter.ts
+++ b/src/store/TaskFilter.ts
@@ -1,5 +1,5 @@
 import { parsePlainDate, Temporal, today } from '../dates'
-import type { DueDateFilter, FilterState, StatusConfig, Task } from '../types'
+import type { CustomFieldFilterSelection, DueDateFilter, FilterState, StatusConfig, Task } from '../types'
 import { isTerminalStatus } from '../utils'
 import type { FlatTask } from './TaskTreeOps'
 
@@ -10,7 +10,8 @@ export function isFilterActive(filter: FilterState): boolean {
     filter.priorities.length ||
     filter.assignees.length ||
     filter.tags.length ||
-    filter.dueDateFilter !== 'any'
+    filter.dueDateFilter !== 'any' ||
+    Object.values(filter.customFields ?? {}).some(isCustomFieldSelectionActive)
   )
 }
 
@@ -23,6 +24,7 @@ export function countActiveFilters(filter: FilterState): number {
   if (filter.tags.length) count++
   if (filter.dueDateFilter !== 'any') count++
   if (filter.showArchived) count++
+  count += Object.values(filter.customFields ?? {}).filter(isCustomFieldSelectionActive,).length
   return count
 }
 
@@ -47,6 +49,9 @@ export function matchesFilter(task: Task, filter: FilterState, statuses: StatusC
   if (filter.assignees.length && !task.assignees.some((a) => filter.assignees.includes(a))) return false
   if (filter.tags.length && !task.tags.some((t) => filter.tags.includes(t))) return false
   if (filter.dueDateFilter !== 'any' && !matchDueDateFilter(task, filter.dueDateFilter, statuses)) return false
+  for (const [fieldId, selection] of Object.entries(filter.customFields ?? {})) {
+    if (!matchesCustomFieldFilter(task.customFields[fieldId], selection)) return false
+  }
   return true
 }
 
@@ -54,6 +59,41 @@ export function applyTaskFilter(tasks: Task[], filter: FilterState, statuses: St
   return tasks
     .filter((t) => matchesFilter(t, filter, statuses))
     .map((t) => (t.subtasks.length ? { ...t, subtasks: applyTaskFilter(t.subtasks, filter, statuses) } : t))
+}
+
+function isCustomFieldSelectionActive(selection: CustomFieldFilterSelection | undefined): boolean {
+  if (!selection) return false
+  if (selection.type === 'multiselect') {
+    return Array.isArray(selection.value) && selection.value.length > 0
+  }
+  return selection.value !== undefined && selection.value !== null && selection.value !== ''
+}
+
+function matchesCustomFieldFilter(actual: unknown, selection: CustomFieldFilterSelection | undefined): boolean {
+  if (!selection || !isCustomFieldSelectionActive(selection)) return true
+  switch (selection.type) {
+    case 'checkbox':
+      return Boolean(actual) === Boolean(selection.value)
+    case 'multiselect': {
+      const selected = Array.isArray(selection.value) ? selection.value : []
+      const values = Array.isArray(actual) ? actual : []
+      return selected.some((option) => values.includes(option))
+    }
+    case 'number': {
+      const expected = Number(selection.value)
+      const actualNumber = typeof actual === 'number' ? actual : typeof actual === 'string' ? Number(actual) : Number.NaN
+      return Number.isNaN(expected) ? false : actualNumber === expected
+    }
+    default: {
+      const actualText =
+        typeof actual === 'string'
+          ? actual
+          : typeof actual === 'number' || typeof actual === 'boolean'
+            ? String(actual)
+            : ''
+      return actualText === String(selection.value)
+    }
+  }
 }
 
 /**

--- a/src/store/YamlHydrator.ts
+++ b/src/store/YamlHydrator.ts
@@ -1,5 +1,6 @@
 import type {
   CustomFieldDef,
+  CustomFieldFilterSelection,
   PriorityConfig,
   Project,
   ProjectConfig,
@@ -33,7 +34,16 @@ export function hydrateSavedViews(raw: unknown[]): SavedView[] {
           assignees: Array.isArray(filter.assignees) ? filter.assignees : [],
           tags: Array.isArray(filter.tags) ? filter.tags : [],
           dueDateFilter: (filter.dueDateFilter as string as SavedView['filter']['dueDateFilter']) ?? 'any',
-          showArchived: (filter.showArchived as boolean) ?? false
+          showArchived: (filter.showArchived as boolean) ?? false,
+          customFields:
+            typeof filter.customFields === 'object' && filter.customFields !== null
+              ? Object.fromEntries(
+                  Object.entries(filter.customFields as Record<string, unknown>).map(([key, value]) => [
+                    key,
+                    value as CustomFieldFilterSelection
+                  ])
+                )
+              : {}
         },
         sortKey: (v.sortKey as string) ?? 'status',
         sortDir: (v.sortDir as 'asc' | 'desc') ?? 'asc',

--- a/src/store/yaml-round-trip.test.ts
+++ b/src/store/yaml-round-trip.test.ts
@@ -162,7 +162,8 @@ describe('project round-trip', () => {
         assignees: ['Alice'],
         tags: ['design'],
         dueDateFilter: 'overdue',
-        showArchived: false
+        showArchived: false,
+        customFields: {}
       },
       sortKey: 'due',
       sortDir: 'desc'

--- a/src/styles/project-modal.css
+++ b/src/styles/project-modal.css
@@ -221,6 +221,15 @@
 .pm-cf-type {
   flex: 0 0 130px;
 }
+.pm-cf-filter-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--font-ui-smaller);
+  color: var(--text-muted);
+  margin-left: auto;
+  align-self: center;
+}
 .pm-cf-options {
   width: 100%;
   display: flex;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,12 +21,18 @@ export interface TimeLog {
   note: string
 }
 
+export interface CustomFieldFilterSelection {
+  type: CustomFieldDef["type"];
+  value: string | string[] | number | boolean | null;
+}
+
 export interface CustomFieldDef {
   id: string
   name: string
   type: 'text' | 'number' | 'date' | 'select' | 'multiselect' | 'person' | 'checkbox' | 'url'
   options?: string[] // for select / multiselect
   icon?: string // emoji or lucide icon name
+  filterable?: boolean
 }
 
 export interface Task {
@@ -83,6 +89,7 @@ export interface FilterState {
   tags: string[]
   dueDateFilter: DueDateFilter
   showArchived: boolean
+  customFields: Record<string, CustomFieldFilterSelection>
 }
 
 export interface SavedView {
@@ -256,6 +263,7 @@ export function makeDefaultFilter(): FilterState {
     assignees: [],
     tags: [],
     dueDateFilter: 'any',
-    showArchived: false
+    showArchived: false,
+    customFields: {},
   }
 }

--- a/src/ui/composites/ProjectHeader/FilterRow.ts
+++ b/src/ui/composites/ProjectHeader/FilterRow.ts
@@ -1,10 +1,10 @@
 import { Menu } from 'obsidian'
-import type { Project, FilterState, StatusConfig, PriorityConfig, DueDateFilter } from '../../../types'
+import type { CustomFieldDef, Project, FilterState, StatusConfig, PriorityConfig, DueDateFilter } from '../../../types'
 import { collectAllAssignees, collectAllTags } from '../../../store'
 import { countActiveFilters } from '../../../store/TaskFilter'
 import { renderFilterDropdown } from '../../FilterDropdown'
 import { ChipButton } from '../../primitives/ChipButton'
-import { formatBadgeText } from '../../../utils'
+import { formatBadgeText, stringifyCustomValue } from '../../../utils'
 
 export interface FilterRowProps {
   project: Project
@@ -94,9 +94,144 @@ export class FilterRow {
       )
     }
 
+    for (const cf of project.customFields.filter((field) => field.filterable)) {
+      this.renderCustomFieldFilter(cf, notify)
+    }
+
     this.renderDueDateButton(notify)
     this.renderArchivedButton(notify)
     this.renderClearButton()
+  }
+
+  private renderCustomFieldFilter(cf: CustomFieldDef, notify: () => void): void {
+    const { filter, project } = this.props
+    const btn = new ChipButton(this.el).setAriaLabel(`Filter by ${cf.name}`)
+    const updateLabel = () => {
+      const current = filter.customFields[cf.id]
+      const active = this.isCustomFieldSelectionActive(current)
+      const label = active ? `${cf.name}: ${this.describeCustomFieldSelection(cf, current)}` : cf.name
+      btn.setLabel(label).setActive(active)
+    }
+    updateLabel()
+
+    btn.onClick((e) => {
+      const menu = new Menu()
+      const current = filter.customFields[cf.id]
+
+      if (cf.type === 'checkbox') {
+        for (const opt of [true, false]) {
+          const label = opt ? 'Yes' : 'No'
+          menu.addItem((item) =>
+            item
+              .setTitle(label)
+              .setChecked(current?.type === 'checkbox' && current.value === opt)
+              .onClick(() => {
+                filter.customFields[cf.id] = { type: cf.type, value: opt }
+                updateLabel()
+                notify()
+              })
+          )
+        }
+      } else if (cf.type === 'multiselect') {
+        const selected = Array.isArray(current?.value) ? current.value : []
+        const options = this.getCustomFieldOptions(cf, project)
+        for (const opt of options) {
+          menu.addItem((item) =>
+            item
+              .setTitle(opt)
+              .setChecked(selected.includes(opt))
+              .onClick(() => {
+                const next = selected.includes(opt) ? selected.filter((v) => v !== opt) : [...selected, opt]
+                filter.customFields[cf.id] = { type: cf.type, value: next }
+                updateLabel()
+                notify()
+              })
+          )
+        }
+      } else {
+        const selected = current?.type === cf.type ? String(current.value) : ''
+        const options = this.getCustomFieldOptions(cf, project)
+        for (const opt of options) {
+          menu.addItem((item) =>
+            item
+              .setTitle(opt)
+              .setChecked(selected === opt)
+              .onClick(() => {
+                filter.customFields[cf.id] = { type: cf.type, value: opt }
+                updateLabel()
+                notify()
+              })
+          )
+        }
+      }
+
+      if (this.isCustomFieldSelectionActive(current)) {
+        menu.addSeparator()
+        menu.addItem((item) =>
+          item.setTitle('Clear').onClick(() => {
+            delete filter.customFields[cf.id]
+            updateLabel()
+            notify()
+          })
+        )
+      }
+      menu.showAtMouseEvent(e)
+    })
+  }
+
+  private isCustomFieldSelectionActive(selection: { type: CustomFieldDef['type']; value: string | string[] | number | boolean | null } | undefined): boolean {
+    if (!selection) return false
+    if (selection.type === 'multiselect') {
+      return Array.isArray(selection.value) && selection.value.length > 0
+    }
+    return selection.value !== undefined && selection.value !== null && selection.value !== ''
+  }
+
+  private describeCustomFieldSelection(cf: CustomFieldDef, selection: { type: CustomFieldDef['type']; value: string | string[] | number | boolean | null } | undefined): string {
+    if (!selection) return cf.name
+    if (cf.type === 'multiselect' && Array.isArray(selection.value)) {
+      return selection.value.join(', ')
+    }
+    if (cf.type === 'checkbox') {
+      return selection.value ? 'Yes' : 'No'
+    }
+    return stringifyCustomValue(selection.value)
+  }
+
+  private getCustomFieldOptions(cf: CustomFieldDef, project: Project): string[] {
+    const values: string[] = []
+    const seen = new Set<string>()
+    const add = (value: unknown) => {
+      const text = stringifyCustomValue(value)
+      if (text && !seen.has(text)) {
+        values.push(text)
+        seen.add(text)
+      }
+    }
+
+    if (cf.type === 'select' || cf.type === 'multiselect') {
+      for (const opt of cf.options ?? []) {
+        add(opt)
+      }
+    }
+
+    if (cf.type === 'multiselect') {
+      for (const task of project.tasks) {
+        const current = task.customFields[cf.id]
+        if (Array.isArray(current)) {
+          for (const value of current) {
+            add(value)
+          }
+        }
+      }
+      return values
+    }
+
+    for (const task of project.tasks) {
+      add(task.customFields[cf.id])
+    }
+
+    return values
   }
 
   private renderDueDateButton(notify: () => void): void {

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -323,6 +323,8 @@ export class ProjectView extends ItemView {
         onSave: (updated) => {
           this.project = updated
           this.renderProjectToolbar()
+          this.renderProjectHeader()
+          this.renderCurrentView()
         }
       })
     })
@@ -385,6 +387,7 @@ export class ProjectView extends ItemView {
           onSave: (updated) => {
             this.project = updated
             this.renderProjectToolbar()
+            this.renderProjectHeader()
             this.renderCurrentView()
           }
         })


### PR DESCRIPTION
## What this PR does

This PR adds dynamic filters for custom-defined ticket fields. It adds a more flexible approach and usability to custom defined filters, as currently they do not allow users to use them for filtering, or search. 

When defining custom fields, they now have a checkbox "Filterable" which determines if that field will be visible in the filter section (false by default; this aims to remove clutter if somebody had defined many custom fields). The filter option for custom fields will mirror the type of custom field that is.

<img width="807" height="140" alt="image" src="https://github.com/user-attachments/assets/812ca38e-1774-489e-8a57-35d2724feb2b" />

<img width="435" height="360" alt="image" src="https://github.com/user-attachments/assets/0c4fa49f-4eda-4a9c-949f-76a55ca36fca" />

## Linked issue

Fixes #170

## Checklist

- [ ] I discussed this change in an issue and got a thumbs-up before writing code. (Note: **Repo owner is currently on a vacation, and was at the time of Issue creation. I created changes for my personal use in the meantime, and wanted to propose the PR as well. 🙂)**
- [x] `npm run build` passes with zero errors.
- [x] `npx eslint src/` passes with zero warnings — includes no inline styles, sentence-case UI text, no unnecessary non-null assertions.
- [x] New UI follows the Quiet Architect design system (no emojis, no hard corners, no 1px dividers, no pure black text, depth via tonal stacking).
- [x] New modals are created through `ModalFactory`, never instantiated directly.
- [x] No `element.style.*` assignments — CSS classes only.
- [x] No dynamic `await import()` — static imports only.
- [x] Dates use `YYYY-MM-DD` format; UTC operations only (`T00:00:00Z`, `setUTCDate()`).
- [x] This PR is focused on one logical change. Unrelated cleanup is in a separate PR.