### PR TITLE
let a project link open its tasks instead of the overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The project name above the table, timeline, and board opens that project's overview when clicked. Previously it was an editable field for renaming the project
 - Assignee lists sort by the name shown rather than by the link behind it
 - The project list is a table of rows with progress, task counts, members, and the last due date, replacing the cards
 - The project list counts how many projects have tasks past due

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A person note opened in the editor shows that person's tasks with the show tasks assigned to this note command
 - The link assignees to their person notes command turns typed names into links to the notes of the same name
 - Opening a project from the project list shows its overview: progress, description, milestones, sub-projects, and properties
+- Clicking a project opens its tasks instead of its overview when the open projects in setting is set to tasks
 - A row, card, or timeline label naming its project opens that project when clicked
 - Projects are listed wherever their files live in the vault
 - A project can sit under another one, chosen in the project settings

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Task hierarchy and dependencies don't resolve on the TaskNotes side (it uses pro
 | Setting | Description |
 |---|---|
 | Projects folder | Vault folder where project and task files are stored |
-| Default view | Table, Gantt, or Kanban |
+| Open projects in | Overview page, or straight to the project's tasks |
+| Default tasks view | Table, Gantt, or Kanban |
 | Open tasks in | Modal or tab. On tab, task notes open in the task editor instead of Obsidian's. |
 | Gantt granularity | Default timeline scale (day / week / month / quarter) |
 | Gantt week labels | Week number, date range, or both |
@@ -240,7 +241,7 @@ Task description in Markdown goes here.
 | Setting | Description |
 |---|---|
 | Projects folder | Vault folder where project and task files are stored |
-| Default view | Table, Gantt, or Kanban |
+| Default tasks view | Table, Gantt, or Kanban |
 | Gantt granularity | Default timeline scale (day / week / month / quarter) |
 | Gantt week labels | Week number, date range, or both |
 | Due date notifications | Reminders N days before due dates |

--- a/src/main.ts
+++ b/src/main.ts
@@ -198,7 +198,7 @@ export default class PMPlugin extends Plugin {
         const cache = this.app.metadataCache.getFileCache(file)
         if (cache?.frontmatter?.['pm-project'] !== true) return false
         if (checking) return true
-        void this.router.openProjectOverview(file.path, md.leaf)
+        void this.router.openProjectLink(file.path, md.leaf)
         return true
       }
     })

--- a/src/modals/ProjectCreateModal.ts
+++ b/src/modals/ProjectCreateModal.ts
@@ -303,6 +303,6 @@ export class ProjectCreateModal extends Modal {
       parentPath: this.draft.parentPath || undefined
     })
     this.close()
-    await this.plugin.router.openProjectOverview(project.filePath)
+    await this.plugin.router.openProjectLink(project.filePath)
   })
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -49,8 +49,19 @@ export class PMSettingTab extends PluginSettingTab {
           },
           this.excludedFoldersPage(),
           {
-            name: 'Default view',
-            desc: 'View that opens when a project is opened.',
+            name: 'Open projects in',
+            desc: 'Tasks skips the overview page and goes straight to the table, timeline, or board.',
+            aliases: ['click', 'project list', 'overview'],
+            control: {
+              type: 'dropdown',
+              key: 'projectSurface',
+              options: { overview: 'Overview', tasks: 'Tasks' }
+            }
+          },
+          {
+            name: 'Default tasks view',
+            desc: "View a project's tasks open in.",
+            aliases: ['default view'],
             control: {
               type: 'dropdown',
               key: 'defaultView',

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -105,18 +105,17 @@
   font-size: 20px;
   font-weight: 700;
   margin: 0;
-  padding: 2px 6px;
-  border-radius: var(--radius-s);
-  outline: none;
-  min-width: 40px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 340px;
 }
-.pm-toolbar-title:focus {
-  background: var(--background-modifier-hover);
-  box-shadow: 0 0 0 2px var(--interactive-accent);
+.pm-toolbar-title--link {
+  cursor: pointer;
+}
+.pm-toolbar-title--link:hover,
+.pm-toolbar-title--link:focus-visible {
+  color: var(--text-accent);
 }
 
 .pm-view-switcher {

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,6 +200,8 @@ export interface PMSettings {
   showTagColors: boolean
   saveTaskOnClose: boolean
   taskEditorSurface: 'modal' | 'tab'
+  /** Where a project link lands: its overview page or its tasks in the default view. */
+  projectSurface: 'overview' | 'tasks'
   /** Keyed by scope key, e.g. `project:Projects/Roadmap.md`. */
   projectFilters: Record<string, PerProjectFilter>
   /** Saved views for a scope covering several projects, which has no file to keep them in. */
@@ -248,6 +250,7 @@ export const DEFAULT_SETTINGS: PMSettings = {
   pullForwardOnEarlyFinish: false,
   saveTaskOnClose: true,
   taskEditorSurface: 'modal',
+  projectSurface: 'overview',
   projectFilters: {},
   scopeViews: {},
   collapsedTasks: {},

--- a/src/views/DashboardView.ts
+++ b/src/views/DashboardView.ts
@@ -73,7 +73,7 @@ export class DashboardView extends ItemView {
       plugin: this.plugin,
       toolbarEl: this.toolbarEl,
       contentEl: this.bodyEl,
-      openProject: (path: string) => this.plugin.router.openProjectOverview(path)
+      openProject: (path: string) => this.plugin.router.openProjectLink(path)
     }
   }
 }

--- a/src/views/KanbanView.ts
+++ b/src/views/KanbanView.ts
@@ -119,7 +119,7 @@ export class KanbanView implements SubView {
             renderProjectChip(el, {
               title: owner.title,
               color: owner.color,
-              onClick: safeAsync(() => this.plugin.router.openProjectOverview(owner.filePath))
+              onClick: safeAsync(() => this.plugin.router.openProjectLink(owner.filePath))
             })
         : undefined,
       loggedHours: totalLoggedHours(task),

--- a/src/views/PMViewRouter.ts
+++ b/src/views/PMViewRouter.ts
@@ -34,6 +34,12 @@ export class PMViewRouter {
     await this.open(PM_PROJECT_OVERVIEW_VIEW_TYPE, { filePath: path }, leaf)
   }
 
+  /** Where a project link lands, per the open projects in setting. */
+  async openProjectLink(path: string, leaf?: WorkspaceLeaf): Promise<void> {
+    if (this.plugin.settings.projectSurface === 'tasks') await this.openScope({ kind: 'project', path }, leaf)
+    else await this.openProjectOverview(path, leaf)
+  }
+
   async openProjectEdit(path: string, leaf?: WorkspaceLeaf): Promise<void> {
     await this.open(PM_PROJECT_EDIT_VIEW_TYPE, { filePath: path }, leaf)
   }

--- a/src/views/ProjectEditView.ts
+++ b/src/views/ProjectEditView.ts
@@ -360,7 +360,7 @@ export class ProjectEditView extends ItemView {
       })
     }
 
-    row('Default view', 'defaultView', [
+    row('Default tasks view', 'defaultView', [
       { value: 'table', label: 'Table' },
       { value: 'gantt', label: 'Gantt' },
       { value: 'kanban', label: 'Board' }

--- a/src/views/ProjectListRenderer.ts
+++ b/src/views/ProjectListRenderer.ts
@@ -118,6 +118,12 @@ function openProjectContextMenu(ctx: ProjectListContext, ref: ProjectRef, e: Mou
   const menu = new Menu()
   menu.addItem((item) =>
     item
+      .setTitle('Open overview')
+      .setIcon('file-text')
+      .onClick(safeAsync(() => ctx.plugin.router.openProjectOverview(ref.path)))
+  )
+  menu.addItem((item) =>
+    item
       .setTitle('Open tasks')
       .setIcon('table')
       .onClick(safeAsync(() => ctx.plugin.router.openScope({ kind: 'project', path: ref.path })))

--- a/src/views/ProjectOverviewView.ts
+++ b/src/views/ProjectOverviewView.ts
@@ -304,7 +304,7 @@ export class ProjectOverviewView extends ItemView {
       row.createSpan({ cls: 'pm-overview-child-count', text: `${done}/${total}` })
       row.addEventListener(
         'click',
-        safeAsync(() => this.plugin.router.openProjectOverview(child.path))
+        safeAsync(() => this.plugin.router.openProjectLink(child.path))
       )
     }
   }

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -41,7 +41,6 @@ export class ProjectView extends ItemView {
   private headerEl!: HTMLElement
   private bodyEl!: HTMLElement
   private header: ProjectHeader | null = null
-  private titleEl2!: HTMLElement
   private keydownHandler: ((e: KeyboardEvent) => void) | null = null
   private pendingRefresh: Promise<void> | null = null
   private initialized = false
@@ -361,29 +360,21 @@ export class ProjectView extends ItemView {
     this.toolbarEl.empty()
 
     const left = this.toolbarEl.createDiv('pm-toolbar-left')
+    const openOverview = safeAsync(() => this.plugin.router.openProjectOverview(primary.filePath))
     if (!scope.isMulti) {
       const iconEl = left.createSpan({
         text: primary.icon,
         cls: 'pm-toolbar-icon',
         attr: { 'aria-label': 'Open project page', role: 'button', tabindex: '0' }
       })
-      iconEl.addEventListener(
-        'click',
-        safeAsync(() => this.plugin.router.openProjectOverview(primary.filePath))
-      )
+      iconEl.addEventListener('click', openOverview)
     }
 
-    this.titleEl2 = left.createEl('h2', { text: scope.label(), cls: 'pm-toolbar-title' })
+    const titleEl = left.createEl('h2', { text: scope.label(), cls: 'pm-toolbar-title' })
     if (!scope.isMulti) {
-      this.titleEl2.contentEditable = 'true'
-      this.titleEl2.addEventListener(
-        'blur',
-        safeAsync(async () => {
-          const title = this.titleEl2.textContent?.trim()
-          if (!title || title === primary.title) return
-          await this.plugin.store.updateProject(primary, { title })
-        })
-      )
+      titleEl.addClass('pm-toolbar-title--link')
+      titleEl.setAttrs({ 'aria-label': 'Open project page', role: 'button', tabindex: '0' })
+      titleEl.addEventListener('click', openOverview)
     }
     this.renderScopeSwitcher(left)
 

--- a/src/views/gantt/TaskLabelRenderer.ts
+++ b/src/views/gantt/TaskLabelRenderer.ts
@@ -88,7 +88,7 @@ export function renderTaskLabel(
     renderProjectChip(el, {
       title: project.title,
       color: project.color,
-      onClick: safeAsync(() => ctx.plugin.router.openProjectOverview(project.filePath))
+      onClick: safeAsync(() => ctx.plugin.router.openProjectLink(project.filePath))
     })
   }
 

--- a/src/views/table/TableRow.ts
+++ b/src/views/table/TableRow.ts
@@ -108,7 +108,7 @@ export function renderTaskRow(tbody: HTMLElement, flat: TableTreeRow, ctx: Table
     new ProjectCell(row, {
       title: project.title,
       color: project.color,
-      onClick: safeAsync(() => ctx.plugin.router.openProjectOverview(project.filePath))
+      onClick: safeAsync(() => ctx.plugin.router.openProjectLink(project.filePath))
     })
   }
 


### PR DESCRIPTION
A new open projects in setting decides where clicking a project goes: its overview page, or straight to its tasks in that project's default view. It applies to project list rows, sub-project rows, and the project chips on rows, cards, and timeline labels. The row context menu now offers both, so whichever surface the setting skips is one right-click away.

The project name above the task views is a link to the overview too. It used to be an editable field that renamed the project on blur, which was easy to trigger by accident; renaming stays on the project settings page.