### PR TITLE
measure table row height from the painted rows, not the first one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A task edited in the task editor lost changes made to it elsewhere while the editor was open
 - Edits to a project file made outside the plugin reached an open project view only after reopening it
 - A settings change reached an open project or project list only after reopening it
+- The table stopped short of its last rows and left empty space below them when scrolled to the bottom
 - The sort arrow in the table stayed on the column that was sorted before
 - Start and completed dates were labelled overdue in the task editor ([#156](https://github.com/StepanKropachev/obsidian-pm/issues/156))
 - The due date of a done task was labelled overdue in the task editor ([#156](https://github.com/StepanKropachev/obsidian-pm/issues/156))

--- a/src/views/table/TableRenderer.ts
+++ b/src/views/table/TableRenderer.ts
@@ -31,9 +31,8 @@ export interface TableState {
   wrapper: HTMLElement | null
   /** Display list after filter/sort/collapse. Drives the virtual window and selection. */
   visibleRows: TableTreeRow[]
-  /** An estimate until measured against the painted rows. */
+  /** An estimate until the painted rows are measured. */
   rowHeight: number
-  /** Set while calibration repaints, so that repaint does not calibrate again. */
   calibrating: boolean
   resizeObserver: ResizeObserver | null
   /** Bounds of the rendered window into visibleRows. -1 forces a repaint. */
@@ -153,9 +152,6 @@ export function renderTable(ctx: TableContext): void {
 
   void remeasureOnceFontsLoad(ctx)
 
-  // A resize changes how many rows fit, and a zoom change resizes every row with it.
-  // Dragging the window fires this every frame, so repaint on the same terms as a scroll:
-  // only once the bounds actually move, not for every pixel of width.
   ctx.state.resizeObserver?.disconnect()
   ctx.state.resizeObserver = new ResizeObserver(() => {
     const before = ctx.state.rowHeight
@@ -288,22 +284,12 @@ function renderWindowRows(ctx: TableContext): void {
   calibrateRowHeight(ctx)
 }
 
-/**
- * Until the interface font loads, wider fallback metrics wrap the tags onto a second line
- * and every row paints far taller than it ends up, so the first measurement is taken
- * against rows that are about to shrink.
- */
+/** Fallback font metrics wrap the tags, so rows paint taller until the real font loads. */
 async function remeasureOnceFontsLoad(ctx: TableContext): Promise<void> {
   await activeDocument.fonts.ready
   if (ctx.state.tableBody?.isConnected) calibrateRowHeight(ctx)
 }
 
-/**
- * The spacers that keep the scrollbar honest are all sized from this one number, so it has
- * to track the rows on screen. Averaging the window instead of trusting a single row stops
- * one wrapped title from standing in for the rest, and the dead band keeps the average from
- * chasing itself as taller and shorter rows scroll through.
- */
 function calibrateRowHeight(ctx: TableContext): void {
   const { state } = ctx
   const tbody = state.tableBody

--- a/src/views/table/TableRenderer.ts
+++ b/src/views/table/TableRenderer.ts
@@ -31,9 +31,11 @@ export interface TableState {
   wrapper: HTMLElement | null
   /** Display list after filter/sort/collapse. Drives the virtual window and selection. */
   visibleRows: TableTreeRow[]
-  /** An estimate until calibrated against the first painted row. */
+  /** An estimate until measured against the painted rows. */
   rowHeight: number
-  heightCalibrated: boolean
+  /** Set while calibration repaints, so that repaint does not calibrate again. */
+  calibrating: boolean
+  resizeObserver: ResizeObserver | null
   /** Bounds of the rendered window into visibleRows. -1 forces a repaint. */
   windowStart: number
   windowEnd: number
@@ -148,6 +150,22 @@ export function renderTable(ctx: TableContext): void {
 
   ctx.state.tableBody = table.createEl('tbody')
   fillTableBody(ctx)
+
+  void remeasureOnceFontsLoad(ctx)
+
+  // A resize changes how many rows fit, and a zoom change resizes every row with it.
+  // Dragging the window fires this every frame, so repaint on the same terms as a scroll:
+  // only once the bounds actually move, not for every pixel of width.
+  ctx.state.resizeObserver?.disconnect()
+  ctx.state.resizeObserver = new ResizeObserver(() => {
+    const before = ctx.state.rowHeight
+    calibrateRowHeight(ctx)
+    if (ctx.state.rowHeight !== before) return
+    const { start, end } = computeWindow(ctx.state)
+    if (start === ctx.state.windowStart && end === ctx.state.windowEnd) return
+    ctx.state.renderWindow?.()
+  })
+  ctx.state.resizeObserver.observe(wrapper)
 }
 
 export function refreshTableBody(ctx: TableContext): void {
@@ -267,18 +285,39 @@ function renderWindowRows(ctx: TableContext): void {
     openTaskModal(ctx.plugin, ctx.project, { onSave: () => ctx.onRefresh() })
   })
 
-  // Calibrate exactly once. Row heights are not perfectly uniform, so re-measuring
-  // every pass feeds back into the window math and oscillates.
-  if (!state.heightCalibrated) {
-    const first = tbody.querySelector('tr[data-task-id]')
-    if (first instanceof HTMLElement && first.offsetHeight > 0) {
-      state.heightCalibrated = true
-      if (Math.abs(first.offsetHeight - state.rowHeight) > 0.5) {
-        state.rowHeight = first.offsetHeight
-        renderWindowRows(ctx)
-      }
-    }
-  }
+  calibrateRowHeight(ctx)
+}
+
+/**
+ * Until the interface font loads, wider fallback metrics wrap the tags onto a second line
+ * and every row paints far taller than it ends up, so the first measurement is taken
+ * against rows that are about to shrink.
+ */
+async function remeasureOnceFontsLoad(ctx: TableContext): Promise<void> {
+  await activeDocument.fonts.ready
+  if (ctx.state.tableBody?.isConnected) calibrateRowHeight(ctx)
+}
+
+/**
+ * The spacers that keep the scrollbar honest are all sized from this one number, so it has
+ * to track the rows on screen. Averaging the window instead of trusting a single row stops
+ * one wrapped title from standing in for the rest, and the dead band keeps the average from
+ * chasing itself as taller and shorter rows scroll through.
+ */
+function calibrateRowHeight(ctx: TableContext): void {
+  const { state } = ctx
+  const tbody = state.tableBody
+  if (state.calibrating || !tbody) return
+
+  const rows = Array.from(tbody.querySelectorAll<HTMLElement>('tr[data-task-id]'))
+  if (!rows.length) return
+  const measured = rows.reduce((total, row) => total + row.offsetHeight, 0) / rows.length
+  if (measured <= 0 || Math.abs(measured - state.rowHeight) <= 1) return
+
+  state.rowHeight = measured
+  state.calibrating = true
+  renderWindowRows(ctx)
+  state.calibrating = false
 }
 
 function spacerRow(tbody: HTMLElement, colCount: number, height: number): void {

--- a/src/views/table/TableView.ts
+++ b/src/views/table/TableView.ts
@@ -40,7 +40,8 @@ export class TableView implements SubView {
       wrapper: null,
       visibleRows: [],
       rowHeight: ROW_HEIGHT_ESTIMATE,
-      heightCalibrated: false,
+      calibrating: false,
+      resizeObserver: null,
       windowStart: -1,
       windowEnd: -1,
       renderWindow: null
@@ -85,6 +86,11 @@ export class TableView implements SubView {
 
   handleKeyDown(e: KeyboardEvent): void {
     handleTableKeyDown(e, this.makeTableContext())
+  }
+
+  destroy(): void {
+    this.state.resizeObserver?.disconnect()
+    this.state.resizeObserver = null
   }
 
   refresh(): void {


### PR DESCRIPTION
The table stopped short of its last rows and left empty space below them when scrolled to the bottom. The spacers that size the scrollbar came from a row height measured once, from the first row, before the interface font had loaded and while its tags were still wrapped: 67px against a real 42px, never corrected. On a 67-row project that hid the last 9 rows behind 275px of padding.

It now averages the painted rows and re-measures as they settle, resize, or zoom.