### PR TITLE
pull dependent tasks forward when a blocker finishes early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Projects can override the default view, auto-scheduling, and the board display options in the project settings
 - The completed date shows whether a task finished on time or how many days late it was
 - Task progress can be set from 0 to 100 in the task editor and by clicking the progress bar in the table
+- Dependent tasks move earlier when a task is completed before its due date, using the new pull-forward setting ([#154](https://github.com/StepanKropachev/obsidian-pm/issues/154))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Card-based board grouped by status. Drag cards between columns to update status 
 
 ### Scheduling & time
 - **Drag-and-drop scheduling** — Reschedule tasks by dragging bars on the Gantt chart.
-- **Smart scheduling** — Auto-adjust dependent task dates when a blocker's dates change. Cycle detection prevents circular dependencies.
+- **Smart scheduling** — Auto-adjust dependent task dates when a blocker's dates change. Cycle detection prevents circular dependencies. Optionally pull dependents earlier when a blocker is completed ahead of its due date.
 - **Recurring tasks** — Daily, weekly, monthly, or yearly recurrence with configurable end dates.
 - **Time estimates & logging** — Set estimated hours, log actual time with date and notes. Visual progress bar shows logged vs. estimated.
 - **Due date notifications** — Get reminders before tasks are due. Configurable lead time.
@@ -62,7 +62,7 @@ Card-based board grouped by status. Drag cards between columns to update status 
 ### Customization
 - **Custom fields** — Add per-project fields: text, number, date, select, multi-select, person, checkbox, URL.
 - **Custom statuses & priorities** — Edit labels, colors, and icons for each status and priority level.
-- **Per-project settings** — A project can define its own statuses and priorities and override the default view, auto-scheduling, and board display options. Project-defined statuses replace the global ones everywhere in that project, from kanban columns to pickers; statuses still in use by tasks always stay visible.
+- **Per-project settings** — A project can define its own statuses and priorities and override the default view, auto-scheduling, early-finish pull-forward, and board display options. Project-defined statuses replace the global ones everywhere in that project, from kanban columns to pickers; statuses still in use by tasks always stay visible.
 - **Saved views** — Save filter/sort combinations in Table view and switch between them instantly.
 - **Team roster** — Manage a global team list for assignment across all projects, plus per-project team members.
 
@@ -141,6 +141,7 @@ Task hierarchy and dependencies don't resolve on the TaskNotes side (it uses pro
 | Due date notifications | Reminders N days before due dates |
 | Notifications on/off | Master switch for due date reminders, separate from lead time |
 | Auto-schedule | When a blocking task moves, its dependents shift to match. Cycles are refused. |
+| Pull dependents forward on early finish | Off by default. When a task is completed before its due date, its dependents move earlier by the days it saved, keeping any slack they already had. |
 | Hide done in Gantt | Skip completed and cancelled tasks on the timeline |
 | Show subtasks in Kanban | Render subtasks as their own cards, not just inside the parent |
 | Custom statuses | Edit labels, colors, and icons for each status |

--- a/src/modals/ProjectModal.ts
+++ b/src/modals/ProjectModal.ts
@@ -271,6 +271,10 @@ export class ProjectModal extends Modal {
       { value: true, label: 'On' },
       { value: false, label: 'Off' }
     ])
+    this.renderOverrideSelect(behaviorGrid, 'Pull forward on early finish', 'pullForwardOnEarlyFinish', [
+      { value: true, label: 'On' },
+      { value: false, label: 'Off' }
+    ])
     this.renderOverrideSelect(behaviorGrid, 'Subtasks on board', 'kanbanShowSubtasks', [
       { value: true, label: 'Show' },
       { value: false, label: 'Hide' }
@@ -363,7 +367,12 @@ export class ProjectModal extends Modal {
   }
 
   private renderOverrideSelect<
-    K extends 'defaultView' | 'autoSchedule' | 'kanbanShowSubtasks' | 'kanbanShowDescriptionPreview'
+    K extends
+      | 'defaultView'
+      | 'autoSchedule'
+      | 'pullForwardOnEarlyFinish'
+      | 'kanbanShowSubtasks'
+      | 'kanbanShowDescriptionPreview'
   >(
     grid: HTMLElement,
     label: string,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -160,6 +160,18 @@ export class PMSettingTab extends PluginSettingTab {
         })
       )
 
+    new Setting(containerEl)
+      .setName('Pull dependents forward on early finish')
+      .setDesc(
+        'When a task is completed before its due date, move its dependent tasks earlier by the days it saved. Needs auto-schedule.'
+      )
+      .addToggle((t) =>
+        t.setValue(this.plugin.settings.pullForwardOnEarlyFinish).onChange(async (v) => {
+          this.plugin.settings.pullForwardOnEarlyFinish = v
+          await this.plugin.saveSettings()
+        })
+      )
+
     // ── Team Members ──────────────────────────────────────────────────────────
     new Setting(containerEl).setName('Team members').setHeading()
 

--- a/src/store/ProjectConfig.test.ts
+++ b/src/store/ProjectConfig.test.ts
@@ -34,6 +34,7 @@ describe('resolveProjectConfig', () => {
     expect(resolved.priorities).toEqual(DEFAULT_PRIORITIES)
     expect(resolved.defaultView).toBe(DEFAULT_SETTINGS.defaultView)
     expect(resolved.autoSchedule).toBe(DEFAULT_SETTINGS.autoSchedule)
+    expect(resolved.pullForwardOnEarlyFinish).toBe(DEFAULT_SETTINGS.pullForwardOnEarlyFinish)
     expect(resolved.kanbanShowSubtasks).toBe(DEFAULT_SETTINGS.kanbanShowSubtasks)
     expect(resolved.kanbanShowDescriptionPreview).toBe(DEFAULT_SETTINGS.kanbanShowDescriptionPreview)
   })
@@ -56,11 +57,17 @@ describe('resolveProjectConfig', () => {
 
   it('overrides behavior settings independently of the palettes', () => {
     const resolved = resolveProjectConfig(
-      makeOverrideProject({ defaultView: 'kanban', autoSchedule: false, kanbanShowSubtasks: true }),
+      makeOverrideProject({
+        defaultView: 'kanban',
+        autoSchedule: false,
+        pullForwardOnEarlyFinish: true,
+        kanbanShowSubtasks: true
+      }),
       DEFAULT_SETTINGS
     )
     expect(resolved.defaultView).toBe('kanban')
     expect(resolved.autoSchedule).toBe(false)
+    expect(resolved.pullForwardOnEarlyFinish).toBe(true)
     expect(resolved.kanbanShowSubtasks).toBe(true)
     expect(resolved.statuses).toEqual(DEFAULT_STATUSES)
     expect(resolved.kanbanShowDescriptionPreview).toBe(DEFAULT_SETTINGS.kanbanShowDescriptionPreview)

--- a/src/store/ProjectConfig.ts
+++ b/src/store/ProjectConfig.ts
@@ -30,6 +30,7 @@ export function resolveProjectConfig(project: Project, settings: PMSettings): Re
     ),
     defaultView: config?.defaultView ?? settings.defaultView,
     autoSchedule: config?.autoSchedule ?? settings.autoSchedule,
+    pullForwardOnEarlyFinish: config?.pullForwardOnEarlyFinish ?? settings.pullForwardOnEarlyFinish,
     kanbanShowSubtasks: config?.kanbanShowSubtasks ?? settings.kanbanShowSubtasks,
     kanbanShowDescriptionPreview: config?.kanbanShowDescriptionPreview ?? settings.kanbanShowDescriptionPreview
   }

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -2,8 +2,10 @@ import type { App } from 'obsidian'
 import { TFile } from 'obsidian'
 import { describe, expect, it, vi } from 'vitest'
 import { makeFakeApp, type FakeVault } from '../../test/fakeVault'
+import { today } from '../dates'
 import { DEFAULT_SETTINGS, makeTask, type PMSettings, type Project, type StatusConfig, type Task } from '../types'
 import { ProjectStore } from './ProjectStore'
+import { addDays } from './Scheduler'
 import { buildTaskIndex } from './TaskIndex'
 import { findTask, flattenTasks } from './TaskTreeOps'
 
@@ -330,6 +332,61 @@ describe('ProjectStore completion date', () => {
     // a stamped date onto the open task in the same call.
     await store.updateTasks(project, [finishing.id, open.id], { priority: 'high' })
     expect(open.completed).toBe('')
+  })
+})
+
+describe('ProjectStore pull-forward on early finish', () => {
+  const BLOCKER_DUE = '2099-06-10'
+
+  async function chain(pullForward: boolean): Promise<{ store: ProjectStore; project: Project; blocked: Task }> {
+    const { app } = makeFakeApp()
+    const store = new ProjectStore(app as unknown as App, () => ({
+      ...SETTINGS,
+      pullForwardOnEarlyFinish: pullForward
+    }))
+    const project = await store.createProject('Early', 'Projects')
+    const blocker = makeTask({ title: 'Blocker', due: BLOCKER_DUE })
+    await store.insertTask(project, blocker)
+    const blocked = makeTask({
+      title: 'Blocked',
+      start: addDays(BLOCKER_DUE, 1),
+      due: addDays(BLOCKER_DUE, 2),
+      dependencies: [blocker.id]
+    })
+    await store.insertTask(project, blocked)
+    await store.updateTask(project, blocker.id, { status: 'done' })
+    return { store, project, blocked }
+  }
+
+  it('pulls a dependent back when its blocker is completed ahead of its due date', async () => {
+    const { blocked } = await chain(true)
+    const finishedOn = today().toString()
+    expect(blocked.start).toBe(addDays(finishedOn, 1))
+    expect(blocked.due).toBe(addDays(finishedOn, 2))
+  })
+
+  it('leaves the dependent in place when the option is off', async () => {
+    const { blocked } = await chain(false)
+    expect(blocked.start).toBe(addDays(BLOCKER_DUE, 1))
+  })
+
+  it('keeps a project-level override across a reload', async () => {
+    const { store, vault, app } = newStore()
+    const project = await store.createProject('Override', 'Projects')
+    project.config = { pullForwardOnEarlyFinish: true }
+    await store.saveProject(project)
+
+    const file = vault.getAbstractFileByPath(project.filePath)
+    if (!(file instanceof TFile)) throw new Error('project file missing')
+    const reloaded = expectDefined(await new ProjectStore(app, () => SETTINGS).loadProject(file))
+    expect(reloaded.config?.pullForwardOnEarlyFinish).toBe(true)
+  })
+
+  it('pushes the dependent back out when the blocker is reopened', async () => {
+    const { store, project, blocked } = await chain(true)
+    const blocker = expectDefined(flattenTasks(project.tasks).find((f) => f.task.title === 'Blocker')).task
+    await store.updateTask(project, blocker.id, { status: 'todo' })
+    expect(blocked.start).toBe(addDays(BLOCKER_DUE, 1))
   })
 })
 

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -885,10 +885,22 @@ export class ProjectStore implements TaskSource {
     else if (!nowComplete && wasComplete) patch.completed = ''
   }
 
+  /** Call between `stampCompletion` and the patch reaching the tree, while `task` still holds its old value. */
+  private completionMoved(task: Task, patch: Partial<Task>): boolean {
+    return patch.completed !== undefined && patch.completed !== task.completed
+  }
+
+  private async scheduleAfterEarlyFinish(project: Project, taskIds: string[]): Promise<void> {
+    if (taskIds.length === 0) return
+    if (!this.configFor(project).pullForwardOnEarlyFinish) return
+    for (const id of taskIds) await this.scheduleAfterChange(project, id)
+  }
+
   async updateTask(project: Project, taskId: string, patch: Partial<Task>): Promise<void> {
     const task = findTaskById(project, taskId)
     const oldTitle = task?.title
     if (task) this.stampCompletion(project, task, patch)
+    const completionMoved = task !== null && this.completionMoved(task, patch)
     // The task editor saves the whole task, so a patch can add, rename, remove,
     // or reorder subtasks. Snapshot the pre-edit subtree to diff against once the
     // tree has the new one.
@@ -910,6 +922,7 @@ export class ProjectStore implements TaskSource {
       for (const sub of task.subtasks) this.markDirty(project, [sub.id], 'full')
     }
     await this.saveProject(project)
+    if (completionMoved) await this.scheduleAfterEarlyFinish(project, [taskId])
   }
 
   /**
@@ -956,6 +969,7 @@ export class ProjectStore implements TaskSource {
     taskIds: string[],
     patch: Partial<Task> | ((task: Task) => Partial<Task> | null)
   ): Promise<void> {
+    const completionMovedIds: string[] = []
     for (const id of taskIds) {
       const task = findTaskById(project, id)
       if (!task) continue
@@ -965,6 +979,7 @@ export class ProjectStore implements TaskSource {
       // doesn't bleed onto the next iteration through the same reference.
       const p = { ...raw }
       this.stampCompletion(project, task, p)
+      if (this.completionMoved(task, p)) completionMovedIds.push(id)
       const oldTitle = task.title
       updateTaskInTree(project.tasks, id, p)
       const titleChanged = p.title !== undefined && p.title !== oldTitle
@@ -976,6 +991,7 @@ export class ProjectStore implements TaskSource {
       }
     }
     await this.saveProject(project)
+    await this.scheduleAfterEarlyFinish(project, completionMovedIds)
   }
 
   /**
@@ -1118,7 +1134,7 @@ export class ProjectStore implements TaskSource {
   async scheduleAfterChange(project: Project, changedTaskId?: string): Promise<number> {
     const config = this.configFor(project)
     if (!config.autoSchedule) return 0
-    const { patches } = computeSchedule(project.tasks, changedTaskId, config.statuses)
+    const { patches } = computeSchedule(project.tasks, changedTaskId, config.statuses, config.pullForwardOnEarlyFinish)
     if (patches.length === 0) return 0
 
     for (const p of patches) {

--- a/src/store/Scheduler.test.ts
+++ b/src/store/Scheduler.test.ts
@@ -183,3 +183,83 @@ describe('computeSchedule', () => {
     expect(result.cycles).toEqual([])
   })
 })
+
+describe('computeSchedule with pullForward', () => {
+  const finishedEarly = task({
+    id: 'a',
+    start: '2026-07-06',
+    due: '2026-07-13',
+    completed: '2026-07-10',
+    status: 'done'
+  })
+
+  it('leaves dependents alone when the option is off', () => {
+    const tasks = [finishedEarly, task({ id: 'b', start: '2026-07-14', due: '2026-07-16', dependencies: ['a'] })]
+    expect(computeSchedule(tasks, undefined, statuses).patches).toEqual([])
+  })
+
+  it('pulls a dependent back by the days its predecessor saved', () => {
+    const tasks = [finishedEarly, task({ id: 'b', start: '2026-07-14', due: '2026-07-16', dependencies: ['a'] })]
+    const result = computeSchedule(tasks, undefined, statuses, true)
+    expect(result.patches).toEqual([{ taskId: 'b', start: '2026-07-11', due: '2026-07-13' }])
+  })
+
+  it('keeps the slack a dependent already had', () => {
+    const tasks = [finishedEarly, task({ id: 'b', start: '2026-07-20', due: '2026-07-22', dependencies: ['a'] })]
+    const result = computeSchedule(tasks, undefined, statuses, true)
+    expect(result.patches).toEqual([{ taskId: 'b', start: '2026-07-17', due: '2026-07-19' }])
+  })
+
+  it('never pulls a dependent before the day after its predecessor finished', () => {
+    const early = task({ id: 'a', start: '2026-07-01', due: '2026-07-13', completed: '2026-07-02', status: 'done' })
+    const tasks = [early, task({ id: 'b', start: '2026-07-05', due: '2026-07-08', dependencies: ['a'] })]
+    const result = computeSchedule(tasks, undefined, statuses, true)
+    expect(result.patches).toEqual([{ taskId: 'b', start: '2026-07-03', due: '2026-07-06' }])
+  })
+
+  it('cascades the saved days down the chain', () => {
+    const tasks = [
+      finishedEarly,
+      task({ id: 'b', start: '2026-07-14', due: '2026-07-16', dependencies: ['a'] }),
+      task({ id: 'c', start: '2026-07-20', due: '2026-07-21', dependencies: ['b'] })
+    ]
+    const result = computeSchedule(tasks, undefined, statuses, true)
+    expect(result.patches).toEqual([
+      { taskId: 'b', start: '2026-07-11', due: '2026-07-13' },
+      { taskId: 'c', start: '2026-07-17', due: '2026-07-18' }
+    ])
+  })
+
+  it('holds a dependent in place while another predecessor is still due later', () => {
+    const tasks = [
+      finishedEarly,
+      task({ id: 'gate', start: '2026-07-06', due: '2026-07-13' }),
+      task({ id: 'b', start: '2026-07-14', due: '2026-07-16', dependencies: ['a', 'gate'] })
+    ]
+    expect(computeSchedule(tasks, undefined, statuses, true).patches).toEqual([])
+  })
+
+  it('pulls a milestone by its due date', () => {
+    const tasks = [finishedEarly, task({ id: 'm', due: '2026-07-14', type: 'milestone', dependencies: ['a'] })]
+    const result = computeSchedule(tasks, undefined, statuses, true)
+    expect(result.patches).toEqual([{ taskId: 'm', start: '', due: '2026-07-11' }])
+  })
+
+  it('ignores a task that completed on or after its due date', () => {
+    const onTime = task({ id: 'a', start: '2026-07-06', due: '2026-07-13', completed: '2026-07-13', status: 'done' })
+    const tasks = [onTime, task({ id: 'b', start: '2026-07-20', due: '2026-07-22', dependencies: ['a'] })]
+    expect(computeSchedule(tasks, undefined, statuses, true).patches).toEqual([])
+  })
+
+  it('ignores a completion date on a task that is not in a terminal status', () => {
+    const reopened = task({ id: 'a', start: '2026-07-06', due: '2026-07-13', completed: '2026-07-10' })
+    const tasks = [reopened, task({ id: 'b', start: '2026-07-14', due: '2026-07-16', dependencies: ['a'] })]
+    expect(computeSchedule(tasks, undefined, statuses, true).patches).toEqual([])
+  })
+
+  it('still pushes a dependent that starts too early', () => {
+    const tasks = [finishedEarly, task({ id: 'b', start: '2026-07-08', due: '2026-07-09', dependencies: ['a'] })]
+    const result = computeSchedule(tasks, undefined, statuses, true)
+    expect(result.patches).toEqual([{ taskId: 'b', start: '2026-07-11', due: '2026-07-12' }])
+  })
+})

--- a/src/store/Scheduler.ts
+++ b/src/store/Scheduler.ts
@@ -72,8 +72,18 @@ export function wouldCreateCycle(tasks: Task[], fromId: string, toId: string): b
  *
  * Tasks with status `done` or `cancelled` are skipped — their dates are
  * historically meaningful and should not move.
+ *
+ * With `pullForward`, a predecessor that completed before its due date counts as
+ * finishing on its completion date, and its dependents move earlier by the days
+ * it saved — never past the day after their predecessors finish, and keeping
+ * whatever slack they already had.
  */
-export function computeSchedule(tasks: Task[], changedTaskId?: string, statuses: StatusConfig[] = []): ScheduleResult {
+export function computeSchedule(
+  tasks: Task[],
+  changedTaskId?: string,
+  statuses: StatusConfig[] = [],
+  pullForward = false
+): ScheduleResult {
   const flat = flattenTasks(tasks).map((ft) => ft.task)
   const taskById = new Map<string, Task>()
   const dependentsOf = new Map<string, string[]>() // depId → [taskIds that depend on it]
@@ -151,9 +161,15 @@ export function computeSchedule(tasks: Task[], changedTaskId?: string, statuses:
   // We work with a mutable copy of dates so cascading works within this run
   const startOf = new Map<string, string>()
   const dueOf = new Map<string, string>()
+  // Days by which a task's finish beat the date it was planned for.
+  const daysSavedBy = new Map<string, number>()
   for (const t of flat) {
     startOf.set(t.id, t.start)
     dueOf.set(t.id, t.due)
+    if (!pullForward || !t.completed || !t.due || t.completed >= t.due) continue
+    if (!isTerminalStatus(t.status, statuses)) continue
+    dueOf.set(t.id, t.completed)
+    daysSavedBy.set(t.id, daysBetween(t.completed, t.due))
   }
 
   const patches: SchedulePatch[] = []
@@ -170,23 +186,30 @@ export function computeSchedule(tasks: Task[], changedTaskId?: string, statuses:
 
     // Find latest due among predecessors that have a due date
     // Skip archived predecessors — they are hidden from the UI
+    // `latestPlannedDue` is the same date had every predecessor finished on plan.
     let latestDue = ''
+    let latestPlannedDue = ''
     for (const depId of deps) {
       const dep = taskById.get(depId)
       if (dep?.archived) continue
       const depDue = dueOf.get(depId) ?? ''
-      if (depDue && (!latestDue || depDue > latestDue)) {
-        latestDue = depDue
-      }
+      if (!depDue) continue
+      if (!latestDue || depDue > latestDue) latestDue = depDue
+      const plannedDue = addDays(depDue, daysSavedBy.get(depId) ?? 0)
+      if (!latestPlannedDue || plannedDue > latestPlannedDue) latestPlannedDue = plannedDue
     }
     if (!latestDue) continue // no predecessors with due dates
 
     const earliestStart = addDays(latestDue, 1)
+    const daysSaved = daysBetween(latestDue, latestPlannedDue)
     const currentStart = startOf.get(id) ?? ''
     const currentDue = dueOf.get(id) ?? ''
 
+    const pullBy = (anchor: string) => Math.min(daysSaved, Math.max(0, daysBetween(earliestStart, anchor)))
+
     let newStart = currentStart
     let newDue = currentDue
+    let pulled = 0
 
     const isMilestone = task.type === 'milestone' || (!currentStart && currentDue)
 
@@ -194,6 +217,9 @@ export function computeSchedule(tasks: Task[], changedTaskId?: string, statuses:
       // Milestone: shift due instead of start
       if (!currentDue || currentDue < earliestStart) {
         newDue = earliestStart
+      } else if (daysSaved > 0) {
+        pulled = pullBy(currentDue)
+        newDue = addDays(currentDue, -pulled)
       }
     } else if (currentStart && currentDue) {
       // Has both: preserve duration, shift if needed
@@ -203,16 +229,18 @@ export function computeSchedule(tasks: Task[], changedTaskId?: string, statuses:
         const duration = daysBetween(currentStart, currentDue) + 1
         newStart = earliestStart
         newDue = addDays(earliestStart, duration - 1)
-      }
-    } else if (!currentStart && currentDue) {
-      // Has only due: shift due if needed (treat as milestone)
-      if (currentDue < earliestStart) {
-        newDue = earliestStart
+      } else if (daysSaved > 0) {
+        pulled = pullBy(currentStart)
+        newStart = addDays(currentStart, -pulled)
+        newDue = addDays(currentDue, -pulled)
       }
     } else if (currentStart && !currentDue) {
       // Start only: shift start if needed
       if (currentStart < earliestStart) {
         newStart = earliestStart
+      } else if (daysSaved > 0) {
+        pulled = pullBy(currentStart)
+        newStart = addDays(currentStart, -pulled)
       }
     } else {
       // Neither start nor due: set start
@@ -223,6 +251,7 @@ export function computeSchedule(tasks: Task[], changedTaskId?: string, statuses:
       // Update mutable maps for cascading
       startOf.set(id, newStart)
       dueOf.set(id, newDue)
+      if (pulled > 0) daysSavedBy.set(id, pulled)
       patches.push({ taskId: id, start: newStart, due: newDue })
     }
   }

--- a/src/store/YamlHydrator.ts
+++ b/src/store/YamlHydrator.ts
@@ -146,6 +146,7 @@ function hydrateProjectConfig(raw: unknown): ProjectConfig | undefined {
     config.defaultView = r.defaultView
   }
   if (typeof r.autoSchedule === 'boolean') config.autoSchedule = r.autoSchedule
+  if (typeof r.pullForwardOnEarlyFinish === 'boolean') config.pullForwardOnEarlyFinish = r.pullForwardOnEarlyFinish
   if (typeof r.kanbanShowSubtasks === 'boolean') config.kanbanShowSubtasks = r.kanbanShowSubtasks
   if (typeof r.kanbanShowDescriptionPreview === 'boolean') {
     config.kanbanShowDescriptionPreview = r.kanbanShowDescriptionPreview

--- a/src/store/YamlSerializer.ts
+++ b/src/store/YamlSerializer.ts
@@ -12,6 +12,7 @@ function serializeProjectConfig(config: ProjectConfig | undefined): Record<strin
   if (config.priorities?.length) out.priorities = config.priorities
   if (config.defaultView) out.defaultView = config.defaultView
   if (config.autoSchedule !== undefined) out.autoSchedule = config.autoSchedule
+  if (config.pullForwardOnEarlyFinish !== undefined) out.pullForwardOnEarlyFinish = config.pullForwardOnEarlyFinish
   if (config.kanbanShowSubtasks !== undefined) out.kanbanShowSubtasks = config.kanbanShowSubtasks
   if (config.kanbanShowDescriptionPreview !== undefined) {
     out.kanbanShowDescriptionPreview = config.kanbanShowDescriptionPreview

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,6 +116,7 @@ export interface ProjectConfig {
   priorities?: PriorityConfig[]
   defaultView?: ViewMode
   autoSchedule?: boolean
+  pullForwardOnEarlyFinish?: boolean
   kanbanShowSubtasks?: boolean
   kanbanShowDescriptionPreview?: boolean
 }
@@ -130,6 +131,7 @@ export interface ResolvedProjectConfig {
   priorities: PriorityConfig[]
   defaultView: ViewMode
   autoSchedule: boolean
+  pullForwardOnEarlyFinish: boolean
   kanbanShowSubtasks: boolean
   kanbanShowDescriptionPreview: boolean
 }
@@ -152,6 +154,7 @@ export interface PMSettings {
   notificationsEnabled: boolean
   notificationLeadDays: number
   autoSchedule: boolean
+  pullForwardOnEarlyFinish: boolean
   kanbanShowSubtasks: boolean
   kanbanShowDescriptionPreview: boolean
   showTagColors: boolean
@@ -193,6 +196,7 @@ export const DEFAULT_SETTINGS: PMSettings = {
   notificationsEnabled: true,
   notificationLeadDays: 2,
   autoSchedule: true,
+  pullForwardOnEarlyFinish: false,
   saveTaskOnClose: true,
   projectFilters: {},
   collapsedTasks: {}


### PR DESCRIPTION
New setting, off by default, global with a per-project override. When a task is completed before its due date, its dependents move earlier by the days it saved, capped so nothing starts before the day after its predecessors finished. Dependents that already had slack keep it, and reopening the task pushes them back out.

Auto-scheduling only ever pushed dates later, so finishing ahead of schedule left the rest of the plan sitting on the old dates.

Closes #154