### PR TITLE
load a project from its path through the store

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { MarkdownView, Plugin, Notice, TFile } from 'obsidian'
+import { MarkdownView, Plugin, Notice } from 'obsidian'
 import { DEFAULT_SETTINGS, makeDefaultFilter, type PMSettings, type Project, type Task } from './types'
 import { flattenTasks, findTask } from './store/TaskTreeOps'
 import { matchPersonNotes, personLink, ProjectStore, scopeKey, VaultIndex } from './store'
@@ -459,8 +459,7 @@ export default class PMPlugin extends Plugin {
     }
     const choose = (ref: ProjectRef): void => {
       void (async () => {
-        const file = this.app.vault.getAbstractFileByPath(ref.path)
-        const project = file instanceof TFile ? await this.store.loadProject(file) : null
+        const project = await this.store.loadProjectByPath(ref.path)
         if (!project) {
           this.showNotice(`Could not open "${ref.title}".`)
           return
@@ -525,7 +524,7 @@ export default class PMPlugin extends Plugin {
     }
 
     for (const [path, taskIds] of byProject) {
-      const project = await this.loadProjectAt(path)
+      const project = await this.store.loadProjectByPath(path)
       if (!project) continue
       await this.store.updateTasks(project, taskIds, (task) => ({ assignees: task.assignees.map(mapValue) }))
       tasksChanged += taskIds.length
@@ -533,7 +532,7 @@ export default class PMPlugin extends Plugin {
 
     for (const ref of this.index.projectRefs()) {
       if (!ref.teamMembers.some((value) => linkFor.has(value.trim().toLowerCase()))) continue
-      const project = await this.loadProjectAt(ref.path)
+      const project = await this.store.loadProjectByPath(ref.path)
       if (!project) continue
       await this.store.updateProject(project, { teamMembers: project.teamMembers.map(mapValue) })
       projectsChanged++
@@ -541,11 +540,6 @@ export default class PMPlugin extends Plugin {
 
     this.refreshViews()
     this.showNotice(`Linked ${tasksChanged} task(s) and ${projectsChanged} project(s).`)
-  }
-
-  private async loadProjectAt(path: string): Promise<Project | null> {
-    const file = this.app.vault.getAbstractFileByPath(path)
-    return file instanceof TFile ? this.store.loadProject(file) : null
   }
 
   /** Opens the whole vault filtered to one person, the way the assignee filter would. */

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -287,14 +287,14 @@ export class ProjectStore implements TaskSource {
   }
 
   async loadProjects(paths: string[]): Promise<Project[]> {
-    const files: TFile[] = []
-    for (const path of paths) {
-      const file = this.app.vault.getAbstractFileByPath(normalizePath(path))
-      if (file instanceof TFile) files.push(file)
-    }
-    const loaded = await Promise.all(files.map((f) => this.loadProject(f)))
+    const loaded = await Promise.all(paths.map((path) => this.loadProjectByPath(path)))
     const projects = loaded.filter((p): p is Project => p !== null)
     return projects.sort((a, b) => a.title.localeCompare(b.title))
+  }
+
+  async loadProjectByPath(path: string): Promise<Project | null> {
+    const file = this.app.vault.getAbstractFileByPath(normalizePath(path))
+    return file instanceof TFile ? this.loadProject(file) : null
   }
 
   /** Concurrent callers share the one in-flight read, so a project never exists twice. */

--- a/src/store/TaskSource.ts
+++ b/src/store/TaskSource.ts
@@ -34,6 +34,8 @@ export interface TaskSource {
 
   /** Every caller gets the same instance for a path, for as long as the project exists. */
   loadProject(file: TFile): Promise<Project | null>
+  /** Null when the path names no file, so callers holding a path don't resolve it themselves. */
+  loadProjectByPath(path: string): Promise<Project | null>
   loadTaskBody(task: Task): Promise<void>
   loadProjectBody(project: Project): Promise<void>
 

--- a/src/ui/ModalFactory.ts
+++ b/src/ui/ModalFactory.ts
@@ -1,4 +1,4 @@
-import { type App, ButtonComponent, Modal, TFile } from 'obsidian'
+import { type App, ButtonComponent, Modal } from 'obsidian'
 import type PMPlugin from '../main'
 import type { Project, Task } from '../types'
 import { flattenTasks, type ProjectRef } from '../store'
@@ -256,8 +256,7 @@ export async function openTaskByPath(plugin: PMPlugin, filePath: string, onSave?
     return
   }
   const projectPath = plugin.index.projectPathForTask(filePath)
-  const projectFile = projectPath ? plugin.app.vault.getAbstractFileByPath(projectPath) : null
-  const project = projectFile instanceof TFile ? await plugin.store.loadProject(projectFile) : null
+  const project = projectPath ? await plugin.store.loadProjectByPath(projectPath) : null
   const task = project ? (flattenTasks(project.tasks).find((f) => f.task.filePath === filePath)?.task ?? null) : null
   if (!project || !task) {
     await plugin.openAsMarkdown(filePath)

--- a/src/ui/TaskContextMenu.ts
+++ b/src/ui/TaskContextMenu.ts
@@ -1,4 +1,4 @@
-import { Menu, Notice, TFile } from 'obsidian'
+import { Menu, Notice } from 'obsidian'
 import type PMPlugin from '../main'
 import type { Task, Project } from '../types'
 import { safeAsync } from '../utils'
@@ -69,8 +69,7 @@ export function buildTaskContextMenu(menu: Menu, task: Task, ctx: TaskMenuContex
           ctx.plugin,
           targets,
           safeAsync(async (ref) => {
-            const file = ctx.plugin.app.vault.getAbstractFileByPath(ref.path)
-            const target = file instanceof TFile ? await ctx.plugin.store.loadProject(file) : null
+            const target = await ctx.plugin.store.loadProjectByPath(ref.path)
             if (!target) return
             await ctx.plugin.store.moveTaskToProject(ctx.project, target, task.id)
             new Notice(`Moved "${task.title}" to ${target.title}`)

--- a/src/views/ProjectEditView.ts
+++ b/src/views/ProjectEditView.ts
@@ -1,4 +1,4 @@
-import { ButtonComponent, ItemView, TFile, WorkspaceLeaf } from 'obsidian'
+import { ButtonComponent, ItemView, WorkspaceLeaf } from 'obsidian'
 import type PMPlugin from '../main'
 import {
   type CustomFieldDef,
@@ -88,8 +88,7 @@ export class ProjectEditView extends ItemView {
 
   private async loadProject(): Promise<void> {
     const path = this.state.filePath
-    const file = path ? this.app.vault.getAbstractFileByPath(path) : null
-    this.project = file instanceof TFile ? await this.plugin.store.loadProject(file) : null
+    this.project = path ? await this.plugin.store.loadProjectByPath(path) : null
     if (!this.project) {
       this.container.empty()
       new EmptyState(this.container)

--- a/src/views/ProjectListRenderer.ts
+++ b/src/views/ProjectListRenderer.ts
@@ -1,6 +1,5 @@
-import { TFile, Menu, ButtonComponent } from 'obsidian'
+import { Menu, ButtonComponent } from 'obsidian'
 import type PMPlugin from '../main'
-import type { Project } from '../types'
 import type { ProjectRef } from '../store'
 import { dateUrgency, formatDateShort, safeAsync } from '../utils'
 import { openProjectCreate } from '../ui/ModalFactory'
@@ -148,7 +147,7 @@ function openProjectContextMenu(ctx: ProjectListContext, ref: ProjectRef, e: Mou
       .setIcon('trash')
       .onClick(
         safeAsync(async () => {
-          const project = await loadRef(ctx, ref)
+          const project = await ctx.plugin.store.loadProjectByPath(ref.path)
           if (!project) return
           await ctx.plugin.store.deleteProject(project)
           renderProjectListContent(ctx)
@@ -156,9 +155,4 @@ function openProjectContextMenu(ctx: ProjectListContext, ref: ProjectRef, e: Mou
       )
   )
   menu.showAtMouseEvent(e)
-}
-
-async function loadRef(ctx: ProjectListContext, ref: ProjectRef): Promise<Project | null> {
-  const file = ctx.plugin.app.vault.getAbstractFileByPath(ref.path)
-  return file instanceof TFile ? ctx.plugin.store.loadProject(file) : null
 }

--- a/src/views/ProjectOverviewView.ts
+++ b/src/views/ProjectOverviewView.ts
@@ -1,4 +1,4 @@
-import { ButtonComponent, Component, ItemView, MarkdownRenderer, TFile, WorkspaceLeaf } from 'obsidian'
+import { ButtonComponent, Component, ItemView, MarkdownRenderer, WorkspaceLeaf } from 'obsidian'
 import type PMPlugin from '../main'
 import type { Project, ResolvedProjectConfig, Task } from '../types'
 import { collectAllTags, flattenTasks, personKeyer, totalLoggedHours, type ProjectRef } from '../store'
@@ -95,13 +95,7 @@ export class ProjectOverviewView extends ItemView {
 
   private async loadProject(): Promise<void> {
     const path = this.state.filePath
-    const file = path ? this.app.vault.getAbstractFileByPath(path) : null
-    if (!(file instanceof TFile)) {
-      this.project = null
-      this.renderMissing()
-      return
-    }
-    this.project = await this.plugin.store.loadProject(file)
+    this.project = path ? await this.plugin.store.loadProjectByPath(path) : null
     ;(this.leaf as WorkspaceLeaf & { updateHeader?: () => void }).updateHeader?.()
     if (!this.project) {
       this.renderMissing()

--- a/src/views/TaskView.ts
+++ b/src/views/TaskView.ts
@@ -1,4 +1,4 @@
-import { ItemView, TFile, WorkspaceLeaf } from 'obsidian'
+import { ItemView, WorkspaceLeaf } from 'obsidian'
 import type PMPlugin from '../main'
 import type { Task } from '../types'
 import { flattenTasks } from '../store'
@@ -69,13 +69,7 @@ export class TaskView extends ItemView {
 
     const { filePath, projectPath, parentId, defaults } = this.state
     const resolvedProjectPath = projectPath ?? (filePath ? this.plugin.index.projectPathForTask(filePath) : null)
-    const projectFile = resolvedProjectPath ? this.app.vault.getAbstractFileByPath(resolvedProjectPath) : null
-    if (!(projectFile instanceof TFile)) {
-      this.showMissing('This note does not belong to a project.')
-      return
-    }
-
-    const project = await this.plugin.store.loadProject(projectFile)
+    const project = resolvedProjectPath ? await this.plugin.store.loadProjectByPath(resolvedProjectPath) : null
     if (!project) {
       this.showMissing('This note does not belong to a project.')
       return


### PR DESCRIPTION
Adds `store.loadProjectByPath`, so the eight places holding a project path stop resolving the file and narrowing it themselves. Views, the task context menu, the task tab and two commands all called `getAbstractFileByPath` and checked `instanceof TFile` before `loadProject`; two of them spelled the same failure twice for the same outcome. Paths are normalized on the way in, which the open-coded lookups skipped. No behavior change beyond that.