### PR TITLE
space the task editor sections evenly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Searching for a task by its id found nothing ([#167](https://github.com/StepanKropachev/obsidian-pm/issues/167))
 - The import dialog offered the built-in statuses and priorities instead of the configured ones
 - The task editor showed two close buttons in its top right corner
+- The add property button in the task editor touched the custom fields section below it
+- The task editor left more space around the line under the properties than around its other section lines
 
 ## [1.8.0] - 2026-07-03
 

--- a/src/modals/ProjectCreateModal.ts
+++ b/src/modals/ProjectCreateModal.ts
@@ -57,7 +57,6 @@ export class ProjectCreateModal extends Modal {
     this.renderParent(grid)
     this.renderMembers(grid)
 
-    body.createEl('hr', { cls: 'pm-te-divider' })
     this.renderDescription(body)
 
     this.renderFooter(contentEl)

--- a/src/modals/TaskEditor.ts
+++ b/src/modals/TaskEditor.ts
@@ -369,8 +369,6 @@ export class TaskEditor {
       openTask: (path) => this.openLinkedTask(path)
     })
 
-    body.createEl('hr', { cls: 'pm-te-divider' })
-
     const descSection = body.createDiv('pm-modal-section pm-modal-desc-section')
     descSection.createEl('h4', { text: 'Description', cls: 'pm-modal-section-title' })
 

--- a/src/styles/task-editor.css
+++ b/src/styles/task-editor.css
@@ -373,7 +373,7 @@ button.pm-icon-trigger {
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-bottom: 8px;
+  margin-bottom: 10px;
 }
 /* Outside .pm-modal-section-header the title keeps its default bottom margin; zero it
    so the header's own margin sets the spacing. */
@@ -551,14 +551,10 @@ button.pm-icon-trigger {
   color: var(--text-faint);
   font-weight: 600;
 }
-.pm-te-props {
+/* Matches a section's own bottom padding, so the rule below the properties sits where the
+   rule below every other section does. A custom fields section brings its own padding. */
+.pm-te-props > .pm-prop-grid:last-child {
   margin-bottom: 14px;
-}
-.pm-te-divider {
-  height: 1px;
-  margin: 14px 0;
-  border: none;
-  background: var(--background-modifier-border);
 }
 
 .pm-te-footer {
@@ -615,7 +611,11 @@ button.pm-icon-trigger {
 }
 .pm-prop-add-cell {
   grid-column: 1 / -1;
-  padding-top: 4px;
+  padding-top: 2px;
+}
+/* The add-property button ends the grid, so the custom fields rule would sit against it. */
+.pm-te-props .pm-prop-grid + .pm-modal-section {
+  margin-top: 14px;
 }
 
 @media (max-width: 520px) {

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -34,7 +34,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-bottom: 8px;
+  margin-bottom: 4px;
 }
 .pm-time-label {
   font-size: 12px;
@@ -47,8 +47,11 @@
 .pm-time-log-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  margin-bottom: 8px;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+.pm-time-log-list:empty {
+  display: none;
 }
 .pm-time-log-row {
   display: flex;
@@ -166,7 +169,6 @@
 }
 
 .pm-modal-desc-section {
-  border-top: none;
   position: relative;
 }
 .pm-modal-desc-preview {


### PR DESCRIPTION
Every section line in the task editor now sits 14px below the content above it and 14px above the next heading. The line under the properties block was an hr whose margins stacked with the description section's padding, giving it double the clearance of the lines below, and the add property button sat directly on the custom fields line when a project defined custom fields. The subtask heading gap and the time tracking row gaps were also off by a few pixels from the rest.

The same hr was in the new project dialog and is gone there too; its description section draws the line instead.