### PR TITLE
make task descriptions selectable and place the cursor on click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The import dialog uses Obsidian's native buttons
 - The Gantt zoom control uses Obsidian's native buttons
 - Filter and saved-view buttons match Obsidian's native buttons, with an accent tint when active
+- The cursor lands where a task description was clicked when the editor opens
 
 ### Fixed
 
+- Text and images in a task description could not be selected or copied ([#169](https://github.com/StepanKropachev/obsidian-pm/issues/169))
+- A task description rewrapped its text when clicked for editing
 - Searching for a task by its id found nothing ([#167](https://github.com/StepanKropachev/obsidian-pm/issues/167))
 - The import dialog offered the built-in statuses and priorities instead of the configured ones
 

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -382,13 +382,14 @@ export class TaskModal extends Modal {
       attachFileLinkHandlers()
     }
 
-    const showEdit = () => {
+    const showEdit = (caret?: number) => {
       descPreview.classList.add('pm-hidden')
       descArea.classList.remove('pm-hidden')
       descArea.value = this.task.description
       window.setTimeout(() => {
         autoResize()
         descArea.focus()
+        if (caret !== undefined) descArea.setSelectionRange(caret, caret)
       }, 0)
     }
 
@@ -451,6 +452,37 @@ export class TaskModal extends Modal {
     })
     this.noteSuggest.attach(descSection)
 
+    // Walk the rendered text and the markdown source in step, skipping the source
+    // characters that produced no output, so a caret in the preview lands on the
+    // character that rendered it rather than on the syntax around it.
+    const sourceOffsetOf = (renderedIndex: number) => {
+      const rendered = descPreview.textContent || ''
+      const src = this.task.description
+      const plain = (c: string) => (/\s/.test(c) ? ' ' : c)
+      let cursor = 0
+      for (let i = 0; i < renderedIndex && i < rendered.length; i++) {
+        const ch = plain(rendered[i])
+        while (cursor < src.length && plain(src[cursor]) !== ch) cursor++
+        cursor++
+      }
+      return Math.min(cursor, src.length)
+    }
+
+    const clickedSourceOffset = (e: MouseEvent) => {
+      const doc = descPreview.ownerDocument
+      const caret = doc.caretPositionFromPoint?.(e.clientX, e.clientY)
+      const node = caret?.offsetNode
+      if (!node || node.nodeType !== Node.TEXT_NODE || !descPreview.contains(node)) return undefined
+      const walker = doc.createTreeWalker(descPreview, NodeFilter.SHOW_TEXT)
+      let rendered = 0
+      let current = walker.nextNode()
+      while (current && current !== node) {
+        rendered += (current.textContent || '').length
+        current = walker.nextNode()
+      }
+      return current ? sourceOffsetOf(rendered + caret.offset) : undefined
+    }
+
     descPreview.addEventListener('click', (e) => {
       const target = e.target as HTMLElement
       if (target.instanceOf(HTMLInputElement) && target.type === 'checkbox') return
@@ -473,8 +505,13 @@ export class TaskModal extends Modal {
         return
       }
 
+      if (target.instanceOf(HTMLImageElement)) return
+
+      const selection = activeWindow.getSelection()
+      if (selection && !selection.isCollapsed && descPreview.contains(selection.anchorNode)) return
+
       // Click on non-link text = edit
-      showEdit()
+      showEdit(clickedSourceOffset(e))
     })
 
     if (hasContent()) {

--- a/src/store/TaskFilter.ts
+++ b/src/store/TaskFilter.ts
@@ -30,8 +30,6 @@ export function matchesFilter(task: Task, filter: FilterState, statuses: StatusC
   if (task.archived && !filter.showArchived) return false
   const q = filter.text.trim().toLowerCase()
   if (q) {
-    // Ids compare whole-string: they are opaque generated strings, so a substring test would
-    // match tasks whose id merely contains the query, with nothing on screen to explain the hit.
     if (
       !(
         task.id.toLowerCase() === q ||

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -191,9 +191,8 @@
   font-size: 13px;
   line-height: 1.6;
   min-height: 32px;
-  max-height: 300px;
-  overflow-y: auto;
   cursor: text;
+  user-select: text;
 }
 .pm-modal-desc-preview:hover {
   background: var(--background-modifier-hover);


### PR DESCRIPTION
Text and images in a task description can be selected and copied, and clicking opens the editor with the cursor at the click point rather than at the end.

Closes #169