### PR TITLE
give the new project dialog the task editor layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The project list counts how many projects have tasks past due
 - Project settings open in a page of their own, keeping each change as it is made
 - Creating a project asks for its name, icon, color, parent, members, and description in one dialog
+- The new project dialog is laid out like the task editor, with a large name field and a properties grid
 - A project's color is chosen from the color picker, replacing the ten preset swatches
 - The projects folder setting decides where new projects are created, not which projects the plugin shows
 - Table rows have no line between them unless line borders are turned on

--- a/src/modals/ProjectCreateModal.ts
+++ b/src/modals/ProjectCreateModal.ts
@@ -1,11 +1,11 @@
-import { App, ButtonComponent, Modal } from 'obsidian'
+import { App, ButtonComponent, ExtraButtonComponent, Modal, setIcon } from 'obsidian'
 import type PMPlugin from '../main'
 import { DEFAULT_PROJECT_COLOR, DEFAULT_PROJECT_ICON } from '../types'
 import { projectFilePath } from '../store'
 import { safeAsync } from '../utils'
 import { promptText } from '../ui/ModalFactory'
 import { renderAddButton } from '../ui/composites/addButton'
-import { renderChipList } from '../ui/FormField'
+import { renderChipList, renderPropRow } from '../ui/FormField'
 import { renderIconControl, renderSelectControl } from '../ui/composites/properties'
 
 interface Draft {
@@ -27,7 +27,10 @@ export class ProjectCreateModal extends Modal {
     teamMembers: [],
     description: ''
   }
-  private notice!: HTMLElement
+  private header!: HTMLElement
+  private titleInput!: HTMLTextAreaElement
+  private titleError!: HTMLElement
+  private pathHint!: HTMLElement
   private iconHost!: HTMLElement
   private submit!: ButtonComponent
 
@@ -41,55 +44,101 @@ export class ProjectCreateModal extends Modal {
   onOpen(): void {
     const { contentEl } = this
     contentEl.empty()
-    contentEl.addClass('pm-create')
+    contentEl.addClass('pm-te-modal', 'pm-te-surface')
     this.modalEl.addClass('pm-modal', 'pm-modal--create')
-    this.setTitle('New project')
 
-    this.renderName(contentEl)
-    const grid = contentEl.createDiv('pm-create-grid')
+    this.renderHeader(contentEl)
+
+    const body = contentEl.createDiv('pm-te-body')
+    this.renderTitle(body)
+
+    const grid = body.createDiv('pm-te-props').createDiv('pm-prop-grid')
     this.renderIcon(grid)
     this.renderColor(grid)
-    this.renderParent(contentEl)
-    this.renderMembers(contentEl)
-    this.renderDescription(contentEl)
+    this.renderParent(grid)
+    this.renderMembers(grid)
 
-    const buttons = contentEl.createDiv('pm-modal-btn-row')
-    new ButtonComponent(buttons).setButtonText('Cancel').onClick(() => this.close())
-    this.submit = new ButtonComponent(buttons)
-      .setButtonText('Create project')
-      .setCta()
-      .onClick(() => this.create())
+    body.createEl('hr', { cls: 'pm-te-divider' })
+    this.renderDescription(body)
+
+    this.renderFooter(contentEl)
+
+    this.modalEl.addEventListener('keydown', this.handleKeyDown)
     this.refreshValidity()
   }
 
   onClose(): void {
+    this.modalEl.removeEventListener('keydown', this.handleKeyDown)
     this.contentEl.empty()
   }
 
-  private renderName(parent: HTMLElement): void {
-    const block = parent.createDiv('pm-create-block')
-    block.createEl('label', { text: 'Name', cls: 'pm-label' })
-    const input = block.createEl('input', { type: 'text', cls: 'pm-input' })
-    input.placeholder = 'Project name'
-    input.addEventListener('input', () => {
-      this.draft.title = input.value
+  private readonly handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === 'Enter' && e.shiftKey) {
+      e.preventDefault()
+      this.create()
+    }
+  }
+
+  private renderHeader(parent: HTMLElement): void {
+    this.header = parent.createDiv('pm-te-header')
+    this.paintAccent()
+    const crumb = this.header.createDiv('pm-te-crumb')
+    const folderIcon = crumb.createSpan({ cls: 'pm-te-crumb-icon' })
+    setIcon(folderIcon, 'folder')
+    crumb.createSpan({ cls: 'pm-te-crumb-name', text: this.plugin.settings.projectsFolder || this.app.vault.getName() })
+    const sep = crumb.createSpan({ cls: 'pm-te-crumb-sep' })
+    setIcon(sep, 'chevron-right')
+    crumb.createSpan({ text: 'New project' })
+
+    this.header.createDiv('pm-te-header-spacer')
+
+    const closeBtn = new ExtraButtonComponent(this.header).setIcon('x').setTooltip('Close')
+    closeBtn.extraSettingsEl.addClass('pm-te-header-btn')
+    closeBtn.onClick(() => this.close())
+  }
+
+  private paintAccent(): void {
+    this.header.setCssProps({ '--pm-accent-strip': this.draft.color })
+  }
+
+  private renderTitle(parent: HTMLElement): void {
+    const wrap = parent.createDiv('pm-te-title-wrap')
+    this.titleInput = wrap.createEl('textarea', { cls: 'pm-te-title' })
+    this.titleInput.rows = 1
+    this.titleInput.placeholder = 'Project name'
+    this.titleInput.spellcheck = false
+    this.titleError = wrap.createDiv({ cls: 'pm-modal-title-error', attr: { hidden: '' } })
+
+    const autosize = () => {
+      this.titleInput.setCssProps({ '--te-title-height': 'auto' })
+      this.titleInput.setCssProps({ '--te-title-height': this.titleInput.scrollHeight + 'px' })
+    }
+    this.titleInput.addEventListener('input', () => {
+      this.draft.title = this.titleInput.value
+      autosize()
       this.refreshValidity()
     })
-    input.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') {
+    this.titleInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault()
         this.create()
       }
     })
-    this.notice = block.createDiv({ cls: 'pm-create-notice' })
-    window.setTimeout(() => input.focus(), 10)
+    window.setTimeout(autosize, 0)
+    this.titleInput.focus()
   }
 
   private renderIcon(parent: HTMLElement): void {
-    const block = parent.createDiv('pm-create-block')
-    block.createEl('label', { text: 'Icon', cls: 'pm-label' })
-    this.iconHost = block.createDiv()
-    this.drawIcon()
+    renderPropRow(
+      parent,
+      'Icon',
+      () => {
+        this.iconHost = createDiv('pm-prop-value')
+        this.drawIcon()
+        return this.iconHost
+      },
+      'smile'
+    )
   }
 
   private drawIcon(): void {
@@ -105,82 +154,137 @@ export class ProjectCreateModal extends Modal {
   }
 
   private renderColor(parent: HTMLElement): void {
-    const block = parent.createDiv('pm-create-block')
-    block.createEl('label', { text: 'Color', cls: 'pm-label' })
-    const field = block.createEl('input', { type: 'color', cls: 'pm-color-custom' })
-    field.value = this.draft.color
-    field.addEventListener('change', () => {
-      this.draft.color = field.value
-      this.drawIcon()
-    })
+    renderPropRow(
+      parent,
+      'Color',
+      () => {
+        const cell = createDiv('pm-prop-value pm-prop-color')
+        const picker = cell.createEl('input', { type: 'color', cls: 'pm-color-custom' })
+        picker.value = this.draft.color
+        picker.addEventListener('change', () => {
+          this.draft.color = picker.value
+          this.paintAccent()
+          this.drawIcon()
+        })
+        return cell
+      },
+      'palette'
+    )
   }
 
   private renderParent(parent: HTMLElement): void {
-    const block = parent.createDiv('pm-create-block')
-    block.createEl('label', { text: 'Parent', cls: 'pm-label' })
-    const cell = block.createDiv('pm-prop-value')
-    const draw = (): void => {
-      cell.empty()
-      renderSelectControl({
-        container: cell,
-        value: this.draft.parentPath,
-        placeholder: 'No parent',
-        search: true,
-        options: [
-          { id: '', label: 'No parent' },
-          ...this.plugin.index.projectRefs().map((ref) => ({ id: ref.path, label: ref.title, color: ref.color }))
-        ],
-        onChange: (path) => {
-          this.draft.parentPath = path
-          draw()
+    renderPropRow(
+      parent,
+      'Parent',
+      () => {
+        const cell = createDiv('pm-prop-value')
+        const draw = (): void => {
+          cell.empty()
+          renderSelectControl({
+            container: cell,
+            value: this.draft.parentPath,
+            placeholder: 'No parent',
+            search: true,
+            options: [
+              { id: '', label: 'No parent' },
+              ...this.plugin.index.projectRefs().map((ref) => ({ id: ref.path, label: ref.title, color: ref.color }))
+            ],
+            onChange: (path) => {
+              this.draft.parentPath = path
+              draw()
+            }
+          })
         }
-      })
-    }
-    draw()
+        draw()
+        return cell
+      },
+      'corner-up-right'
+    )
   }
 
   private renderMembers(parent: HTMLElement): void {
-    const block = parent.createDiv('pm-create-block')
-    block.createEl('label', { text: 'Members', cls: 'pm-label' })
-    const list = block.createDiv('pm-prop-value')
-    const draw = (): void => {
-      renderChipList(list, this.draft.teamMembers, {
-        variant: 'accent',
-        onRemove: (member) => {
-          this.draft.teamMembers = this.draft.teamMembers.filter((name) => name !== member)
-          draw()
-        },
-        renderAdd: (container) => {
-          renderAddButton(
-            container,
-            'Add member',
-            safeAsync(async () => {
-              const name = await promptText(this.app, 'Member name', 'Name')
-              if (!name || this.draft.teamMembers.includes(name)) return
-              this.draft.teamMembers.push(name)
+    const row = renderPropRow(
+      parent,
+      'Members',
+      () => {
+        const list = createDiv('pm-prop-value')
+        const draw = (): void => {
+          renderChipList(list, this.draft.teamMembers, {
+            variant: 'accent',
+            onRemove: (member) => {
+              this.draft.teamMembers = this.draft.teamMembers.filter((name) => name !== member)
               draw()
-            })
-          )
+            },
+            renderAdd: (container) => {
+              renderAddButton(
+                container,
+                'Add member',
+                safeAsync(async () => {
+                  const name = await promptText(this.app, 'Member name', 'Name')
+                  if (!name || this.draft.teamMembers.includes(name)) return
+                  this.draft.teamMembers.push(name)
+                  draw()
+                })
+              )
+            }
+          })
         }
-      })
-    }
-    draw()
+        draw()
+        return list
+      },
+      'users'
+    )
+    row.addClass('pm-prop-row--wide')
   }
 
   private renderDescription(parent: HTMLElement): void {
-    const block = parent.createDiv('pm-create-block')
-    block.createEl('label', { text: 'Description', cls: 'pm-label' })
-    const area = block.createEl('textarea', { cls: 'pm-input pm-edit-desc' })
+    const section = parent.createDiv('pm-modal-section pm-modal-desc-section')
+    section.createEl('h4', { text: 'Description', cls: 'pm-modal-section-title' })
+    const area = section.createEl('textarea', { cls: 'pm-modal-description' })
     area.placeholder = 'What this project covers and what done looks like'
+    const autoResize = () => {
+      area.setCssProps({ '--desc-height': 'auto' })
+      area.setCssProps({ '--desc-height': area.scrollHeight + 'px' })
+    }
     area.addEventListener('input', () => {
       this.draft.description = area.value
+      autoResize()
     })
+    window.setTimeout(autoResize, 0)
+  }
+
+  private renderFooter(parent: HTMLElement): void {
+    const footer = parent.createDiv('pm-te-footer')
+    this.pathHint = footer.createSpan({ cls: 'pm-te-footer-path' })
+    const fileIcon = this.pathHint.createSpan({ cls: 'pm-te-footer-icon' })
+    setIcon(fileIcon, 'file-text')
+    this.pathHint.createSpan()
+
+    footer.createDiv('pm-footer-spacer')
+
+    new ButtonComponent(footer).setButtonText('Cancel').onClick(() => this.close())
+    this.submit = new ButtonComponent(footer)
+      .setButtonText('Create project (Shift+Enter)')
+      .setCta()
+      .onClick(() => this.create())
   }
 
   private refreshValidity(): void {
     const title = this.draft.title.trim()
-    const taken = !!title && !!this.app.vault.getAbstractFileByPath(this.targetPath(title))
-    this.notice.setText(taken ? 'A note with this name is already there.' : '')
+    const path = title ? this.targetPath(title) : ''
+    const taken = !!path && !!this.app.vault.getAbstractFileByPath(path)
+
+    this.pathHint.lastElementChild?.setText(path)
+    this.pathHint.toggleClass('pm-hidden', !path)
+    if (taken) {
+      this.titleError.setText('A note with this name is already there.')
+      this.titleError.removeAttribute('hidden')
+      this.titleInput.addClass('pm-input-error')
+    } else {
+      this.titleError.setText('')
+      this.titleError.setAttribute('hidden', '')
+      this.titleInput.removeClass('pm-input-error')
+    }
     this.submit.setDisabled(!title || taken)
   }
 

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -31,7 +31,7 @@ export class TaskModal extends Modal {
   onOpen(): void {
     const { contentEl } = this
     contentEl.empty()
-    contentEl.addClass('pm-task-modal', 'pm-te-surface')
+    contentEl.addClass('pm-te-modal', 'pm-te-surface')
     this.modalEl.addClass('pm-modal', 'pm-modal--task')
     this.editor.mount(contentEl)
   }

--- a/src/styles/project-edit.css
+++ b/src/styles/project-edit.css
@@ -36,31 +36,6 @@
   max-width: 560px;
 }
 
-.pm-create-block + .pm-create-block,
-.pm-create-grid {
-  margin-top: 16px;
-}
-.pm-create-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-  align-items: start;
-}
-.pm-create-grid .pm-create-block + .pm-create-block {
-  margin-top: 0;
-}
-
-.pm-create-notice {
-  min-height: 16px;
-  margin-top: 4px;
-  font-size: 12px;
-  color: var(--text-error);
-}
-
-.pm-create .pm-modal-btn-row {
-  margin-top: 24px;
-}
-
 .pm-edit-desc {
   min-height: 72px;
   resize: vertical;
@@ -87,6 +62,12 @@
 .pm-edit-danger-title {
   font-size: var(--font-ui-small);
   font-weight: 500;
+}
+
+/* The swatch is shorter than the pickers beside it, so the cell keeps the control height
+   and centers it against them. */
+.pm-prop-color {
+  min-height: 30px;
 }
 
 .pm-color-custom {

--- a/src/styles/task-editor.css
+++ b/src/styles/task-editor.css
@@ -410,26 +410,26 @@ button.pm-icon-trigger {
   outline: none;
 }
 
-.pm-task-modal {
-  padding: 0;
-}
-
 /* Dropping .modal's 16px inset lets the header and footer bleed to both edges; the
    overflow:hidden re-clips those bands to the modal's rounded corners. */
-.pm-modal--task {
+.pm-modal--task,
+.pm-modal--create {
   padding: 0;
   overflow: hidden;
 }
 
 /* The editor draws its own close button, so the native corner one would be a second X. */
 .pm-modal--task .modal-close-button,
-.pm-modal--task .modal-header-button {
+.pm-modal--task .modal-header-button,
+.pm-modal--create .modal-close-button,
+.pm-modal--create .modal-header-button {
   display: none;
 }
 
 /* The empty native .modal-header still carries a margin-bottom, which pushes our own
    header and its accent strip off the top edge. */
-.pm-modal--task .modal-header {
+.pm-modal--task .modal-header,
+.pm-modal--create .modal-header {
   display: none;
 }
 

--- a/src/styles/task-modal.css
+++ b/src/styles/task-modal.css
@@ -8,7 +8,7 @@
   max-height: 88vh;
 }
 
-.pm-task-modal {
+.pm-te-modal {
   display: flex;
   flex-direction: column;
   gap: 0;


### PR DESCRIPTION
The new project dialog now uses the same chrome as the task editor: a header band with a breadcrumb and close button, a large borderless name field with the duplicate-name error under it, a two-column properties grid for icon, color, parent, and members, a description section, and a footer showing the target file path next to the buttons. Shift+Enter creates, as it saves in the task editor.

Its own layout of stacked labeled blocks was the last dialog that did not look like the rest of the plugin.