### PR TITLE
quiet the task editor section labels and align the subtask rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The time tracking section in the task editor no longer shows a progress bar
 - The kanban card no longer shows a subtask count next to the progress bar
 - Every property row in the task editor is the same height
+- Section labels in the task editor are smaller and lighter
+- A completed subtask is crossed out in the task editor
+- The field for adding a subtask lines up with the subtasks above it
 
 ### Fixed
 

--- a/src/modals/SubtasksPanel.ts
+++ b/src/modals/SubtasksPanel.ts
@@ -34,8 +34,10 @@ export function renderSubtasksPanel(
     for (const sub of task.subtasks) {
       const row = subList.createDiv('pm-modal-subtask-row')
 
+      const done = isTerminalStatus(sub.status, statuses)
+
       const cb = row.createEl('input', { type: 'checkbox', cls: 'pm-subtask-checkbox' })
-      cb.checked = isTerminalStatus(sub.status, statuses)
+      cb.checked = done
       cb.addEventListener('change', () => {
         sub.status = cb.checked ? getCompleteStatusId(statuses) : getDefaultStatusId(statuses)
         sub.progress = cb.checked ? 100 : 0
@@ -43,7 +45,10 @@ export function renderSubtasksPanel(
         renderCount()
       })
 
-      const titleEl = row.createSpan({ text: sub.title, cls: 'pm-subtask-title' })
+      const titleEl = row.createSpan({
+        text: sub.title,
+        cls: done ? 'pm-subtask-title pm-subtask-title--done' : 'pm-subtask-title'
+      })
       titleEl.contentEditable = 'true'
       titleEl.addEventListener('blur', () => {
         sub.title = titleEl.textContent?.trim() ?? sub.title
@@ -64,7 +69,8 @@ export function renderSubtasksPanel(
   renderSubtasks()
   renderCount()
 
-  const addRow = subSection.createDiv('pm-subtask-add-row')
+  const addRow = subSection.createDiv('pm-modal-subtask-row pm-subtask-add-row')
+  addRow.createSpan({ cls: 'pm-subtask-checkbox-ghost', attr: { 'aria-hidden': 'true' } })
   const addInput = addRow.createEl('input', {
     cls: 'pm-subtask-add-input',
     attr: { placeholder: 'Add subtask…' }

--- a/src/styles/task-editor.css
+++ b/src/styles/task-editor.css
@@ -327,24 +327,31 @@ input.pm-pop-field:focus {
   font-variant-numeric: tabular-nums;
 }
 .pm-subtask-add-row {
-  margin-top: 6px;
+  margin-top: 4px;
+}
+/* Stands in for the checkbox so the add row lines up with the rows above. */
+.pm-subtask-checkbox-ghost {
+  width: var(--checkbox-size);
+  height: var(--checkbox-size);
+  flex-shrink: 0;
+  border: 1px dashed var(--background-modifier-border);
+  border-radius: var(--checkbox-radius);
 }
 .pm-subtask-add-input {
-  width: 100%;
-  padding: 5px 8px;
-  border: 1px solid transparent;
-  border-radius: var(--radius-s);
+  flex: 1;
+  min-width: 0;
+  padding: 1px 3px;
+  border: none;
+  border-radius: 3px;
   background: transparent;
+  box-shadow: none;
   color: var(--text-normal);
-  font-size: var(--font-ui-smaller);
+  font-size: 13px;
   font-family: inherit;
 }
-.pm-subtask-add-input:hover {
-  background: var(--background-modifier-hover);
-}
 .pm-subtask-add-input:focus {
-  border-color: var(--background-modifier-border-focus);
-  background: var(--background-primary);
+  background: var(--background-modifier-hover);
+  box-shadow: none;
   outline: none;
 }
 

--- a/src/styles/task-modal.css
+++ b/src/styles/task-modal.css
@@ -97,8 +97,8 @@
   margin-bottom: 10px;
 }
 .pm-modal-section-title {
-  font-size: 12px;
-  font-weight: 700;
+  font-size: 11px;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-muted);
@@ -140,16 +140,28 @@ textarea.pm-modal-description:focus {
   flex-direction: column;
   gap: 4px;
 }
+/* min-height is the padding plus the button below it, so a row without a button
+   still matches the rows that have one. */
 .pm-modal-subtask-row {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-height: 34px;
   padding: 5px 8px;
   border-radius: var(--radius-s);
   transition: background 0.1s;
 }
+.pm-modal-subtask-row .pm-icon-btn {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+}
 .pm-modal-subtask-row:hover {
   background: var(--background-modifier-hover);
+}
+.pm-modal-subtask-row .pm-subtask-checkbox {
+  margin: 0;
+  flex-shrink: 0;
 }
 
 .pm-subtask-dot {
@@ -167,6 +179,10 @@ textarea.pm-modal-description:focus {
 }
 .pm-subtask-title:focus {
   background: var(--background-modifier-hover);
+}
+.pm-subtask-title--done {
+  color: var(--text-muted);
+  text-decoration: line-through;
 }
 
 .pm-modal-footer {


### PR DESCRIPTION
Completed subtasks are crossed out, and the field for adding one lines up with the rows above it: same column, same row height, a placeholder box in the checkbox slot. Section labels drop to 11px/600 so they read as labels rather than headings.

These were the last gaps between the task editor and the task view design.