### PR TITLE
give the overview property labels room for longer names

### DIFF
--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -203,8 +203,12 @@
 }
 
 .pm-overview-props .pm-prop-row {
-  grid-template-columns: 90px 1fr;
+  grid-template-columns: 104px 1fr;
   min-height: 30px;
+}
+.pm-overview-props .pm-prop-label {
+  white-space: normal;
+  overflow-wrap: break-word;
 }
 
 .pm-overview-member {


### PR DESCRIPTION
Widens the property label column on the project overview from 90px to 104px, matching the task editor, and lets a label wrap instead of running past its column.