### PR TITLE
archive subtasks along with their parent task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Gantt zoom control uses Obsidian's native buttons
 - Filter and saved-view buttons match Obsidian's native buttons, with an accent tint when active
 - The cursor lands where a task description was clicked when the editor opens
+- Subtasks are archived and unarchived along with their parent task
 
 ### Fixed
 

--- a/src/store/ArchiveOps.ts
+++ b/src/store/ArchiveOps.ts
@@ -1,6 +1,6 @@
 import type { App } from 'obsidian'
 import { TFile, normalizePath } from 'obsidian'
-import type { Project } from '../types'
+import type { Project, Task } from '../types'
 import { findTaskById } from './TaskIndex'
 import { ensureFolder, moveTaskAttachmentFolder } from './vaultFs'
 
@@ -9,43 +9,47 @@ function projectTaskFolder(project: Project): string {
   return project.filePath.replace(/\.md$/, '_tasks')
 }
 
-export async function archiveTask(app: App, project: Project, taskId: string): Promise<void> {
-  const task = findTaskById(project, taskId)
-  if (!task || !task.filePath) return
+function subtree(task: Task): Task[] {
+  return [task, ...task.subtasks.flatMap(subtree)]
+}
 
-  const taskFolder = projectTaskFolder(project)
-  const archiveFolder = normalizePath(taskFolder + '/Archive')
-  await ensureFolder(app, archiveFolder)
+/** Move a task's file (and attachments) into `targetFolder`. Reports whether the file ended up there. */
+async function moveTaskFile(app: App, task: Task, targetFolder: string): Promise<boolean> {
+  if (!task.filePath) return false
 
   const fileName = task.filePath.split('/').pop()
-  if (!fileName) return
-  const newPath = normalizePath(archiveFolder + '/' + fileName)
+  if (!fileName) return false
+  const newPath = normalizePath(targetFolder + '/' + fileName)
+  if (newPath === task.filePath) return true
 
   const file = app.vault.getAbstractFileByPath(task.filePath)
-  if (file instanceof TFile) {
-    const oldPath = task.filePath
-    await app.vault.rename(file, newPath)
-    await moveTaskAttachmentFolder(app, oldPath, newPath)
-    task.filePath = newPath
-    task.archived = true
+  if (!(file instanceof TFile)) return false
+
+  const oldPath = task.filePath
+  await app.vault.rename(file, newPath)
+  await moveTaskAttachmentFolder(app, oldPath, newPath)
+  task.filePath = newPath
+  return true
+}
+
+export async function archiveTask(app: App, project: Project, taskId: string): Promise<void> {
+  const task = findTaskById(project, taskId)
+  if (!task) return
+
+  const archiveFolder = normalizePath(projectTaskFolder(project) + '/Archive')
+  await ensureFolder(app, archiveFolder)
+
+  for (const t of subtree(task)) {
+    if (await moveTaskFile(app, t, archiveFolder)) t.archived = true
   }
 }
 
 export async function unarchiveTask(app: App, project: Project, taskId: string): Promise<void> {
   const task = findTaskById(project, taskId)
-  if (!task || !task.filePath) return
+  if (!task) return
 
-  const taskFolder = projectTaskFolder(project)
-  const fileName = task.filePath.split('/').pop()
-  if (!fileName) return
-  const newPath = normalizePath(taskFolder + '/' + fileName)
-
-  const file = app.vault.getAbstractFileByPath(task.filePath)
-  if (file instanceof TFile) {
-    const oldPath = task.filePath
-    await app.vault.rename(file, newPath)
-    await moveTaskAttachmentFolder(app, oldPath, newPath)
-    task.filePath = newPath
-    task.archived = false
+  const taskFolder = normalizePath(projectTaskFolder(project))
+  for (const t of subtree(task)) {
+    if (await moveTaskFile(app, t, taskFolder)) t.archived = false
   }
 }

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -397,6 +397,53 @@ describe('ProjectStore task attachments', () => {
   })
 })
 
+describe('ProjectStore archiving', () => {
+  it('archives the whole subtree when a parent is archived', async () => {
+    const { store, vault } = newStore()
+    const project = await store.createProject('Tree', 'Projects')
+    const parent = await addNamed(store, project, 'Parent')
+    const child = await addNamed(store, project, 'Child', parent.id)
+    const grandchild = await addNamed(store, project, 'Grandchild', child.id)
+
+    await store.archiveTask(project, parent.id)
+
+    for (const task of [parent, child, grandchild]) {
+      expect(task.archived).toBe(true)
+      expect(task.filePath).toMatch(/^Projects\/Tree_tasks\/Archive\//)
+      expect(vault.getAbstractFileByPath(expectDefined(task.filePath))).not.toBeNull()
+    }
+  })
+
+  it('unarchives the whole subtree when a parent is unarchived', async () => {
+    const { store, vault } = newStore()
+    const project = await store.createProject('Tree', 'Projects')
+    const parent = await addNamed(store, project, 'Parent')
+    const child = await addNamed(store, project, 'Child', parent.id)
+
+    await store.archiveTask(project, parent.id)
+    await store.unarchiveTask(project, parent.id)
+
+    for (const task of [parent, child]) {
+      expect(task.archived).toBe(false)
+      expect(task.filePath).toBe(`Projects/Tree_tasks/${task.title.toLowerCase()}.md`)
+      expect(vault.getAbstractFileByPath(expectDefined(task.filePath))).not.toBeNull()
+    }
+  })
+
+  it('leaves an already archived subtask in place when its parent is archived', async () => {
+    const { store } = newStore()
+    const project = await store.createProject('Tree', 'Projects')
+    const parent = await addNamed(store, project, 'Parent')
+    const child = await addNamed(store, project, 'Child', parent.id)
+
+    await store.archiveTask(project, child.id)
+    await store.archiveTask(project, parent.id)
+
+    expect(child.archived).toBe(true)
+    expect(child.filePath).toBe('Projects/Tree_tasks/Archive/child.md')
+  })
+})
+
 describe('ProjectStore metadataCache fast path', () => {
   function stubTaskCache(app: App, path: string, fm: Record<string, unknown>): void {
     const cache = (app as unknown as { metadataCache: { getFileCache: (f: TFile) => unknown } }).metadataCache


### PR DESCRIPTION
Archiving a task now archives its whole subtree, and unarchiving restores it. Previously only the parent moved to the archive, leaving its subtasks visible in the table with no parent to sit under.

Closes #183.

A subtask archived on its own before its parent was archived comes back when the parent is unarchived; the archived state is derived from where the note lives, so there is nowhere to record that it was archived separately.