### PR TITLE
move the settings tab to obsidian's declarative settings api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The plugin requires Obsidian 1.13
+- Settings are grouped by area, with statuses, priorities, team members, and TaskNotes each on their own page
+- Settings can be found from Obsidian's settings search
+- The TaskNotes page shows how many statuses and priorities differ before importing
+- A setting that depends on another one is unavailable until that one is turned on
 - Add buttons in the table, Gantt, project editor, and settings share one quiet style
 - Remove buttons in the task editor, project editor, and settings are icon buttons with tooltips
 - The import dialog uses Obsidian's native buttons

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -142,7 +142,7 @@ Richer than primitives, used across views. Avoid expanding this bucket; prefer c
 - **StatusBadge** - `renderStatusBadge(container, task, statuses, onChange)` (solid dot-led Chip + picker Menu), `renderPriorityBadge(...)` (plain Chip with chevron icon + picker Menu), `renderStatusDot(container, status, statuses, cls?)` (bare colored dot), `PRIORITY_CHEVRONS`. The only way to render status/priority.
 - **TaskContextMenu** - `buildTaskContextMenu(menu, task, ctx)`: the task right-click menu.
 - **ModalFactory** - all modal opening: `openTaskModal`, `openProjectModal`, `openProjectPicker`, `openTaskPicker`, `openImportModal`, `confirmDialog`, `confirmDuplicateSubtasks`, `promptText`. Never instantiate a modal directly from a view.
-- **PaletteListEditor** - `renderStatusListEditor` / `renderPriorityListEditor` for settings-style palette editing, plus `attachIconSuggest`, `wireRowDragReorder`.
+- **PaletteListEditor** - `renderPaletteFields(parent, app, item, onChanged)` (icon + label + color inputs) and `renderStatusDoneToggle` are the row internals, used by the plugin settings pages. `renderStatusListEditor` / `renderPriorityListEditor` wrap them with their own drag handle and delete button for the project modal's per-project overrides; plugin settings get those affordances from Obsidian's list settings instead. Plus `attachIconSuggest`, `wireRowDragReorder`.
 
 ## Native Obsidian components to use directly
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "project-manager",
   "name": "Project Manager",
   "version": "1.8.0",
-  "minAppVersion": "1.7.2",
+  "minAppVersion": "1.13.0",
   "description": "Full-featured project management: stunning Gantt charts, Kanban boards, Table views, customizable fields, due date notifications.",
   "author": "Stepan Kropachev",
   "authorUrl": "https://github.com/StepanKropachev",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-obsidianmd": "0.3.0",
     "lightningcss": "1.33.0",
     "npm-run-all2": "9.0.2",
-    "obsidian": "1.12.3",
+    "obsidian": "1.13.1",
     "oxfmt": "0.60.0",
     "oxlint": "1.75.0",
     "temporal-polyfill": "1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 10.8.0
       eslint-plugin-obsidianmd:
         specifier: 0.3.0
-        version: 0.3.0(@eslint/js@9.39.4)(@eslint/json@0.14.0)(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(obsidian@1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(typescript-eslint@8.61.1(eslint@10.8.0)(typescript@6.0.3))
+        version: 0.3.0(@eslint/js@9.39.4)(@eslint/json@0.14.0)(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(obsidian@1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(typescript-eslint@8.61.1(eslint@10.8.0)(typescript@6.0.3))
       lightningcss:
         specifier: 1.33.0
         version: 1.33.0
@@ -40,8 +40,8 @@ importers:
         specifier: 9.0.2
         version: 9.0.2
       obsidian:
-        specifier: 1.12.3
-        version: 1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
+        specifier: 1.13.1
+        version: 1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
       oxfmt:
         specifier: 0.60.0
         version: 0.60.0
@@ -1857,8 +1857,8 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
-  obsidian@1.12.3:
-    resolution: {integrity: sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==}
+  obsidian@1.13.1:
+    resolution: {integrity: sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==}
     peerDependencies:
       '@codemirror/state': 6.5.0
       '@codemirror/view': 6.38.6
@@ -3629,7 +3629,7 @@ snapshots:
     dependencies:
       eslint: 10.8.0
 
-  eslint-plugin-obsidianmd@0.3.0(@eslint/js@9.39.4)(@eslint/json@0.14.0)(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(obsidian@1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(typescript-eslint@8.61.1(eslint@10.8.0)(typescript@6.0.3)):
+  eslint-plugin-obsidianmd@0.3.0(@eslint/js@9.39.4)(@eslint/json@0.14.0)(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(obsidian@1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(typescript-eslint@8.61.1(eslint@10.8.0)(typescript@6.0.3)):
     dependencies:
       '@eslint/config-helpers': 0.4.2
       '@eslint/js': 9.39.4
@@ -3646,7 +3646,7 @@ snapshots:
       eslint-plugin-no-unsanitized: 4.1.5(eslint@10.8.0)
       eslint-plugin-security: 2.1.1
       globals: 14.0.0
-      obsidian: 1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
+      obsidian: 1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
       semver: 7.8.4
       typescript: 5.4.5
       typescript-eslint: 8.61.1(eslint@10.8.0)(typescript@6.0.3)
@@ -4254,7 +4254,7 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
-  obsidian@1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6):
+  obsidian@1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6):
     dependencies:
       '@codemirror/state': 6.5.0
       '@codemirror/view': 6.38.6

--- a/src/integrations/tasknotes.test.ts
+++ b/src/integrations/tasknotes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { DEFAULT_SETTINGS, type PMSettings } from '../types'
-import { importTaskNotesPalettes, type TaskNotesApi } from './tasknotes'
+import { countTaskNotesPaletteChanges, importTaskNotesPalettes, type TaskNotesApi } from './tasknotes'
 
 function makeApi(): TaskNotesApi {
   return {
@@ -68,5 +68,24 @@ describe('importTaskNotesPalettes', () => {
 
     const second = importTaskNotesPalettes(makeApi(), settings)
     expect(second).toEqual({ added: 0, updated: 0 })
+  })
+})
+
+describe('countTaskNotesPaletteChanges', () => {
+  it('reports what the import would change without changing anything', () => {
+    const settings = makeSettings()
+    const before = JSON.stringify(settings)
+
+    const counted = countTaskNotesPaletteChanges(makeApi(), settings)
+
+    expect(JSON.stringify(settings)).toBe(before)
+    expect(counted).toEqual(importTaskNotesPalettes(makeApi(), makeSettings()))
+  })
+
+  it('reports nothing once the palettes match TaskNotes', () => {
+    const settings = makeSettings()
+    importTaskNotesPalettes(makeApi(), settings)
+
+    expect(countTaskNotesPaletteChanges(makeApi(), settings)).toEqual({ added: 0, updated: 0 })
   })
 })

--- a/src/integrations/tasknotes.ts
+++ b/src/integrations/tasknotes.ts
@@ -71,6 +71,13 @@ export function getTaskNotesApi(app: App): TaskNotesApi | null {
   return api
 }
 
+interface PaletteUpsert<T> {
+  id: string
+  make: () => T
+  differs: (existing: T) => boolean
+  apply: (existing: T) => void
+}
+
 /**
  * Upsert one ordered TaskNotes palette into ours. Entries with a matching id are
  * patched in place; missing entries are inserted right after the last TaskNotes
@@ -79,7 +86,7 @@ export function getTaskNotesApi(app: App): TaskNotesApi | null {
  */
 function upsertPalette<T extends { id: string }>(
   target: T[],
-  incoming: Array<{ id: string; make: () => T; patch: (existing: T) => boolean }>
+  incoming: PaletteUpsert<T>[]
 ): { added: number; updated: number } {
   let added = 0
   let updated = 0
@@ -88,12 +95,30 @@ function upsertPalette<T extends { id: string }>(
     const idx = target.findIndex((cfg) => cfg.id === item.id)
     if (idx >= 0) {
       anchor = idx
-      if (item.patch(target[idx])) updated++
+      if (item.differs(target[idx])) {
+        item.apply(target[idx])
+        updated++
+      }
     } else {
       anchor += 1
       target.splice(anchor, 0, item.make())
       added++
     }
+  }
+  return { added, updated }
+}
+
+/** What `upsertPalette` would change, without touching the target. */
+function countPaletteChanges<T extends { id: string }>(
+  target: T[],
+  incoming: PaletteUpsert<T>[]
+): { added: number; updated: number } {
+  let added = 0
+  let updated = 0
+  for (const item of incoming) {
+    const existing = target.find((cfg) => cfg.id === item.id)
+    if (!existing) added++
+    else if (item.differs(existing)) updated++
   }
   return { added, updated }
 }
@@ -136,42 +161,49 @@ export function ensurePaletteEntries(
   return added
 }
 
+function statusUpserts(api: TaskNotesApi): PaletteUpsert<StatusConfig>[] {
+  return [...api.getStatuses()]
+    .sort((a, b) => a.order - b.order)
+    .map((s) => ({
+      id: s.value,
+      make: () => ({ id: s.value, label: s.label, color: s.color, icon: '', complete: s.isCompleted }),
+      differs: (existing: StatusConfig) =>
+        existing.label !== s.label || existing.color !== s.color || existing.complete !== s.isCompleted,
+      apply: (existing: StatusConfig) => {
+        existing.label = s.label
+        existing.color = s.color
+        existing.complete = s.isCompleted
+      }
+    }))
+}
+
+function priorityUpserts(api: TaskNotesApi): PaletteUpsert<PriorityConfig>[] {
+  return [...api.getPriorities()]
+    .sort((a, b) => b.weight - a.weight)
+    .map((p) => ({
+      id: p.value,
+      make: () => ({ id: p.value, label: p.label, color: p.color, icon: '' }),
+      differs: (existing: PriorityConfig) => existing.label !== p.label || existing.color !== p.color,
+      apply: (existing: PriorityConfig) => {
+        existing.label = p.label
+        existing.color = p.color
+      }
+    }))
+}
+
 /** Upsert TaskNotes' configured statuses and priorities into our palettes. */
 export function importTaskNotesPalettes(api: TaskNotesApi, settings: PMSettings): { added: number; updated: number } {
-  const statuses = upsertPalette(
-    settings.statuses,
-    [...api.getStatuses()]
-      .sort((a, b) => a.order - b.order)
-      .map((s) => ({
-        id: s.value,
-        make: () => ({ id: s.value, label: s.label, color: s.color, icon: '', complete: s.isCompleted }),
-        patch: (existing: StatusConfig) => {
-          if (existing.label === s.label && existing.color === s.color && existing.complete === s.isCompleted) {
-            return false
-          }
-          existing.label = s.label
-          existing.color = s.color
-          existing.complete = s.isCompleted
-          return true
-        }
-      }))
-  )
+  const statuses = upsertPalette(settings.statuses, statusUpserts(api))
+  const priorities = upsertPalette(settings.priorities, priorityUpserts(api))
+  return { added: statuses.added + priorities.added, updated: statuses.updated + priorities.updated }
+}
 
-  const priorities = upsertPalette(
-    settings.priorities,
-    [...api.getPriorities()]
-      .sort((a, b) => b.weight - a.weight)
-      .map((p) => ({
-        id: p.value,
-        make: () => ({ id: p.value, label: p.label, color: p.color, icon: '' }),
-        patch: (existing: PriorityConfig) => {
-          if (existing.label === p.label && existing.color === p.color) return false
-          existing.label = p.label
-          existing.color = p.color
-          return true
-        }
-      }))
-  )
-
+/** What `importTaskNotesPalettes` would change right now, without changing anything. */
+export function countTaskNotesPaletteChanges(
+  api: TaskNotesApi,
+  settings: PMSettings
+): { added: number; updated: number } {
+  const statuses = countPaletteChanges(settings.statuses, statusUpserts(api))
+  const priorities = countPaletteChanges(settings.priorities, priorityUpserts(api))
   return { added: statuses.added + priorities.added, updated: statuses.updated + priorities.updated }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,13 +1,22 @@
-import { App, PluginSettingTab, Setting, Notice } from 'obsidian'
+import { App, Notice, PluginSettingTab, Setting } from 'obsidian'
+import type { SettingDefinitionItem, SettingDefinitionPage } from 'obsidian'
 import type PMPlugin from './main'
 import { type PMSettings, DEFAULT_SETTINGS, makeId } from './types'
 import { flattenTasks } from './store/TaskTreeOps'
-import { getTaskNotesApi, importTaskNotesPalettes, isTaskNotesInstalled } from './integrations/tasknotes'
-import { renderPriorityListEditor, renderStatusListEditor } from './ui/PaletteListEditor'
-import { IconButton } from './ui/primitives/IconButton'
+import {
+  countTaskNotesPaletteChanges,
+  getTaskNotesApi,
+  importTaskNotesPalettes,
+  isTaskNotesInstalled
+} from './integrations/tasknotes'
+import { renderPaletteFields, renderStatusDoneToggle } from './ui/PaletteListEditor'
 
 export type { PMSettings }
 export { DEFAULT_SETTINGS }
+
+function plural(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`
+}
 
 export class PMSettingTab extends PluginSettingTab {
   plugin: PMPlugin
@@ -15,287 +24,374 @@ export class PMSettingTab extends PluginSettingTab {
   constructor(app: App, plugin: PMPlugin) {
     super(app, plugin)
     this.plugin = plugin
+    this.icon = 'chart-gantt'
   }
 
-  display(): void {
-    const { containerEl } = this
-    containerEl.empty()
-    containerEl.addClass('pm-settings')
-
-    // ── General ──────────────────────────────────────────────────────────────
-    new Setting(containerEl)
-      .setName('Projects folder')
-      .setDesc('Vault folder where project files are stored.')
-      .addText((text) =>
-        text
-          .setPlaceholder('Projects')
-          .setValue(this.plugin.settings.projectsFolder)
-          .onChange(async (v) => {
-            this.plugin.settings.projectsFolder = v.trim() || 'Projects'
-            await this.plugin.saveSettings()
-          })
-      )
-
-    new Setting(containerEl)
-      .setName('Default view')
-      .setDesc('Which view opens when you open a project.')
-      .addDropdown((dd) =>
-        dd
-          .addOption('table', 'Table')
-          .addOption('gantt', 'Gantt')
-          .addOption('kanban', 'Board')
-          .setValue(this.plugin.settings.defaultView)
-          .onChange(async (v) => {
-            this.plugin.settings.defaultView = v as PMSettings['defaultView']
-            await this.plugin.saveSettings()
-          })
-      )
-
-    new Setting(containerEl).setName('Default gantt granularity').addDropdown((dd) =>
-      dd
-        .addOption('day', 'Day')
-        .addOption('week', 'Week')
-        .addOption('month', 'Month')
-        .addOption('quarter', 'Quarter')
-        .setValue(this.plugin.settings.ganttGranularity)
-        .onChange(async (v) => {
-          this.plugin.settings.ganttGranularity = v as PMSettings['ganttGranularity']
-          await this.plugin.saveSettings()
-        })
-    )
-
-    new Setting(containerEl)
-      .setName('Gantt week label')
-      .setDesc('What to display in weekly gantt header cells.')
-      .addDropdown((dd) =>
-        dd
-          .addOption('weekNumber', 'Week number (w15)')
-          .addOption('dateRange', 'Date range (apr 7\u201313)')
-          .addOption('both', 'Both (w15: apr 7\u201313)')
-          .setValue(this.plugin.settings.ganttWeekLabel)
-          .onChange(async (v) => {
-            this.plugin.settings.ganttWeekLabel = v as PMSettings['ganttWeekLabel']
-            await this.plugin.saveSettings()
-          })
-      )
-
-    new Setting(containerEl)
-      .setName('Show subtasks on board')
-      .setDesc('Display subtasks as individual cards on the kanban board.')
-      .addToggle((t) =>
-        t.setValue(this.plugin.settings.kanbanShowSubtasks).onChange(async (v) => {
-          this.plugin.settings.kanbanShowSubtasks = v
-          await this.plugin.saveSettings()
-        })
-      )
-
-    new Setting(containerEl)
-      .setName('Show description preview on board')
-      .setDesc('Display the first few lines of each task description on kanban cards.')
-      .addToggle((t) =>
-        t.setValue(this.plugin.settings.kanbanShowDescriptionPreview).onChange(async (v) => {
-          this.plugin.settings.kanbanShowDescriptionPreview = v
-          await this.plugin.saveSettings()
-          this.plugin.refreshProjectViews()
-        })
-      )
-
-    new Setting(containerEl)
-      .setName('Show tag colors')
-      .setDesc('Show a colored dot on each tag, derived from its name. Turn off for plain tags.')
-      .addToggle((t) =>
-        t.setValue(this.plugin.settings.showTagColors).onChange(async (v) => {
-          this.plugin.settings.showTagColors = v
-          await this.plugin.saveSettings()
-        })
-      )
-
-    new Setting(containerEl)
-      .setName('Save tasks on close')
-      .setDesc('Automatically save tasks when you close the task modal. When off, only clicking save persists changes.')
-      .addToggle((t) =>
-        t.setValue(this.plugin.settings.saveTaskOnClose).onChange(async (v) => {
-          this.plugin.settings.saveTaskOnClose = v
-          await this.plugin.saveSettings()
-        })
-      )
-
-    // ── Notifications ─────────────────────────────────────────────────────────
-    new Setting(containerEl).setName('Due date notifications').setHeading()
-
-    new Setting(containerEl)
-      .setName('Enable notifications')
-      .setDesc('Show a banner when tasks are approaching their due date.')
-      .addToggle((t) =>
-        t.setValue(this.plugin.settings.notificationsEnabled).onChange(async (v) => {
-          this.plugin.settings.notificationsEnabled = v
-          await this.plugin.saveSettings()
-        })
-      )
-
-    new Setting(containerEl)
-      .setName('Lead time (days)')
-      .setDesc('How many days before the due date to show the notification.')
-      .addSlider((sl) =>
-        sl
-          .setLimits(1, 14, 1)
-          .setValue(this.plugin.settings.notificationLeadDays)
-          .setDynamicTooltip()
-          .onChange(async (v) => {
-            this.plugin.settings.notificationLeadDays = v
-            await this.plugin.saveSettings()
-          })
-      )
-
-    // ── Scheduling ───────────────────────────────────────────────────────────
-    new Setting(containerEl).setName('Scheduling').setHeading()
-
-    new Setting(containerEl)
-      .setName('Auto-schedule')
-      .setDesc('Automatically adjust dependent task dates when a task changes.')
-      .addToggle((t) =>
-        t.setValue(this.plugin.settings.autoSchedule).onChange(async (v) => {
-          this.plugin.settings.autoSchedule = v
-          await this.plugin.saveSettings()
-        })
-      )
-
-    new Setting(containerEl)
-      .setName('Pull dependents forward on early finish')
-      .setDesc(
-        'When a task is completed before its due date, move its dependent tasks earlier by the days it saved. Needs auto-schedule.'
-      )
-      .addToggle((t) =>
-        t.setValue(this.plugin.settings.pullForwardOnEarlyFinish).onChange(async (v) => {
-          this.plugin.settings.pullForwardOnEarlyFinish = v
-          await this.plugin.saveSettings()
-        })
-      )
-
-    // ── Team Members ──────────────────────────────────────────────────────────
-    new Setting(containerEl).setName('Team members').setHeading()
-
-    containerEl.createEl('p', {
-      cls: 'pm-settings-desc',
-      text: 'Global list of people available as assignees across all projects.'
-    })
-    // margin handled by .pm-settings-desc CSS class
-
-    const membersContainer = containerEl.createDiv('pm-settings-members')
-    this.renderMembersList(membersContainer)
-
-    new Setting(containerEl).addButton((btn) =>
-      btn
-        .setButtonText('+ add member')
-        .setCta()
-        .onClick(() => {
-          this.plugin.settings.globalTeamMembers.push('')
-          void this.plugin.saveSettings()
-          this.renderMembersList(membersContainer)
-        })
-    )
-
-    // ── Statuses ──────────────────────────────────────────────────────────────
-    new Setting(containerEl).setName('Statuses').setHeading()
-    containerEl.createEl('p', {
-      cls: 'pm-settings-desc',
-      text: 'Customize status labels, colors, and icons. Drag to reorder.'
-    })
-
-    const statusContainer = containerEl.createDiv('pm-settings-statuses')
-    this.renderStatusList(statusContainer)
-
-    new Setting(containerEl).addButton((btn) =>
-      btn
-        .setButtonText('+ add status')
-        .setCta()
-        .onClick(() => {
-          const id = 'status-' + makeId().slice(0, 6)
-          this.plugin.settings.statuses.push({
-            id,
-            label: 'New status',
-            color: '#8a94a0',
-            icon: '',
-            complete: false
-          })
-          void this.plugin.saveSettings()
-          this.renderStatusList(statusContainer)
-        })
-    )
-
-    // ── Priorities ────────────────────────────────────────────────────────────
-    new Setting(containerEl).setName('Priorities').setHeading()
-    containerEl.createEl('p', {
-      cls: 'pm-settings-desc',
-      text: 'Customize priority labels, colors, and icons. Drag to reorder from most to least important.'
-    })
-
-    const priorityContainer = containerEl.createDiv('pm-settings-statuses')
-    this.renderPriorityList(priorityContainer)
-
-    new Setting(containerEl).addButton((btn) =>
-      btn
-        .setButtonText('+ add priority')
-        .setCta()
-        .onClick(() => {
-          const id = 'priority-' + makeId().slice(0, 6)
-          this.plugin.settings.priorities.push({
-            id,
-            label: 'New priority',
-            color: '#8a94a0',
-            icon: ''
-          })
-          void this.plugin.saveSettings()
-          this.renderPriorityList(priorityContainer)
-        })
-    )
-
-    if (isTaskNotesInstalled(this.app)) {
-      new Setting(containerEl).setName('TaskNotes').setHeading()
-
-      new Setting(containerEl)
-        .setName('Import statuses and priorities')
-        .setDesc('Add or update statuses and priorities to match TaskNotes. Entries TaskNotes does not know are kept.')
-        .addButton((btn) =>
-          btn.setButtonText('Import from TaskNotes').onClick(() => {
-            const api = getTaskNotesApi(this.app)
-            if (!api) {
-              new Notice('TaskNotes 4.10 or newer is required.')
-              return
+  getSettingDefinitions(): SettingDefinitionItem[] {
+    return [
+      {
+        type: 'group',
+        heading: 'General',
+        items: [
+          {
+            name: 'Projects folder',
+            desc: 'Vault folder where project files are stored.',
+            control: {
+              type: 'folder',
+              key: 'projectsFolder',
+              defaultValue: 'Projects',
+              placeholder: 'Projects',
+              validate: (value) => (value.trim() ? undefined : 'Enter a folder name.')
             }
-            const { added, updated } = importTaskNotesPalettes(api, this.plugin.settings)
-            void this.plugin.saveSettings()
-            this.display()
-            new Notice(
-              added || updated
-                ? `Imported from TaskNotes: ${added} added, ${updated} updated.`
-                : 'Statuses and priorities already match TaskNotes.'
-            )
-          })
-        )
+          },
+          {
+            name: 'Default view',
+            desc: 'View that opens when a project is opened.',
+            control: {
+              type: 'dropdown',
+              key: 'defaultView',
+              options: { table: 'Table', gantt: 'Gantt', kanban: 'Board' }
+            }
+          },
+          {
+            name: 'Save tasks on close',
+            desc: 'Save changes when the task editor is closed.',
+            control: { type: 'toggle', key: 'saveTaskOnClose' }
+          }
+        ]
+      },
+      {
+        type: 'group',
+        heading: 'Style',
+        items: [
+          {
+            name: 'Show tag colors',
+            desc: 'Give each tag a colored dot derived from its name.',
+            aliases: ['appearance'],
+            control: { type: 'toggle', key: 'showTagColors' }
+          }
+        ]
+      },
+      {
+        type: 'group',
+        heading: 'Gantt',
+        items: [
+          {
+            name: 'Default granularity',
+            desc: 'Time unit for each column in the timeline.',
+            aliases: ['timeline', 'zoom'],
+            control: {
+              type: 'dropdown',
+              key: 'ganttGranularity',
+              options: { day: 'Day', week: 'Week', month: 'Month', quarter: 'Quarter' }
+            }
+          },
+          {
+            name: 'Week label',
+            desc: 'Text shown in weekly header cells.',
+            aliases: ['timeline'],
+            control: {
+              type: 'dropdown',
+              key: 'ganttWeekLabel',
+              options: {
+                weekNumber: 'Week number (w15)',
+                dateRange: 'Date range (apr 7\u201313)',
+                both: 'Both (w15: apr 7\u201313)'
+              }
+            }
+          }
+        ]
+      },
+      {
+        type: 'group',
+        heading: 'Board',
+        items: [
+          {
+            name: 'Show subtasks',
+            desc: 'Display subtasks as individual cards.',
+            aliases: ['kanban'],
+            control: { type: 'toggle', key: 'kanbanShowSubtasks' }
+          },
+          {
+            name: 'Show description preview',
+            desc: 'Display the first few lines of each task description.',
+            aliases: ['kanban'],
+            control: { type: 'toggle', key: 'kanbanShowDescriptionPreview' }
+          }
+        ]
+      },
+      {
+        type: 'group',
+        heading: 'Scheduling',
+        items: [
+          {
+            name: 'Auto-schedule',
+            desc: 'Adjust dependent task dates when a task changes.',
+            aliases: ['dependencies'],
+            control: { type: 'toggle', key: 'autoSchedule' }
+          },
+          {
+            name: 'Pull dependents forward',
+            desc: 'Move dependent tasks earlier when a task is completed before its due date.',
+            aliases: ['dependencies'],
+            control: {
+              type: 'toggle',
+              key: 'pullForwardOnEarlyFinish',
+              disabled: () => !this.plugin.settings.autoSchedule
+            }
+          }
+        ]
+      },
+      {
+        type: 'group',
+        heading: 'Notifications',
+        items: [
+          {
+            name: 'Due date reminders',
+            desc: 'Show a banner when a task is approaching its due date.',
+            aliases: ['notifications', 'banner'],
+            control: { type: 'toggle', key: 'notificationsEnabled' }
+          },
+          {
+            name: 'Days in advance',
+            desc: 'How many days before the due date to notify.',
+            aliases: ['notifications', 'reminders', 'lead time'],
+            control: {
+              type: 'slider',
+              key: 'notificationLeadDays',
+              min: 1,
+              max: 14,
+              step: 1,
+              disabled: () => !this.plugin.settings.notificationsEnabled
+            }
+          }
+        ]
+      },
+      {
+        type: 'group',
+        heading: 'Task fields',
+        items: [this.statusesPage(), this.prioritiesPage(), this.teamMembersPage()]
+      },
+      {
+        type: 'group',
+        heading: 'Integrations',
+        visible: () => isTaskNotesInstalled(this.app),
+        items: [this.taskNotesPage()]
+      }
+    ]
+  }
+
+  async setControlValue(key: string, value: unknown): Promise<void> {
+    await super.setControlValue(key, value)
+    if (key === 'kanbanShowDescriptionPreview') this.plugin.refreshProjectViews()
+    this.refreshDomState()
+  }
+
+  private statusesPage(): SettingDefinitionPage {
+    const statuses = this.plugin.settings.statuses
+    return {
+      type: 'page',
+      name: 'Statuses',
+      desc: 'Labels, colors, and icons for the status field.',
+      displayValue: () => plural(this.plugin.settings.statuses.length, 'status', 'statuses'),
+      items: [
+        {
+          type: 'list',
+          heading: 'Statuses',
+          emptyState: 'No statuses.',
+          items: statuses.map((status) => ({
+            name: status.label,
+            render: (setting: Setting) => {
+              setting.setClass('pm-palette-row')
+              renderPaletteFields(setting.controlEl, this.app, status, () => this.persist())
+              renderStatusDoneToggle(setting.controlEl, status, () => this.persist())
+            }
+          })),
+          onReorder: (from, to) => this.reorder(statuses, from, to),
+          onDelete: (index) => this.deleteEntry('status', index),
+          addItem: {
+            name: 'Add status',
+            action: () => {
+              statuses.push({
+                id: 'status-' + makeId().slice(0, 6),
+                label: 'New status',
+                color: '#8a94a0',
+                icon: '',
+                complete: false
+              })
+              this.persist()
+              this.update()
+            }
+          }
+        }
+      ]
     }
   }
 
-  private renderMembersList(container: HTMLElement): void {
-    container.empty()
+  private prioritiesPage(): SettingDefinitionPage {
+    const priorities = this.plugin.settings.priorities
+    return {
+      type: 'page',
+      name: 'Priorities',
+      desc: 'Labels, colors, and icons for the priority field.',
+      displayValue: () => plural(this.plugin.settings.priorities.length, 'priority', 'priorities'),
+      items: [
+        {
+          type: 'list',
+          heading: 'Priorities',
+          emptyState: 'No priorities.',
+          items: priorities.map((priority) => ({
+            name: priority.label,
+            render: (setting: Setting) => {
+              setting.setClass('pm-palette-row')
+              renderPaletteFields(setting.controlEl, this.app, priority, () => this.persist())
+            }
+          })),
+          onReorder: (from, to) => this.reorder(priorities, from, to),
+          onDelete: (index) => this.deleteEntry('priority', index),
+          addItem: {
+            name: 'Add priority',
+            action: () => {
+              priorities.push({
+                id: 'priority-' + makeId().slice(0, 6),
+                label: 'New priority',
+                color: '#8a94a0',
+                icon: ''
+              })
+              this.persist()
+              this.update()
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  private taskNotesPage(): SettingDefinitionPage {
+    const connected = (): boolean => getTaskNotesApi(this.app) !== null
+    return {
+      type: 'page',
+      name: 'TaskNotes',
+      desc: 'Share statuses and priorities with the TaskNotes plugin.',
+      displayValue: () => this.taskNotesStatus(),
+      status: () => (connected() ? null : 'warning'),
+      items: [
+        {
+          type: 'list',
+          extraButtons: [
+            (button) =>
+              button
+                .setIcon('refresh-cw')
+                .setTooltip('Import from TaskNotes')
+                .setDisabled(!connected())
+                .onClick(() => this.importFromTaskNotes())
+          ],
+          items: [
+            {
+              name: 'Statuses and priorities',
+              desc: 'Copies labels, colors, and completion from TaskNotes 4.10 or newer.',
+              render: (setting: Setting) => {
+                setting.controlEl.createDiv({ cls: 'setting-item-value', text: this.taskNotesStatus() })
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  /** Whether an import would change anything right now, as a short value. */
+  private taskNotesStatus(): string {
+    const api = getTaskNotesApi(this.app)
+    if (!api) return 'Update required'
+    const { added, updated } = countTaskNotesPaletteChanges(api, this.plugin.settings)
+    const total = added + updated
+    return total === 0 ? 'Up to date' : plural(total, 'change', 'changes')
+  }
+
+  private teamMembersPage(): SettingDefinitionPage {
     const members = this.plugin.settings.globalTeamMembers
-    members.forEach((m, i) => {
-      const row = container.createDiv('pm-settings-member-row')
-      const input = row.createEl('input', { type: 'text', value: m })
-      input.placeholder = 'Name'
-      input.addEventListener('change', () => {
-        this.plugin.settings.globalTeamMembers[i] = input.value
-        void this.plugin.saveSettings()
-      })
-      new IconButton(row)
-        .setIcon('x')
-        .setTooltip('Remove member')
-        .onClick(() => {
-          this.plugin.settings.globalTeamMembers.splice(i, 1)
-          void this.plugin.saveSettings()
-          this.renderMembersList(container)
-        })
-    })
+    return {
+      type: 'page',
+      name: 'Team members',
+      desc: 'People available as assignees across all projects.',
+      displayValue: () => plural(this.plugin.settings.globalTeamMembers.length, 'person', 'people'),
+      items: [
+        {
+          type: 'list',
+          heading: 'Team members',
+          emptyState: 'No team members yet.',
+          items: members.map((member, index) => ({
+            name: member || 'Unnamed member',
+            render: (setting: Setting) => {
+              setting.setClass('pm-palette-row')
+              setting.addText((text) =>
+                text
+                  .setPlaceholder('Name')
+                  .setValue(member)
+                  .onChange((value) => {
+                    this.plugin.settings.globalTeamMembers[index] = value
+                    this.persist()
+                  })
+              )
+            }
+          })),
+          onReorder: (from, to) => this.reorder(members, from, to),
+          onDelete: (index) => {
+            members.splice(index, 1)
+            this.persist()
+            this.update()
+          },
+          addItem: {
+            name: 'Add member',
+            action: () => {
+              members.push('')
+              this.persist()
+              this.update()
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  private persist(): void {
+    void this.plugin.saveSettings()
+  }
+
+  private reorder<T>(items: T[], from: number, to: number): void {
+    const [moved] = items.splice(from, 1)
+    items.splice(to, 0, moved)
+    this.persist()
+    this.update()
+  }
+
+  private deleteEntry(field: 'status' | 'priority', index: number): void {
+    const entries = field === 'status' ? this.plugin.settings.statuses : this.plugin.settings.priorities
+    if (entries.length <= 1) {
+      new Notice(`You must have at least one ${field}.`)
+      return
+    }
+    const [removed] = entries.splice(index, 1)
+    this.persist()
+    this.update()
+    void this.remapOrphanTasks(field, removed.id, removed.label)
+  }
+
+  private importFromTaskNotes(): void {
+    const api = getTaskNotesApi(this.app)
+    if (!api) {
+      new Notice('TaskNotes 4.10 or newer is required.')
+      return
+    }
+    const { added, updated } = importTaskNotesPalettes(api, this.plugin.settings)
+    this.persist()
+    this.update()
+    new Notice(
+      added || updated
+        ? `Imported from TaskNotes: ${added} added, ${updated} updated.`
+        : 'Statuses and priorities already match TaskNotes.'
+    )
   }
 
   private async remapOrphanTasks(field: 'status' | 'priority', deletedId: string, deletedLabel: string): Promise<void> {
@@ -320,23 +416,5 @@ export class PMSettingTab extends PluginSettingTab {
     if (remapped > 0) {
       new Notice(`Remapped ${remapped} task${remapped === 1 ? '' : 's'} from '${deletedLabel}' to '${fallback.label}'.`)
     }
-  }
-
-  private renderStatusList(container: HTMLElement): void {
-    renderStatusListEditor(container, {
-      app: this.app,
-      statuses: this.plugin.settings.statuses,
-      onChanged: () => void this.plugin.saveSettings(),
-      onDeleted: (deleted) => void this.remapOrphanTasks('status', deleted.id, deleted.label)
-    })
-  }
-
-  private renderPriorityList(container: HTMLElement): void {
-    renderPriorityListEditor(container, {
-      app: this.app,
-      priorities: this.plugin.settings.priorities,
-      onChanged: () => void this.plugin.saveSettings(),
-      onDeleted: (deleted) => void this.remapOrphanTasks('priority', deleted.id, deleted.label)
-    })
   }
 }

--- a/src/styles/project-modal.css
+++ b/src/styles/project-modal.css
@@ -237,31 +237,32 @@
 }
 
 /* Settings */
-.pm-settings h3 {
-  margin-top: 24px;
-  margin-bottom: 8px;
-  font-size: 14px;
-}
-.pm-settings-desc {
-  font-size: 13px;
-  color: var(--text-muted);
-  margin-bottom: 8px;
-}
-.pm-settings-members,
 .pm-settings-statuses {
   display: flex;
   flex-direction: column;
   gap: 6px;
   margin-bottom: 8px;
 }
-.pm-settings-member-row,
 .pm-settings-status-row {
   display: flex;
   gap: 8px;
   align-items: center;
 }
-.pm-settings-member-row input[type='text'] {
+.pm-palette-row .setting-item-info {
+  display: none;
+}
+.pm-palette-row .setting-item-control {
   flex: 1;
+  flex-wrap: nowrap;
+  gap: 8px;
+  min-width: 0;
+}
+.pm-palette-row .pm-settings-status-icon {
+  flex: 0 0 72px;
+  width: 72px;
+}
+.pm-palette-row .pm-settings-status-label {
+  min-width: 0;
 }
 .pm-settings-status-icon {
   width: 90px;

--- a/src/ui/ModalFactory.ts
+++ b/src/ui/ModalFactory.ts
@@ -144,7 +144,7 @@ class ConfirmModal extends Modal {
 
     new ButtonComponent(btnRow)
       .setButtonText(this.confirmLabel)
-      .setWarning()
+      .setDestructive()
       .onClick(() => {
         this.finish(true)
         this.close()

--- a/src/ui/PaletteListEditor.ts
+++ b/src/ui/PaletteListEditor.ts
@@ -53,11 +53,51 @@ export function wireRowDragReorder<T>(row: HTMLElement, index: number, items: T[
   })
 }
 
-interface PaletteEntry {
+export interface PaletteEntry {
   id: string
   label: string
   color: string
   icon: string
+}
+
+/**
+ * The icon, label, and color inputs shared by the project modal's palette rows
+ * and the plugin settings pages. Appends to `parent` in that order.
+ */
+export function renderPaletteFields(parent: HTMLElement, app: App, item: PaletteEntry, onChanged: () => void): void {
+  const icon = parent.createEl('input', { type: 'text', value: item.icon })
+  icon.addClass('pm-settings-status-icon')
+  icon.placeholder = 'Icon'
+  attachIconSuggest(app, icon)
+  icon.addEventListener('change', () => {
+    item.icon = icon.value
+    onChanged()
+  })
+
+  const label = parent.createEl('input', { type: 'text', value: item.label })
+  label.addClass('pm-settings-status-label')
+  label.addEventListener('change', () => {
+    item.label = label.value
+    onChanged()
+  })
+
+  const color = parent.createEl('input', { type: 'color', value: item.color })
+  color.addEventListener('change', () => {
+    item.color = color.value
+    onChanged()
+  })
+}
+
+/** The per-status Done checkbox, marking which statuses count as complete. */
+export function renderStatusDoneToggle(parent: HTMLElement, status: StatusConfig, onChanged: () => void): void {
+  const wrapper = parent.createEl('label', { cls: 'pm-settings-complete-toggle' })
+  const checkbox = wrapper.createEl('input', { type: 'checkbox' })
+  checkbox.checked = status.complete
+  wrapper.createSpan({ text: 'Done', cls: 'pm-settings-complete-text' })
+  checkbox.addEventListener('change', () => {
+    status.complete = checkbox.checked
+    onChanged()
+  })
 }
 
 interface PaletteListEditorOpts<T extends PaletteEntry> {
@@ -90,30 +130,7 @@ function renderPaletteListEditor<T extends PaletteEntry>(container: HTMLElement,
       rerender()
     })
 
-    // Icon input: emoji or a Lucide icon id (with suggestions)
-    const icon = row.createEl('input', { type: 'text', value: item.icon })
-    icon.addClass('pm-settings-status-icon')
-    icon.placeholder = ''
-    attachIconSuggest(opts.app, icon)
-    icon.addEventListener('change', () => {
-      item.icon = icon.value
-      opts.onChanged()
-    })
-
-    // Label input
-    const label = row.createEl('input', { type: 'text', value: item.label })
-    label.addClass('pm-settings-status-label')
-    label.addEventListener('change', () => {
-      item.label = label.value
-      opts.onChanged()
-    })
-
-    // Color picker
-    const color = row.createEl('input', { type: 'color', value: item.color })
-    color.addEventListener('change', () => {
-      item.color = color.value
-      opts.onChanged()
-    })
+    renderPaletteFields(row, opts.app, item, opts.onChanged)
 
     opts.renderExtra?.(row, item)
 
@@ -148,16 +165,7 @@ export function renderStatusListEditor(container: HTMLElement, opts: StatusListE
     onChanged: opts.onChanged,
     onDeleted: opts.onDeleted,
     minOneMessage: 'You must have at least one status.',
-    renderExtra: (row, status) => {
-      const completeLabel = row.createEl('label', { cls: 'pm-settings-complete-toggle' })
-      const checkbox = completeLabel.createEl('input', { type: 'checkbox' })
-      checkbox.checked = status.complete
-      completeLabel.createSpan({ text: 'Done', cls: 'pm-settings-complete-text' })
-      checkbox.addEventListener('change', () => {
-        status.complete = checkbox.checked
-        opts.onChanged()
-      })
-    }
+    renderExtra: (row, status) => renderStatusDoneToggle(row, status, opts.onChanged)
   })
 }
 

--- a/src/views/table/BulkActionBar.ts
+++ b/src/views/table/BulkActionBar.ts
@@ -212,7 +212,7 @@ function updateBarContent(bar: HTMLElement, ctx: TableContext, onAction: (a: Bul
   // Delete button
   new ButtonComponent(left)
     .setButtonText('Delete')
-    .setWarning()
+    .setDestructive()
     .onClick(() => onAction({ type: 'delete' }))
 
   // Right section: clear selection


### PR DESCRIPTION
The settings tab is now defined declaratively, so it renders like Obsidian's own tabs and its settings turn up in the 1.13 settings search. Settings are grouped by area instead of stacked flat, and statuses, priorities, team members, and TaskNotes each moved to their own page. The TaskNotes page reports how many entries differ before you import.

Obsidian 1.13 deprecated `display()` and only indexes tabs that implement `getSettingDefinitions()`, so without this the plugin is invisible to settings search. Sub-pages have no pre-1.13 equivalent, hence `minAppVersion` 1.13.0.

Bumping the obsidian types to 1.13.1 also deprecated `setWarning()`, which `check:submission` treats as an error; both call sites now use `setDestructive()`.