### PR TITLE
keep one project instance per file and notify views of changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A change made in one view of a project was undone by the next click in another view of the same project ([#173](https://github.com/StepanKropachev/obsidian-pm/issues/173))
+- A project open in two views showed the older state in one of them ([#173](https://github.com/StepanKropachev/obsidian-pm/issues/173))
+- A task edited in the task editor lost changes made to it elsewhere while the editor was open
+- Edits to a project file made outside the plugin reached an open project view only after reopening it
 - The sort arrow in the table stayed on the column that was sorted before
 - Start and completed dates were labelled overdue in the task editor ([#156](https://github.com/StepanKropachev/obsidian-pm/issues/156))
 - The due date of a done task was labelled overdue in the task editor ([#156](https://github.com/StepanKropachev/obsidian-pm/issues/156))

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,7 @@ export default class PMPlugin extends Plugin {
   async onload(): Promise<void> {
     await this.loadSettings()
     this.store = new ProjectStore(this.app, () => this.settings)
-    this.store.registerCacheInvalidation(this)
+    this.store.registerVaultSync(this)
     this.notifier = new Notifier(this)
     this.router = new PMViewRouter(this)
 

--- a/src/modals/ProjectModal.ts
+++ b/src/modals/ProjectModal.ts
@@ -1,7 +1,6 @@
 import { App, ButtonComponent, Modal } from 'obsidian'
 import type PMPlugin from '../main'
-import { type Project, type ProjectConfig, type CustomFieldDef, makeId, makeProject } from '../types'
-import { rebuildTaskIndex } from '../store'
+import { type Project, type ProjectConfig, type ProjectPatch, type CustomFieldDef, makeId, makeProject } from '../types'
 import { safeAsync } from '../utils'
 import { renderAddButton } from '../ui/composites/addButton'
 import { Avatar } from '../ui/primitives/Avatar'
@@ -23,34 +22,60 @@ const PROJECT_COLORS = [
 
 const PROJECT_ICONS = ['📋', '🚀', '💡', '🎯', '🔬', '🏗', '📊', '🎨', '📱', '🛠', '📝', '⚡']
 
+/** The project fields this modal edits. Tasks and saved views are not among them. */
+interface ProjectDraft {
+  title: string
+  description: string
+  color: string
+  icon: string
+  customFields: CustomFieldDef[]
+  teamMembers: string[]
+  config: ProjectConfig | undefined
+}
+
+function draftOf(project: Project): ProjectDraft {
+  const { title, description, color, icon, customFields, teamMembers, config } = project
+  const draft = { title, description, color, icon, customFields, teamMembers, config }
+  return JSON.parse(JSON.stringify(draft)) as ProjectDraft
+}
+
 /**
  * Project create/edit modal.
  *
- * Obsidian renders modals outside `.pm-root` in the DOM. We apply `.pm-modal`
- * to re-declare `--pm-*` CSS variables, then use CSS classes from styles.css.
- * Remaining inline styles are only for dynamic runtime values (computed colors,
- * avatar hashes, display toggles) that cannot be expressed in static CSS.
+ * Edits a draft of the project's own fields, never the project itself, and
+ * saves only what changed. Obsidian renders modals outside `.pm-root` in the
+ * DOM. We apply `.pm-modal` to re-declare `--pm-*` CSS variables, then use CSS
+ * classes from styles.css. Remaining inline styles are only for dynamic runtime
+ * values (computed colors, avatar hashes, display toggles) that cannot be
+ * expressed in static CSS.
  */
 export class ProjectModal extends Modal {
-  private project: Project
+  private draft: ProjectDraft
+  private original: ProjectDraft
   private isNew: boolean
 
   constructor(
     app: App,
     private plugin: PMPlugin,
-    existingProject: Project | null,
+    private existingProject: Project | null,
     private onSave: (project: Project) => void | Promise<void>
   ) {
     super(app)
-    if (existingProject) {
-      this.project = JSON.parse(JSON.stringify(existingProject)) as Project
-      // The JSON round-trip turns the taskIndex Map into a plain object.
-      rebuildTaskIndex(this.project)
-      this.isNew = false
-    } else {
-      this.project = makeProject('New Project', '')
-      this.isNew = true
+    this.isNew = existingProject === null
+    const base = existingProject ?? makeProject('New Project', '')
+    this.draft = draftOf(base)
+    this.original = draftOf(base)
+  }
+
+  /** Only the fields the user actually changed, so the form can't write back anything it never showed. */
+  private changedFields(): ProjectPatch {
+    const patch: ProjectPatch = {}
+    for (const key of Object.keys(this.draft) as (keyof ProjectDraft)[]) {
+      if (JSON.stringify(this.draft[key]) !== JSON.stringify(this.original[key])) {
+        Object.assign(patch, { [key]: this.draft[key] })
+      }
     }
+    return patch
   }
 
   onOpen(): void {
@@ -79,14 +104,14 @@ export class ProjectModal extends Modal {
 
     // Icon picker
     const iconWrap = topRow.createDiv('pm-icon-picker')
-    const iconBtn = iconWrap.createEl('button', { text: this.project.icon, cls: 'pm-icon-picker-btn' })
+    const iconBtn = iconWrap.createEl('button', { text: this.draft.icon, cls: 'pm-icon-picker-btn' })
 
     const iconGrid = iconWrap.createDiv('pm-icon-grid')
     iconGrid.addClass('pm-hidden')
     for (const emoji of PROJECT_ICONS) {
       const btn = iconGrid.createEl('button', { text: emoji, cls: 'pm-icon-option' })
       btn.addEventListener('click', () => {
-        this.project.icon = emoji
+        this.draft.icon = emoji
         iconBtn.textContent = emoji
         iconGrid.addClass('pm-hidden')
       })
@@ -100,12 +125,12 @@ export class ProjectModal extends Modal {
     titleWrap.createEl('label', { text: 'Project name', cls: 'pm-label' })
     const titleInput = titleWrap.createEl('input', {
       type: 'text',
-      value: this.project.title,
+      value: this.draft.title,
       cls: 'pm-input pm-input--lg'
     })
     titleInput.placeholder = 'My awesome project'
     titleInput.addEventListener('input', () => {
-      this.project.title = titleInput.value
+      this.draft.title = titleInput.value
     })
     window.setTimeout(() => {
       titleInput.focus()
@@ -119,18 +144,18 @@ export class ProjectModal extends Modal {
     for (const color of PROJECT_COLORS) {
       const swatch = colorPalette.createEl('button', { cls: 'pm-color-swatch' })
       swatch.setCssStyles({ background: color })
-      if (color === this.project.color) swatch.addClass('pm-color-swatch--selected')
+      if (color === this.draft.color) swatch.addClass('pm-color-swatch--selected')
       swatch.addEventListener('click', () => {
-        this.project.color = color
+        this.draft.color = color
         colorPalette.querySelectorAll('.pm-color-swatch').forEach((s) => s.removeClass('pm-color-swatch--selected'))
         swatch.addClass('pm-color-swatch--selected')
       })
     }
     const customColor = colorPalette.createEl('input', { type: 'color', cls: 'pm-color-custom' })
-    customColor.value = this.project.color
+    customColor.value = this.draft.color
     customColor.title = 'Custom color'
     customColor.addEventListener('change', () => {
-      this.project.color = customColor.value
+      this.draft.color = customColor.value
       colorPalette.querySelectorAll('.pm-color-swatch').forEach((s) => s.removeClass('pm-color-swatch--selected'))
     })
 
@@ -139,9 +164,9 @@ export class ProjectModal extends Modal {
     descSection.createEl('label', { text: 'Description', cls: 'pm-label' })
     const descArea = descSection.createEl('textarea', { cls: 'pm-input pm-project-desc' })
     descArea.placeholder = 'What is this project about?'
-    descArea.value = this.project.description
+    descArea.value = this.draft.description
     descArea.addEventListener('input', () => {
-      this.project.description = descArea.value
+      this.draft.description = descArea.value
     })
 
     // ── Team members ──────────────────────────────────────────────────────────
@@ -150,30 +175,30 @@ export class ProjectModal extends Modal {
     const memberWrap = memberSection.createDiv('pm-member-list')
     const renderMembers = () => {
       memberWrap.empty()
-      for (let i = 0; i < this.project.teamMembers.length; i++) {
+      for (let i = 0; i < this.draft.teamMembers.length; i++) {
         const row = memberWrap.createDiv('pm-member-row')
-        const name = this.project.teamMembers[i] || '?'
+        const name = this.draft.teamMembers[i] || '?'
         new Avatar(row).setName(name)
         const input = row.createEl('input', {
           type: 'text',
-          value: this.project.teamMembers[i],
+          value: this.draft.teamMembers[i],
           cls: 'pm-input pm-member-input'
         })
         input.placeholder = 'Name'
         input.addEventListener('change', () => {
-          this.project.teamMembers[i] = input.value
+          this.draft.teamMembers[i] = input.value
           renderMembers()
         })
         new IconButton(row)
           .setIcon('x')
           .setTooltip('Remove member')
           .onClick(() => {
-            this.project.teamMembers.splice(i, 1)
+            this.draft.teamMembers.splice(i, 1)
             renderMembers()
           })
       }
       renderAddButton(memberWrap, 'Add member', () => {
-        this.project.teamMembers.push('')
+        this.draft.teamMembers.push('')
         renderMembers()
         window.setTimeout(() => {
           const inputs = memberWrap.querySelectorAll('input')
@@ -192,11 +217,11 @@ export class ProjectModal extends Modal {
     const cfList = cfSection.createDiv('pm-cf-list')
     const renderCFs = () => {
       cfList.empty()
-      for (let i = 0; i < this.project.customFields.length; i++) {
-        this.renderCustomFieldEditor(cfList, this.project.customFields[i], i, renderCFs)
+      for (let i = 0; i < this.draft.customFields.length; i++) {
+        this.renderCustomFieldEditor(cfList, this.draft.customFields[i], i, renderCFs)
       }
       renderAddButton(cfList, 'Add custom field', () => {
-        this.project.customFields.push({
+        this.draft.customFields.push({
           id: makeId(),
           name: 'New Field',
           type: 'text',
@@ -213,7 +238,7 @@ export class ProjectModal extends Modal {
       hint: 'The workflow for this project',
       toggleLabel: 'Use custom statuses instead of the global ones',
       addLabel: 'Add status',
-      get: () => this.project.config?.statuses,
+      get: () => this.draft.config?.statuses,
       set: (statuses) => this.patchConfig('statuses', statuses),
       copyGlobal: () => this.plugin.settings.statuses.map((s) => ({ ...s })),
       makeEntry: () => ({
@@ -238,7 +263,7 @@ export class ProjectModal extends Modal {
       hint: 'The priority scale for this project',
       toggleLabel: 'Use custom priorities instead of the global ones',
       addLabel: 'Add priority',
-      get: () => this.project.config?.priorities,
+      get: () => this.draft.config?.priorities,
       set: (priorities) => this.patchConfig('priorities', priorities),
       copyGlobal: () => this.plugin.settings.priorities.map((p) => ({ ...p })),
       makeEntry: () => ({
@@ -301,15 +326,19 @@ export class ProjectModal extends Modal {
             titleInput.focus()
             return
           }
-          this.project.title = title
+          this.draft.title = title
 
-          if (this.isNew) {
-            this.project.filePath = `${this.plugin.settings.projectsFolder}/${title.replace(/[\\/:*?"<>|]/g, '-')}.md`
-            await this.plugin.store.ensureFolder(this.plugin.settings.projectsFolder)
+          const folder = this.plugin.settings.projectsFolder
+          if (!this.existingProject) {
+            const project = makeProject(title, `${folder}/${title.replace(/[\\/:*?"<>|]/g, '-')}.md`)
+            Object.assign(project, this.draft)
+            await this.plugin.store.ensureFolder(folder)
+            await this.plugin.store.saveProject(project)
+            await this.onSave(project)
+          } else {
+            await this.plugin.store.updateProject(this.existingProject, this.changedFields())
+            await this.onSave(this.existingProject)
           }
-
-          await this.plugin.store.saveProject(this.project)
-          await this.onSave(this.project)
           this.close()
         })
       )
@@ -317,8 +346,8 @@ export class ProjectModal extends Modal {
 
   /** Set or clear one override; the config object is dropped entirely when its last field clears. */
   private patchConfig<K extends keyof ProjectConfig>(key: K, value: ProjectConfig[K] | undefined): void {
-    const entries = Object.entries({ ...this.project.config, [key]: value }).filter(([, v]) => v !== undefined)
-    this.project.config = entries.length ? Object.fromEntries(entries) : undefined
+    const entries = Object.entries({ ...this.draft.config, [key]: value }).filter(([, v]) => v !== undefined)
+    this.draft.config = entries.length ? Object.fromEntries(entries) : undefined
   }
 
   private renderPaletteOverride<T>(
@@ -382,7 +411,7 @@ export class ProjectModal extends Modal {
     const row = grid.createDiv('pm-config-override-row')
     row.createEl('label', { text: label, cls: 'pm-label' })
     const select = row.createEl('select', { cls: 'pm-input pm-select' })
-    const current = this.project.config?.[key]
+    const current = this.draft.config?.[key]
     const inherit = select.createEl('option', { value: '', text: 'Use global' })
     inherit.selected = current === undefined
     options.forEach((opt, i) => {
@@ -409,7 +438,7 @@ export class ProjectModal extends Modal {
     })
     nameInput.placeholder = 'Field name'
     nameInput.addEventListener('change', () => {
-      this.project.customFields[index].name = nameInput.value
+      this.draft.customFields[index].name = nameInput.value
     })
 
     const typeSelect = row.createEl('select', { cls: 'pm-input pm-select pm-cf-type' })
@@ -428,7 +457,7 @@ export class ProjectModal extends Modal {
       if (val === cf.type) opt.selected = true
     }
     typeSelect.addEventListener('change', () => {
-      this.project.customFields[index].type = typeSelect.value as CustomFieldDef['type']
+      this.draft.customFields[index].type = typeSelect.value as CustomFieldDef['type']
       rerender()
     })
 
@@ -436,7 +465,7 @@ export class ProjectModal extends Modal {
       .setIcon('x')
       .setTooltip('Remove field')
       .onClick(() => {
-        this.project.customFields.splice(index, 1)
+        this.draft.customFields.splice(index, 1)
         rerender()
       })
 

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -23,6 +23,8 @@ import { NoteLinkSuggest } from './NoteLinkSuggest'
 
 export class TaskModal extends Modal {
   private task: Task
+  /** The task as it was when the editor opened, to diff against on save. */
+  private original: Task
   private isNew: boolean
   private originalParentId: string | null
   private cancelled = false
@@ -61,6 +63,7 @@ export class TaskModal extends Modal {
       })
       this.isNew = true
     }
+    this.original = JSON.parse(JSON.stringify(this.task)) as Task
     this.originalParentId = this.parentId
   }
 
@@ -130,14 +133,30 @@ export class TaskModal extends Modal {
     }
   }
 
+  /**
+   * Only the fields the user actually changed. The editor works on a copy taken
+   * when it opened, so saving the whole task would write its view of every other
+   * field back over anything that moved in the meantime.
+   */
+  private changedFields(): Partial<Task> {
+    const patch: Partial<Task> = {}
+    for (const key of Object.keys(this.task) as (keyof Task)[]) {
+      if (JSON.stringify(this.task[key]) !== JSON.stringify(this.original[key])) {
+        Object.assign(patch, { [key]: this.task[key] })
+      }
+    }
+    return patch
+  }
+
   private async runPersist(): Promise<void> {
     if (this.isNew) {
       await this.plugin.store.insertTask(this.project, this.task, this.parentId)
-    } else if (this.parentId !== this.originalParentId) {
-      await this.plugin.store.updateTask(this.project, this.task.id, this.task)
-      await this.plugin.store.moveTask(this.project, this.task.id, this.parentId)
     } else {
-      await this.plugin.store.updateTask(this.project, this.task.id, this.task)
+      const patch = this.changedFields()
+      const moved = this.parentId !== this.originalParentId
+      if (Object.keys(patch).length === 0 && !moved) return
+      await this.plugin.store.updateTask(this.project, this.task.id, patch)
+      if (moved) await this.plugin.store.moveTask(this.project, this.task.id, this.parentId)
     }
     await this.plugin.store.scheduleAfterChange(this.project, this.task.id)
     await this.onSave(this.task)

--- a/src/store/ArchiveOps.ts
+++ b/src/store/ArchiveOps.ts
@@ -13,8 +13,16 @@ function subtree(task: Task): Task[] {
   return [task, ...task.subtasks.flatMap(subtree)]
 }
 
+/** Records a path the plugin is about to write, so the move doesn't read back as an external change. */
+type MarkSelfWrite = (path: string) => void
+
 /** Move a task's file (and attachments) into `targetFolder`. Reports whether the file ended up there. */
-async function moveTaskFile(app: App, task: Task, targetFolder: string): Promise<boolean> {
+async function moveTaskFile(
+  app: App,
+  task: Task,
+  targetFolder: string,
+  markSelfWrite: MarkSelfWrite
+): Promise<boolean> {
   if (!task.filePath) return false
 
   const fileName = task.filePath.split('/').pop()
@@ -26,13 +34,22 @@ async function moveTaskFile(app: App, task: Task, targetFolder: string): Promise
   if (!(file instanceof TFile)) return false
 
   const oldPath = task.filePath
+  markSelfWrite(oldPath)
+  markSelfWrite(newPath)
+  markSelfWrite(oldPath.replace(/\.md$/, ''))
+  markSelfWrite(newPath.replace(/\.md$/, ''))
   await app.vault.rename(file, newPath)
   await moveTaskAttachmentFolder(app, oldPath, newPath)
   task.filePath = newPath
   return true
 }
 
-export async function archiveTask(app: App, project: Project, taskId: string): Promise<void> {
+export async function archiveTask(
+  app: App,
+  project: Project,
+  taskId: string,
+  markSelfWrite: MarkSelfWrite
+): Promise<void> {
   const task = findTaskById(project, taskId)
   if (!task) return
 
@@ -40,16 +57,21 @@ export async function archiveTask(app: App, project: Project, taskId: string): P
   await ensureFolder(app, archiveFolder)
 
   for (const t of subtree(task)) {
-    if (await moveTaskFile(app, t, archiveFolder)) t.archived = true
+    if (await moveTaskFile(app, t, archiveFolder, markSelfWrite)) t.archived = true
   }
 }
 
-export async function unarchiveTask(app: App, project: Project, taskId: string): Promise<void> {
+export async function unarchiveTask(
+  app: App,
+  project: Project,
+  taskId: string,
+  markSelfWrite: MarkSelfWrite
+): Promise<void> {
   const task = findTaskById(project, taskId)
   if (!task) return
 
   const taskFolder = normalizePath(projectTaskFolder(project))
   for (const t of subtree(task)) {
-    if (await moveTaskFile(app, t, taskFolder)) t.archived = false
+    if (await moveTaskFile(app, t, taskFolder, markSelfWrite)) t.archived = false
   }
 }

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -1,9 +1,17 @@
-import type { App } from 'obsidian'
+import type { App, Plugin } from 'obsidian'
 import { TFile } from 'obsidian'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { makeFakeApp, type FakeVault } from '../../test/fakeVault'
 import { today } from '../dates'
-import { DEFAULT_SETTINGS, makeTask, type PMSettings, type Project, type StatusConfig, type Task } from '../types'
+import {
+  DEFAULT_SETTINGS,
+  makeDefaultFilter,
+  makeTask,
+  type PMSettings,
+  type Project,
+  type StatusConfig,
+  type Task
+} from '../types'
 import { ProjectStore } from './ProjectStore'
 import { addDays } from './Scheduler'
 import { buildTaskIndex } from './TaskIndex'
@@ -28,6 +36,23 @@ function newStore(): { store: ProjectStore; vault: FakeVault; app: App } {
   return { store, vault, app: app as unknown as App }
 }
 
+function fileAt(app: App, path: string): TFile {
+  const file = app.vault.getAbstractFileByPath(path)
+  if (!(file instanceof TFile)) throw new Error(`no file at ${path}`)
+  return file
+}
+
+async function readStatus(app: App, path: string): Promise<string> {
+  const content = await app.vault.cachedRead(fileAt(app, path))
+  return (/^status:\s*(.*)$/m.exec(content)?.[1] ?? '').replace(/"/g, '')
+}
+
+/** An edit the plugin did not make, e.g. from another device or a markdown tab. */
+async function editOnDisk(app: App, path: string, edit: (content: string) => string): Promise<void> {
+  const file = fileAt(app, path)
+  await app.vault.modify(file, edit(await app.vault.cachedRead(file)))
+}
+
 async function addNamed(
   store: ProjectStore,
   project: Parameters<ProjectStore['insertTask']>[0],
@@ -39,57 +64,129 @@ async function addNamed(
   return task
 }
 
-describe('ProjectStore self-write tracking', () => {
-  it('marks the project file as self-written after save', async () => {
-    const { store, vault } = newStore()
-    const project = await store.createProject('Self', 'Projects')
-    expect(store.consumeSelfWrite(project.filePath)).toBe(true) // creates mark too (cache invalidation peeks them)
-
-    await store.updateTask(project, 'nope', {}) // no-op (id not found)
-    // Project file is rewritten on every saveProject, which marks it.
-    expect(store.consumeSelfWrite(project.filePath)).toBe(true)
-    expect(vault.modifyCount.get(project.filePath)).toBe(1)
+describe('ProjectStore live project instance', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
-  it('marks task file paths as self-written when modified', async () => {
-    const { store, vault } = newStore()
-    const project = await store.createProject('T', 'Projects')
-    const task = await addNamed(store, project, 'Solo')
-    vault.resetCounts()
+  it('gives concurrent loaders the same instance', async () => {
+    const { store, app } = newStore()
+    const project = await store.createProject('Race', 'Projects')
+    await addNamed(store, project, 'Card')
 
-    await store.updateTask(project, task.id, { status: 'in-progress' })
+    // A second store stands in for a cold start: a view, the dashboard and the
+    // notifier all asking for the same project at once.
+    const cold = new ProjectStore(app, () => SETTINGS)
+    const file = fileAt(app, project.filePath)
+    const [a, b] = await Promise.all([cold.loadProject(file), cold.loadProject(file)])
 
-    expect(store.consumeSelfWrite(expectDefined(task.filePath))).toBe(true)
-    expect(store.consumeSelfWrite(expectDefined(task.filePath))).toBe(false) // single-use
+    expect(a).not.toBeNull()
+    expect(a).toBe(b)
   })
 
-  it('marks both old and new path on title rename (modify new, trash old)', async () => {
-    const { store, vault } = newStore()
-    const project = await store.createProject('R', 'Projects')
-    const task = await addNamed(store, project, 'Before')
-    const oldPath = expectDefined(task.filePath)
-    vault.resetCounts()
+  it('keeps the instance holders already have when another copy is saved', async () => {
+    const { store, app } = newStore()
+    const project = await store.createProject('Held', 'Projects')
+    const task = await addNamed(store, project, 'Card')
+    const held = expectDefined(await store.loadProject(fileAt(app, project.filePath)))
 
-    await store.updateTask(project, task.id, { title: 'Renamed' })
+    // A detached copy, as a form working on its own draft would produce.
+    const copy = JSON.parse(JSON.stringify(held)) as Project
+    copy.taskIndex = buildTaskIndex(copy.tasks)
+    copy.title = 'Detached'
+    await store.saveProject(copy)
 
-    // The new path is created (marked for cache invalidation) and the old
-    // path is trashed (marked so the delete listener skips the reload).
-    expect(store.consumeSelfWrite(expectDefined(task.filePath))).toBe(true)
-    expect(store.consumeSelfWrite(oldPath)).toBe(true)
+    expect(await store.loadProject(fileAt(app, project.filePath))).toBe(held)
+
+    // The copy's stale tasks never become the live tree.
+    await store.updateTask(held, task.id, { status: 'done' })
+    await store.saveProject(copy)
+    expect(await readStatus(app, expectDefined(task.filePath))).toBe('done')
   })
 
-  it('treats markers older than the window as stale', async () => {
+  it('reloads an external edit into the instance holders have', async () => {
+    const { store, app } = newStore()
+    const plugin = { registerEvent: () => {}, register: () => {} } as unknown as Plugin
+    store.registerVaultSync(plugin)
+    const project = await store.createProject('Synced', 'Projects')
+    const task = await addNamed(store, project, 'Card')
+    const held = expectDefined(await store.loadProject(fileAt(app, project.filePath)))
+    const changes: string[] = []
+    store.onProjectChanged((path) => changes.push(path))
+    await vi.advanceTimersByTimeAsync(6000) // past the self-write window
+
+    await editOnDisk(app, expectDefined(task.filePath), (c) => c.replace('status: "todo"', 'status: "done"'))
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(expectDefined(findTask(held.tasks, task.id)).status).toBe('done')
+    expect(changes).toEqual([project.filePath])
+  })
+
+  it('does not reload its own writes', async () => {
+    const { store, app } = newStore()
+    const plugin = { registerEvent: () => {}, register: () => {} } as unknown as Plugin
+    store.registerVaultSync(plugin)
+    const project = await store.createProject('Quiet', 'Projects')
+    const task = await addNamed(store, project, 'Card')
+    const held = expectDefined(await store.loadProject(fileAt(app, project.filePath)))
+    const liveTask = expectDefined(findTask(held.tasks, task.id))
+
+    await store.updateTask(held, task.id, { status: 'in-progress' })
+    await vi.advanceTimersByTimeAsync(400)
+
+    // A reload would have replaced the task objects in the tree.
+    expect(findTask(held.tasks, task.id)).toBe(liveTask)
+  })
+
+  it('does not let one view revert a change made in another', async () => {
+    const { store, app } = newStore()
+    const project = await store.createProject('Two views', 'Projects')
+    const task = await addNamed(store, project, 'Card')
+    const taskPath = expectDefined(task.filePath)
+    const viewA = expectDefined(await store.loadProject(fileAt(app, project.filePath)))
+    const viewB = expectDefined(await store.loadProject(fileAt(app, project.filePath)))
+
+    await store.updateTask(viewA, task.id, { status: 'done' })
+    await store.updateTask(viewB, task.id, { priority: 'high' })
+
+    expect(await readStatus(app, taskPath)).toBe('done')
+  })
+
+  it('notifies on every change, whoever made it', async () => {
     const { store } = newStore()
+    const project = await store.createProject('Notified', 'Projects')
+    const changes: string[] = []
+    const unsubscribe = store.onProjectChanged((path) => changes.push(path))
 
-    try {
-      vi.useFakeTimers()
-      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
-      const project = await store.createProject('Stale', 'Projects')
-      vi.setSystemTime(new Date('2026-01-01T00:00:05.001Z')) // > 5s after marker
-      expect(store.consumeSelfWrite(project.filePath)).toBe(false)
-    } finally {
-      vi.useRealTimers()
-    }
+    const task = await addNamed(store, project, 'Card')
+    await store.updateTask(project, task.id, { status: 'done' })
+    expect(changes).toEqual([project.filePath, project.filePath])
+
+    unsubscribe()
+    await store.updateTask(project, task.id, { status: 'todo' })
+    expect(changes).toHaveLength(2)
+  })
+})
+
+describe('ProjectStore project metadata patch', () => {
+  it('writes only the patched fields', async () => {
+    const { store, app } = newStore()
+    const project = await store.createProject('Patch', 'Projects')
+    await addNamed(store, project, 'Card')
+    project.savedViews = [{ id: 'v1', name: 'Mine', filter: makeDefaultFilter(), sortKey: 'status', sortDir: 'asc' }]
+    await store.saveProject(project)
+
+    await store.updateProject(project, { title: 'Renamed', color: '#123456' })
+
+    expect(project.title).toBe('Renamed')
+    expect(project.savedViews).toHaveLength(1)
+    const content = await app.vault.cachedRead(fileAt(app, project.filePath))
+    expect(content).toContain('title: "Renamed"')
+    expect(content).toContain('color: "#123456"')
+    expect(content).toContain('Mine')
   })
 })
 
@@ -866,23 +963,6 @@ describe('ProjectStore project cache', () => {
 
     expect(first).toBe(project)
     expect(second).toBe(first)
-  })
-
-  it('saving a cloned project makes the clone the canonical cached copy', async () => {
-    const { store, vault } = newStore()
-    const project = await store.createProject('Clone me', 'Projects')
-    await addNamed(store, project, 'task')
-
-    // Same shape as ProjectModal: JSON round-trip plus index rebuild.
-    const clone = JSON.parse(JSON.stringify(project)) as typeof project
-    clone.taskIndex = buildTaskIndex(clone.tasks)
-    clone.description = 'edited in modal'
-    await store.saveProject(clone)
-
-    const file = vault.getAbstractFileByPath(project.filePath)
-    if (!(file instanceof TFile)) throw new Error('project file missing')
-    const reloaded = await store.loadProject(file)
-    expect(reloaded).toBe(clone)
   })
 })
 

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -1,6 +1,6 @@
 import type { Plugin, TAbstractFile } from 'obsidian'
 import { App, Notice, TFile, TFolder, normalizePath } from 'obsidian'
-import type { PMSettings, Project, ResolvedProjectConfig, StatusConfig, Task } from '../types'
+import type { PMSettings, Project, ProjectPatch, ResolvedProjectConfig, StatusConfig, Task } from '../types'
 import { DEFAULT_SETTINGS, makeProject, makeTask } from '../types'
 import { today } from '../dates'
 import { isTerminalStatus } from '../utils'
@@ -118,18 +118,25 @@ export class ProjectStore implements TaskSource {
   private hydratedBodies = new WeakSet<Task | Project>()
 
   /**
-   * Projects already loaded this session, keyed by file path. The cached
-   * object is the in-memory canonical copy: mutators keep it current, every
-   * successful save re-points the entry at the saved object, and external
-   * (non-self-write) vault events drop the entry so the next load re-reads.
+   * The one live Project per file path, keyed by path and held as the loading
+   * promise so concurrent loads collapse onto a single instance. Everything
+   * that holds a project holds this object: mutators keep it current, an
+   * external change reloads into it, and it is only ever replaced when the
+   * project is deleted.
    */
-  private projectCache = new Map<string, Project>()
+  private projectCache = new Map<string, Promise<Project | null>>()
+
+  /** Notified after any change to a project, whoever made it. */
+  private changeHandlers = new Set<(path: string) => void>()
+
+  /** Pending external-change reloads, keyed by project path. */
+  private reloadTimers = new Map<string, number>()
+  private static readonly RELOAD_DEBOUNCE_MS = 300
 
   /**
-   * Paths we've just written, created, or trashed ourselves, timestamped.
-   * The view's modify/delete listeners consume markers to skip reloads; the
-   * cache invalidation listeners peek at them without consuming.
-   * Stale entries (older than the window) are treated as never-marked.
+   * Paths we've just written, created, or trashed ourselves, timestamped. The
+   * vault listeners check them so our own writes don't come back as external
+   * changes. Stale entries (older than the window) are treated as never-marked.
    */
   private selfWrites = new Map<string, number>()
   private static readonly SELF_WRITE_WINDOW_MS = 5000
@@ -184,7 +191,8 @@ export class ProjectStore implements TaskSource {
   // ─── Self-write tracking ──────────────────────────────────────────────────
 
   private markSelfWrite(path: string): void {
-    // Created files have no consumer, so sweep expired markers before they pile up.
+    // Markers are only ever read within their window, so sweep the expired ones
+    // before they pile up.
     if (this.selfWrites.size > 256) {
       const cutoff = Date.now() - ProjectStore.SELF_WRITE_WINDOW_MS
       for (const [p, t] of this.selfWrites) {
@@ -194,46 +202,112 @@ export class ProjectStore implements TaskSource {
     this.selfWrites.set(path, Date.now())
   }
 
-  /** Returns true if we wrote this path recently. Consumes the marker either way. */
-  consumeSelfWrite(path: string): boolean {
-    const ts = this.selfWrites.get(path)
-    if (ts === undefined) return false
-    this.selfWrites.delete(path)
-    return Date.now() - ts < ProjectStore.SELF_WRITE_WINDOW_MS
-  }
-
-  /** Like consumeSelfWrite, but non-destructive — view listeners still need the marker. */
   private peekSelfWrite(path: string): boolean {
     const ts = this.selfWrites.get(path)
     return ts !== undefined && Date.now() - ts < ProjectStore.SELF_WRITE_WINDOW_MS
   }
 
+  // ─── Change notification ──────────────────────────────────────────────────
+
+  /** Subscribe to project changes. Returns the unsubscribe function. */
+  onProjectChanged(handler: (path: string) => void): () => void {
+    this.changeHandlers.add(handler)
+    return () => this.changeHandlers.delete(handler)
+  }
+
+  private emitChange(path: string): void {
+    for (const handler of this.changeHandlers) handler(path)
+  }
+
   /**
-   * Wire vault events that drop cached projects on external changes. Call once
-   * from onload, before any view registers listeners — these must run first so
-   * a view's reload after an external edit misses the stale cache entry.
+   * Wire the vault events that keep loaded projects in step with the files.
+   * Call once from onload. This is the only place the plugin listens for
+   * changes to project files.
    */
-  registerCacheInvalidation(plugin: Plugin): void {
-    const onChange = (file: TAbstractFile): void => this.invalidateForPath(file.path)
+  registerVaultSync(plugin: Plugin): void {
+    const onChange = (file: TAbstractFile): void => this.syncPath(file.path)
     plugin.registerEvent(this.app.vault.on('create', onChange))
     plugin.registerEvent(this.app.vault.on('modify', onChange))
     plugin.registerEvent(this.app.vault.on('delete', onChange))
     plugin.registerEvent(
       this.app.vault.on('rename', (file, oldPath) => {
-        this.invalidateForPath(file.path)
-        this.invalidateForPath(oldPath)
+        this.syncPath(file.path)
+        this.syncPath(oldPath)
       })
     )
+    plugin.register(() => {
+      for (const timer of this.reloadTimers.values()) window.clearTimeout(timer)
+      this.reloadTimers.clear()
+    })
   }
 
-  private invalidateForPath(path: string): void {
+  /** An external write landed. Reload the live project so every holder sees it. */
+  private syncPath(path: string): void {
     if (this.projectCache.size === 0) return
     if (this.peekSelfWrite(path)) return
     for (const key of this.projectCache.keys()) {
       if (path === key || path.startsWith(key.replace(/\.md$/, '_tasks') + '/')) {
-        this.projectCache.delete(key)
+        const pending = this.reloadTimers.get(key)
+        if (pending !== undefined) window.clearTimeout(pending)
+        this.reloadTimers.set(
+          key,
+          window.setTimeout(() => {
+            this.reloadTimers.delete(key)
+            void this.reloadProject(key)
+          }, ProjectStore.RELOAD_DEBOUNCE_MS)
+        )
       }
     }
+  }
+
+  private async reloadProject(path: string): Promise<void> {
+    const live = await this.projectCache.get(path)
+    if (!live) return
+    await this.queue(path, async () => {
+      const file = this.app.vault.getAbstractFileByPath(path)
+      if (!(file instanceof TFile)) {
+        this.projectCache.delete(path)
+        this.emitChange(path)
+        return
+      }
+      const fresh = await this.readProject(file)
+      if (!fresh) return
+      this.adopt(live, fresh)
+      this.emitChange(path)
+    })
+  }
+
+  /**
+   * Copy a freshly read project onto the live instance. Views, modals and the
+   * notifier all hold that object, so a reload updates it in place rather than
+   * handing out a second copy of the same project.
+   */
+  private adopt(live: Project, fresh: Project): void {
+    const { taskIndex, ...fields } = fresh
+    Object.assign(live, fields)
+    rebuildTaskIndex(live)
+    if (this.hydratedBodies.has(fresh)) this.hydratedBodies.add(live)
+    else this.hydratedBodies.delete(live)
+  }
+
+  /** Serialize work on one project: saves and reloads never interleave. */
+  private queue<T>(key: string, work: () => Promise<T>): Promise<T> {
+    const prev = this.saveQueues.get(key) ?? Promise.resolve()
+    const next = (async () => {
+      await prev
+      return work()
+    })()
+    this.saveQueues.set(
+      key,
+      (async () => {
+        try {
+          await next
+        } catch {
+          // swallow so the next queued item still runs after a failure
+        }
+      })()
+    )
+    return next
   }
 
   // ─── Folder helpers ────────────────────────────────────────────────────────
@@ -264,9 +338,21 @@ export class ProjectStore implements TaskSource {
     return projects.sort((a, b) => a.title.localeCompare(b.title))
   }
 
+  /**
+   * The live project for a file. Concurrent callers share the one in-flight
+   * read, so a project never exists twice in memory.
+   */
   async loadProject(file: TFile): Promise<Project | null> {
-    const cachedProject = this.projectCache.get(file.path)
-    if (cachedProject) return cachedProject
+    const live = this.projectCache.get(file.path)
+    if (live) return live
+    const loading = this.readProject(file)
+    this.projectCache.set(file.path, loading)
+    const project = await loading
+    if (!project) this.projectCache.delete(file.path)
+    return project
+  }
+
+  private async readProject(file: TFile): Promise<Project | null> {
     try {
       // Fast path: pull frontmatter from Obsidian's metadataCache, skip the disk read.
       // Only safe for new-format projects (taskIds in frontmatter, no embedded tasks).
@@ -309,7 +395,6 @@ export class ProjectStore implements TaskSource {
         this.clearDirty(project)
       }
 
-      this.projectCache.set(file.path, project)
       return project
     } catch (e) {
       console.error(`[PM] Failed to load project ${file.path}:`, e)
@@ -470,23 +555,18 @@ export class ProjectStore implements TaskSource {
   // ─── Save ──────────────────────────────────────────────────────────────────
 
   async saveProject(project: Project): Promise<void> {
-    const key = project.filePath
-    const prev = this.saveQueues.get(key) ?? Promise.resolve()
-    const next = (async () => {
-      await prev
-      await this.doSaveProject(project)
-    })()
-    this.saveQueues.set(
-      key,
-      (async () => {
-        try {
-          await next
-        } catch {
-          // swallow so the next queued save still runs after a failure
-        }
-      })()
-    )
-    return next
+    return this.queue(project.filePath, () => this.doSaveProject(project))
+  }
+
+  /**
+   * Apply a metadata patch to the live project and save it. The project editor
+   * works on a draft; only the fields it changed come back here, so a stale
+   * draft can't overwrite anything else about the project.
+   */
+  async updateProject(project: Project, patch: ProjectPatch): Promise<void> {
+    Object.assign(project, patch)
+    if (patch.description !== undefined) this.hydratedBodies.add(project)
+    await this.saveProject(project)
   }
 
   private async doSaveProject(project: Project): Promise<void> {
@@ -523,9 +603,12 @@ export class ProjectStore implements TaskSource {
         await this.app.vault.create(project.filePath, content)
         this.hydratedBodies.add(project)
       }
-      // The object we just saved is the canonical in-memory copy (it may be a
-      // clone of a previously cached project, e.g. from the project modal).
-      this.projectCache.set(project.filePath, project)
+      // A project saved before it was ever loaded (creation, migration) becomes
+      // the live instance. A save never replaces an instance others already hold.
+      if (!this.projectCache.has(project.filePath)) {
+        this.projectCache.set(project.filePath, Promise.resolve(project))
+      }
+      this.emitChange(project.filePath)
     } catch (e) {
       // Save failed. Merge the snapshot back so the next save retries.
       for (const [id, kind] of dirty) this.markDirty(project, [id], kind)
@@ -870,10 +953,6 @@ export class ProjectStore implements TaskSource {
    * `completed` away from the task's current value (a manual edit in the modal, or
    * an import) wins and is left untouched; otherwise crossing the
    * complete/incomplete boundary stamps today's date or clears it.
-   *
-   * The modal saves the whole task as the patch, so `patch.completed` is almost
-   * always present and equal to the stored value — comparing against the task,
-   * not just checking presence, is what lets auto-stamping fire from the modal.
    */
   private stampCompletion(project: Project, task: Task, patch: Partial<Task>): void {
     if (patch.status === undefined) return
@@ -1025,11 +1104,13 @@ export class ProjectStore implements TaskSource {
   }
 
   async archiveTask(project: Project, taskId: string): Promise<void> {
-    await doArchiveTask(this.app, project, taskId)
+    await doArchiveTask(this.app, project, taskId, (path) => this.markSelfWrite(path))
+    await this.saveProject(project)
   }
 
   async unarchiveTask(project: Project, taskId: string): Promise<void> {
-    await doUnarchiveTask(this.app, project, taskId)
+    await doUnarchiveTask(this.app, project, taskId, (path) => this.markSelfWrite(path))
+    await this.saveProject(project)
   }
 
   async deleteTask(project: Project, taskId: string): Promise<void> {
@@ -1109,6 +1190,7 @@ export class ProjectStore implements TaskSource {
     this.clearDirty(project)
     this.saveQueues.delete(project.filePath)
     this.projectCache.delete(project.filePath)
+    this.emitChange(project.filePath)
   }
 
   private async deleteFolderRecursive(folder: TFolder): Promise<void> {

--- a/src/store/TaskSource.ts
+++ b/src/store/TaskSource.ts
@@ -1,5 +1,5 @@
 import type { Plugin, TFile } from 'obsidian'
-import type { Project, ResolvedProjectConfig, Task, TaskPriority, TaskStatus } from '../types'
+import type { Project, ProjectPatch, ResolvedProjectConfig, Task, TaskPriority, TaskStatus } from '../types'
 import type { TaskFileNameConflictError } from './ProjectStore'
 
 export interface ImportNoteOptions {
@@ -15,8 +15,15 @@ export interface ImportNoteOptions {
  * the same contract.
  */
 export interface TaskSource {
-  registerCacheInvalidation(plugin: Plugin): void
-  consumeSelfWrite(path: string): boolean
+  registerVaultSync(plugin: Plugin): void
+
+  /**
+   * Subscribe to project changes, whoever made them: a mutation from any view,
+   * or a reload after an external edit. Returns the unsubscribe function.
+   * This is how views learn they need to re-render.
+   */
+  onProjectChanged(handler: (path: string) => void): () => void
+
   ensureFolder(folderPath: string): Promise<void>
 
   /**
@@ -28,12 +35,18 @@ export interface TaskSource {
   configFor(project: Project): ResolvedProjectConfig
 
   loadAllProjects(folder: string): Promise<Project[]>
+
+  /**
+   * The live project for a file. Every caller gets the same instance for a
+   * given path, for as long as the project exists.
+   */
   loadProject(file: TFile): Promise<Project | null>
   loadTaskBody(task: Task): Promise<void>
   loadProjectBody(project: Project): Promise<void>
 
   createProject(title: string, folder: string): Promise<Project>
   saveProject(project: Project): Promise<void>
+  updateProject(project: Project, patch: ProjectPatch): Promise<void>
   deleteProject(project: Project): Promise<void>
 
   insertTask(project: Project, task: Task, parentId?: string | null): Promise<void>

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,14 @@ export interface Project {
   taskIndex: TaskIndex
 }
 
+/**
+ * The project fields the project editor may change. Tasks are excluded: they
+ * are edited through the task mutators, never by writing a whole project back.
+ */
+export type ProjectPatch = Partial<
+  Pick<Project, 'title' | 'description' | 'color' | 'icon' | 'customFields' | 'teamMembers' | 'savedViews' | 'config'>
+>
+
 export interface FilterState {
   text: string
   statuses: TaskStatus[]

--- a/src/ui/ModalFactory.ts
+++ b/src/ui/ModalFactory.ts
@@ -250,12 +250,13 @@ export function openTaskModal(plugin: PMPlugin, project: Project, opts: OpenTask
 
 export interface OpenProjectModalOpts {
   project?: Project | null
-  onSave: (project: Project) => void | Promise<void>
+  /** Only needed when the caller has to act on the saved project, e.g. open a newly created one. */
+  onSave?: (project: Project) => void | Promise<void>
 }
 
 export function openProjectModal(plugin: PMPlugin, opts: OpenProjectModalOpts): void {
   const open = (): void => {
-    new ProjectModal(plugin.app, plugin, opts.project ?? null, opts.onSave).open()
+    new ProjectModal(plugin.app, plugin, opts.project ?? null, opts.onSave ?? (() => {})).open()
   }
   if (opts.project) {
     const project = opts.project

--- a/src/views/DashboardView.ts
+++ b/src/views/DashboardView.ts
@@ -53,7 +53,7 @@ export class DashboardView extends ItemView {
       const folder = this.plugin.settings.projectsFolder
       return path === folder || path.startsWith(`${folder}/`)
     }
-    const scheduleReload = (path: string) => {
+    const scheduleRender = (path: string) => {
       if (!isRelevant(path)) return
       if (this.reloadDebounceTimer !== null) window.clearTimeout(this.reloadDebounceTimer)
       this.reloadDebounceTimer = window.setTimeout(() => {
@@ -61,13 +61,15 @@ export class DashboardView extends ItemView {
         this.render()
       }, 300)
     }
-    this.registerEvent(this.app.vault.on('create', (file) => scheduleReload(file.path)))
-    this.registerEvent(this.app.vault.on('modify', (file) => scheduleReload(file.path)))
-    this.registerEvent(this.app.vault.on('delete', (file) => scheduleReload(file.path)))
+    // The store reports changes within a project; the vault reports projects
+    // appearing and disappearing, which is what changes this list.
+    this.register(this.plugin.store.onProjectChanged(scheduleRender))
+    this.registerEvent(this.app.vault.on('create', (file) => scheduleRender(file.path)))
+    this.registerEvent(this.app.vault.on('delete', (file) => scheduleRender(file.path)))
     this.registerEvent(
       this.app.vault.on('rename', (file, oldPath) => {
-        scheduleReload(file.path)
-        scheduleReload(oldPath)
+        scheduleRender(file.path)
+        scheduleRender(oldPath)
       })
     )
   }

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -1,4 +1,4 @@
-import { ButtonComponent, ExtraButtonComponent, ItemView, WorkspaceLeaf, TFile, type EventRef } from 'obsidian'
+import { ButtonComponent, ExtraButtonComponent, ItemView, WorkspaceLeaf, TFile } from 'obsidian'
 import type PMPlugin from '../main'
 import { type Project, type ViewMode, type FilterState, type SavedView, makeDefaultFilter, makeId } from '../types'
 import { truncateTitle, safeAsync } from '../utils'
@@ -33,8 +33,7 @@ export class ProjectView extends ItemView {
   private header: ProjectHeader | null = null
   private titleEl2!: HTMLElement
   private keydownHandler: ((e: KeyboardEvent) => void) | null = null
-  private fileModifyRef: EventRef | null = null
-  private reloadDebounceTimer: number | null = null
+  private pendingRefresh: Promise<void> | null = null
   private initialized = false
   /** File path whose default view mode has been applied, so reloads don't reset a user's mode switch. */
   private defaultViewAppliedFor: string | null = null
@@ -77,15 +76,10 @@ export class ProjectView extends ItemView {
   }
 
   onClose(): Promise<void> {
-    if (this.reloadDebounceTimer !== null) {
-      window.clearTimeout(this.reloadDebounceTimer)
-      this.reloadDebounceTimer = null
-    }
     if (this.keydownHandler) {
       this.containerEl.removeEventListener('keydown', this.keydownHandler)
       this.keydownHandler = null
     }
-    this.fileModifyRef = null
     this.subview?.destroy?.()
     this.subview = null
     return Promise.resolve()
@@ -115,34 +109,32 @@ export class ProjectView extends ItemView {
       this.containerEl.setAttribute('tabindex', '-1')
     }
 
-    const reloadIfRelevant = (filePath: string) => {
-      if (!this.project || !this.filePath) return false
-      const taskFolder = this.filePath.replace(/\.md$/, '_tasks')
-      return filePath.startsWith(taskFolder) || filePath === this.filePath
-    }
-    this.fileModifyRef = this.app.vault.on('modify', (file) => {
-      if (!(file instanceof TFile) || !reloadIfRelevant(file.path)) return
-      if (this.plugin.store.consumeSelfWrite(file.path)) return
-      if (this.reloadDebounceTimer !== null) window.clearTimeout(this.reloadDebounceTimer)
-      this.reloadDebounceTimer = window.setTimeout(
-        safeAsync(async () => {
-          this.reloadDebounceTimer = null
-          await this.loadProject()
-        }),
-        300
-      )
-    })
-    this.registerEvent(this.fileModifyRef)
-    this.registerEvent(
-      this.app.vault.on(
-        'delete',
-        safeAsync(async (file) => {
-          if (!reloadIfRelevant(file.path)) return
-          if (this.plugin.store.consumeSelfWrite(file.path)) return
-          await this.loadProject()
-        })
-      )
+    this.register(
+      this.plugin.store.onProjectChanged((path) => {
+        if (path === this.filePath) this.handleProjectChanged()
+      })
     )
+  }
+
+  /**
+   * The project changed, from this view or another one. The store keeps a
+   * single instance per file, so `this.project` is already current and only
+   * the DOM needs catching up.
+   */
+  private handleProjectChanged(): void {
+    if (!this.project) return
+    if (!(this.app.vault.getAbstractFileByPath(this.filePath) instanceof TFile)) {
+      this.renderMissingProject()
+      return
+    }
+    // Rebuilding the chrome would drop the caret out of the project title or
+    // the search box, so leave it alone while the user is in it.
+    const focused = activeDocument.activeElement
+    if (!this.toolbarEl.contains(focused) && !this.headerEl.contains(focused)) {
+      this.renderProjectToolbar()
+      this.renderProjectHeader()
+    }
+    void this.refreshProject()
   }
 
   private async loadProject(): Promise<void> {
@@ -318,13 +310,7 @@ export class ProjectView extends ItemView {
       attr: { 'aria-label': 'Edit project', role: 'button', tabindex: '0' }
     })
     iconEl.addEventListener('click', () => {
-      openProjectModal(this.plugin, {
-        project: this.project,
-        onSave: (updated) => {
-          this.project = updated
-          this.renderProjectToolbar()
-        }
-      })
+      openProjectModal(this.plugin, { project: this.project })
     })
 
     this.titleEl2 = left.createEl('h2', { text: this.project.title, cls: 'pm-toolbar-title' })
@@ -333,8 +319,9 @@ export class ProjectView extends ItemView {
       'blur',
       safeAsync(async () => {
         if (!this.project) return
-        this.project.title = this.titleEl2.textContent?.trim() ?? this.project.title
-        await this.plugin.store.saveProject(this.project)
+        const title = this.titleEl2.textContent?.trim()
+        if (!title || title === this.project.title) return
+        await this.plugin.store.updateProject(this.project, { title })
       })
     )
 
@@ -380,14 +367,7 @@ export class ProjectView extends ItemView {
       .setIcon('settings')
       .setTooltip('Project settings')
       .onClick(() => {
-        openProjectModal(this.plugin, {
-          project: this.project,
-          onSave: (updated) => {
-            this.project = updated
-            this.renderProjectToolbar()
-            this.renderCurrentView()
-          }
-        })
+        openProjectModal(this.plugin, { project: this.project })
       })
   }
 
@@ -445,24 +425,24 @@ export class ProjectView extends ItemView {
   }
 
   /**
-   * Re-render after a plugin-initiated mutation. Store mutators update
-   * project.tasks in place before they await the save, so memory is already
-   * current and no disk reload is needed. External edits come in through the
-   * modify/delete listeners in onOpen. Prefers the subview's in-place refresh
-   * over a full destroy-and-rebuild.
+   * Re-render from the project in memory, which the store keeps current.
+   * Coalesced, so a mutation that reports back through its own callback and
+   * through the store's change event paints once. Prefers the subview's
+   * in-place refresh over a full destroy-and-rebuild.
    */
-  async refreshProject(): Promise<void> {
-    if (!this.project) return
-    if (this.reloadDebounceTimer !== null) {
-      window.clearTimeout(this.reloadDebounceTimer)
-      this.reloadDebounceTimer = null
-    }
-    if (this.subview?.refresh) {
-      this.subview.refresh()
-    } else if (this.subview) {
-      this.subview.render()
-    } else {
-      this.renderCurrentView()
-    }
+  refreshProject(): Promise<void> {
+    if (this.pendingRefresh) return this.pendingRefresh
+    this.pendingRefresh = new Promise((resolve) => {
+      window.setTimeout(() => {
+        this.pendingRefresh = null
+        if (this.project) {
+          if (this.subview?.refresh) this.subview.refresh()
+          else if (this.subview) this.subview.render()
+          else this.renderCurrentView()
+        }
+        resolve()
+      }, 0)
+    })
+    return this.pendingRefresh
   }
 }

--- a/test/fakeVault.ts
+++ b/test/fakeVault.ts
@@ -11,9 +11,12 @@ interface FileContent {
   content: string
 }
 
+type VaultHandler = (file: TAbstractFile, oldPath?: string) => void
+
 export class FakeVault {
   private files = new Map<string, FileContent>()
   private folders = new Map<string, TFolder>()
+  private handlers = new Map<string, Set<VaultHandler>>()
 
   modifyCount = new Map<string, number>()
   createCount = new Map<string, number>()
@@ -22,6 +25,20 @@ export class FakeVault {
   constructor() {
     const root = makeFolder('', null)
     this.folders.set('', root)
+  }
+
+  on(name: string, handler: VaultHandler): VaultHandler {
+    let set = this.handlers.get(name)
+    if (!set) {
+      set = new Set()
+      this.handlers.set(name, set)
+    }
+    set.add(handler)
+    return handler
+  }
+
+  private emit(name: string, file: TAbstractFile, oldPath?: string): void {
+    for (const handler of this.handlers.get(name) ?? []) handler(file, oldPath)
   }
 
   getAbstractFileByPath(path: string): TAbstractFile | null {
@@ -42,6 +59,7 @@ export class FakeVault {
     if (!entry) throw new Error(`modify: ${file.path} does not exist`)
     entry.content = content
     bump(this.modifyCount, file.path)
+    this.emit('modify', file)
   }
 
   async process(file: TFile, fn: (data: string) => string): Promise<string> {
@@ -50,6 +68,7 @@ export class FakeVault {
     const next = fn(entry.content)
     entry.content = next
     bump(this.modifyCount, file.path)
+    this.emit('modify', file)
     return next
   }
 
@@ -61,6 +80,7 @@ export class FakeVault {
     this.files.set(n, { file, content })
     parent.children.push(file)
     bump(this.createCount, n)
+    this.emit('create', file)
     return file
   }
 
@@ -72,6 +92,7 @@ export class FakeVault {
     this.files.set(n, { file, content: '' })
     parent.children.push(file)
     bump(this.createCount, n)
+    this.emit('create', file)
     return file
   }
 
@@ -120,6 +141,7 @@ export class FakeVault {
     relocateFile(entry.file, to, parent)
     this.files.set(to, entry)
     parent.children.push(entry.file)
+    this.emit('rename', entry.file, from)
   }
 
   async trashFile(file: TAbstractFile): Promise<void> {
@@ -135,6 +157,7 @@ export class FakeVault {
     this.files.delete(file.path)
     detachFromParent(entry.file)
     bump(this.trashCount, file.path)
+    this.emit('delete', entry.file)
   }
 
   resetCounts(): void {

--- a/test/obsidian-stub.ts
+++ b/test/obsidian-stub.ts
@@ -1,5 +1,10 @@
 import { parse } from 'yaml'
 
+// Plugin code schedules timers through `window`, as Obsidian requires. Point it
+// at the node globals so tests run without a DOM environment, and so vitest's
+// fake timers reach the code under test.
+Object.assign(globalThis, { window: globalThis })
+
 export const parseYaml = (raw: string): unknown => parse(raw)
 
 export class Notice {


### PR DESCRIPTION
The store now hands out a single Project object per file, reloads external edits into it, and tells every open view when it changes. Views no longer listen to vault events themselves, and the project and task editors save only the fields the user changed.

Closes #173.