### PR TITLE
hide obsidian's native close button in the task editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A task description rewrapped its text when clicked for editing
 - Searching for a task by its id found nothing ([#167](https://github.com/StepanKropachev/obsidian-pm/issues/167))
 - The import dialog offered the built-in statuses and priorities instead of the configured ones
+- The task editor showed two close buttons in its top right corner
 
 ## [1.8.0] - 2026-07-03
 

--- a/src/styles/task-editor.css
+++ b/src/styles/task-editor.css
@@ -380,7 +380,8 @@ input.pm-pop-field:focus {
 
 /* The editor draws its own close button in the header row (matching the design),
    so suppress Obsidian's native corner close button to avoid two X's. */
-.pm-modal--task .modal-close-button {
+.pm-modal--task .modal-close-button,
+.pm-modal--task .modal-header-button {
   display: none;
 }
 


### PR DESCRIPTION
The task editor draws its own close button in its header row, so the native one is suppressed. Obsidian now renders that button as .modal-header-button rather than .modal-close-button, so the old rule stopped matching and two X's showed in the top right corner.