### PR TITLE
follow a dependency chain out of its project when rescheduling

### DIFF
--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -37,7 +37,6 @@ function newStore(): { store: ProjectStore; vault: FakeVault; app: App } {
   return { store, vault, app: app as unknown as App }
 }
 
-/** A store backed by a real VaultIndex, for anything that reads across project files. */
 function newIndexedStore(): { store: ProjectStore; index: VaultIndex; app: App } {
   const { app } = makeFakeApp({ liveMetadataCache: true })
   const typed = app as unknown as App

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -16,6 +16,7 @@ import { ProjectStore } from './ProjectStore'
 import { addDays } from './Scheduler'
 import { buildTaskIndex } from './TaskIndex'
 import { findTask, flattenTasks } from './TaskTreeOps'
+import { VaultIndex } from './VaultIndex'
 
 const expectDefined = <T>(value: T | null | undefined, message = 'expected value to be defined'): T => {
   if (value == null) throw new Error(message)
@@ -34,6 +35,15 @@ function newStore(): { store: ProjectStore; vault: FakeVault; app: App } {
   const { app, vault } = makeFakeApp()
   const store = new ProjectStore(app as unknown as App, () => SETTINGS)
   return { store, vault, app: app as unknown as App }
+}
+
+/** A store backed by a real VaultIndex, for anything that reads across project files. */
+function newIndexedStore(): { store: ProjectStore; index: VaultIndex; app: App } {
+  const { app } = makeFakeApp({ liveMetadataCache: true })
+  const typed = app as unknown as App
+  const index = new VaultIndex(typed, () => SETTINGS)
+  const store = new ProjectStore(typed, () => SETTINGS, index)
+  return { store, index, app: typed }
 }
 
 function fileAt(app: App, path: string): TFile {
@@ -1190,5 +1200,93 @@ describe('per-project config', () => {
 
     project.config = undefined
     expect(await store.scheduleAfterChange(project, a.id)).toBeGreaterThan(0)
+  })
+})
+
+describe('ProjectStore cross-project scheduling', () => {
+  it('pushes dependents in other projects when a predecessor moves', async () => {
+    const { store, index } = newIndexedStore()
+    const upstream = await store.createProject('Upstream', 'Projects')
+    const middle = await store.createProject('Middle', 'Projects')
+    const downstream = await store.createProject('Downstream', 'Projects')
+
+    const a = await addNamed(store, upstream, 'Build')
+    const b = await addNamed(store, middle, 'Review')
+    const c = await addNamed(store, downstream, 'Launch')
+    await store.updateTask(upstream, a.id, { start: '2026-07-01', due: '2026-07-03' })
+    await store.updateTask(middle, b.id, { start: '2026-07-04', due: '2026-07-05', dependencies: [a.id] })
+    await store.updateTask(downstream, c.id, { start: '2026-07-06', due: '2026-07-06', dependencies: [b.id] })
+    index.build()
+
+    await store.updateTask(upstream, a.id, { start: '2026-07-08', due: '2026-07-10' })
+    expect(await store.scheduleAfterChange(upstream, a.id)).toBe(2)
+
+    expect(expectDefined(findTask(middle.tasks, b.id)).start).toBe('2026-07-11')
+    expect(expectDefined(findTask(middle.tasks, b.id)).due).toBe('2026-07-12')
+    expect(expectDefined(findTask(downstream.tasks, c.id)).start).toBe('2026-07-13')
+  })
+
+  it('leaves a project that turns auto-scheduling off alone but keeps following the chain', async () => {
+    const { store, index } = newIndexedStore()
+    const upstream = await store.createProject('Source', 'Projects')
+    const frozen = await store.createProject('Frozen', 'Projects')
+    const downstream = await store.createProject('Tail', 'Projects')
+
+    const a = await addNamed(store, upstream, 'Build')
+    const b = await addNamed(store, frozen, 'Fixed date')
+    const c = await addNamed(store, downstream, 'Launch')
+    await store.updateTask(upstream, a.id, { start: '2026-07-01', due: '2026-07-03' })
+    await store.updateTask(frozen, b.id, { start: '2026-07-04', due: '2026-07-05', dependencies: [a.id] })
+    await store.updateTask(downstream, c.id, { start: '2026-07-06', due: '2026-07-06', dependencies: [a.id] })
+    index.build()
+
+    frozen.config = { autoSchedule: false }
+    await store.updateTask(upstream, a.id, { start: '2026-07-08', due: '2026-07-10' })
+    await store.scheduleAfterChange(upstream, a.id)
+
+    expect(expectDefined(findTask(frozen.tasks, b.id)).start).toBe('2026-07-04')
+    expect(expectDefined(findTask(downstream.tasks, c.id)).start).toBe('2026-07-11')
+  })
+
+  it('pulls a dependent forward when the blocker finished early under another palette', async () => {
+    const { store, index } = newIndexedStore()
+    const upstream = await store.createProject('Ships', 'Projects')
+    const downstream = await store.createProject('Waits', 'Projects')
+    upstream.config = {
+      statuses: [
+        { id: 'todo', label: 'Todo', color: '#888', icon: 'circle', complete: false },
+        { id: 'shipped', label: 'Shipped', color: '#0a0', icon: 'check', complete: true }
+      ]
+    }
+    downstream.config = { pullForwardOnEarlyFinish: true }
+
+    const blocker = await addNamed(store, upstream, 'Blocker')
+    const blocked = await addNamed(store, downstream, 'Blocked')
+    await store.updateTask(upstream, blocker.id, { start: '2099-06-01', due: '2099-06-10' })
+    await store.updateTask(downstream, blocked.id, {
+      start: '2099-06-11',
+      due: '2099-06-12',
+      dependencies: [blocker.id]
+    })
+    index.build()
+
+    await store.updateTask(upstream, blocker.id, { status: 'shipped', completed: '2099-06-07' })
+
+    expect(expectDefined(findTask(downstream.tasks, blocked.id)).start).toBe('2099-06-08')
+    expect(expectDefined(findTask(downstream.tasks, blocked.id)).due).toBe('2099-06-09')
+  })
+
+  it('stops rather than looping when the chain closes a cycle across projects', async () => {
+    const { store, index } = newIndexedStore()
+    const one = await store.createProject('Ping', 'Projects')
+    const two = await store.createProject('Pong', 'Projects')
+
+    const a = await addNamed(store, one, 'A')
+    const b = await addNamed(store, two, 'B')
+    await store.updateTask(one, a.id, { start: '2026-07-01', due: '2026-07-02', dependencies: [b.id] })
+    await store.updateTask(two, b.id, { start: '2026-07-03', due: '2026-07-04', dependencies: [a.id] })
+    index.build()
+
+    await expect(store.scheduleAfterChange(one, a.id)).resolves.toBeGreaterThan(0)
   })
 })

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -113,7 +113,6 @@ export class ProjectStore implements TaskSource {
   private selfWrites = new Map<string, number>()
   private static readonly SELF_WRITE_WINDOW_MS = 5000
 
-  /** How far a reschedule follows a dependency chain out of one project and into others. */
   private static readonly MAX_SCHEDULE_ROUNDS = 10
 
   constructor(
@@ -938,7 +937,7 @@ export class ProjectStore implements TaskSource {
   private async scheduleAfterEarlyFinish(project: Project, taskIds: string[]): Promise<void> {
     if (taskIds.length === 0) return
     // A project that doesn't pull its own tasks forward still lets the projects waiting
-    // on it pull theirs, so the pass runs whenever the chain leaves this project.
+    // on it pull theirs.
     if (!this.configFor(project).pullForwardOnEarlyFinish) {
       const elsewhere = this.dependentsElsewhere(
         this.index?.dependentsMap() ?? new Map<string, string[]>(),
@@ -1160,9 +1159,8 @@ export class ProjectStore implements TaskSource {
 
   /**
    * Predecessors this project's tasks depend on that live in other projects. A project
-   * already loaded in this pass contributes the live task, so a date this pass just
-   * moved is the one the next project schedules against; anything else is a read-only
-   * stand-in built from the index.
+   * already loaded in this pass contributes the live task, because the index still holds
+   * the dates from before this pass moved them.
    */
   private externalPredecessors(project: Project, loaded: Map<string, Project>): Task[] {
     const externals: Task[] = []
@@ -1204,11 +1202,9 @@ export class ProjectStore implements TaskSource {
 
   /**
    * Apply dependency-based scheduling and save, returning the number of tasks adjusted.
-   *
-   * A dependency chain can leave the project it starts in, so this keeps following it:
-   * every task the pass moves is looked up in the index, and any project holding a task
-   * that waits on it gets its own pass, against its own config. A project with
-   * auto-scheduling off keeps its dates and still passes the change along.
+   * A dependency chain can leave the project it starts in, so every project holding a
+   * task that waits on one this pass moved gets its own pass, against its own config. A
+   * project with auto-scheduling off keeps its dates and still passes the change along.
    */
   async scheduleAfterChange(project: Project, changedTaskId?: string): Promise<number> {
     const loaded = new Map<string, Project>([[project.filePath, project]])
@@ -1245,7 +1241,6 @@ export class ProjectStore implements TaskSource {
     return total
   }
 
-  /** Schedules one project and saves it, returning the ids whose dates moved. */
   private async schedulePass(
     project: Project,
     seeds: string[] | undefined,

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -113,6 +113,9 @@ export class ProjectStore implements TaskSource {
   private selfWrites = new Map<string, number>()
   private static readonly SELF_WRITE_WINDOW_MS = 5000
 
+  /** How far a reschedule follows a dependency chain out of one project and into others. */
+  private static readonly MAX_SCHEDULE_ROUNDS = 10
+
   constructor(
     private app: App,
     private getSettings: () => PMSettings = () => DEFAULT_SETTINGS,
@@ -934,7 +937,16 @@ export class ProjectStore implements TaskSource {
 
   private async scheduleAfterEarlyFinish(project: Project, taskIds: string[]): Promise<void> {
     if (taskIds.length === 0) return
-    if (!this.configFor(project).pullForwardOnEarlyFinish) return
+    // A project that doesn't pull its own tasks forward still lets the projects waiting
+    // on it pull theirs, so the pass runs whenever the chain leaves this project.
+    if (!this.configFor(project).pullForwardOnEarlyFinish) {
+      const elsewhere = this.dependentsElsewhere(
+        this.index?.dependentsMap() ?? new Map<string, string[]>(),
+        project,
+        taskIds
+      )
+      if (elsewhere.size === 0) return
+    }
     for (const id of taskIds) await this.scheduleAfterChange(project, id)
   }
 
@@ -1147,22 +1159,24 @@ export class ProjectStore implements TaskSource {
   }
 
   /**
-   * Apply dependency-based scheduling and save, returning the number of tasks
-   * adjusted. A no-op when auto-scheduling is off, so callers needn't check.
+   * Predecessors this project's tasks depend on that live in other projects. A project
+   * already loaded in this pass contributes the live task, so a date this pass just
+   * moved is the one the next project schedules against; anything else is a read-only
+   * stand-in built from the index.
    */
-  /**
-   * Predecessors this project's tasks depend on that live in other projects, as read-only
-   * stand-ins the scheduler can date against.
-   */
-  private externalPredecessors(project: Project): Task[] {
-    if (!this.index) return []
+  private externalPredecessors(project: Project, loaded: Map<string, Project>): Task[] {
     const externals: Task[] = []
     const seen = new Set<string>()
     for (const { task } of flattenTasks(project.tasks)) {
       for (const depId of task.dependencies) {
         if (project.taskIndex.has(depId) || seen.has(depId)) continue
         seen.add(depId)
-        const ref = this.index.task(depId)
+        const live = this.liveTask(depId, loaded)
+        if (live) {
+          externals.push(live)
+          continue
+        }
+        const ref = this.index?.task(depId)
         if (!ref) continue
         externals.push(
           makeTask({
@@ -1180,23 +1194,99 @@ export class ProjectStore implements TaskSource {
     return externals
   }
 
+  private liveTask(taskId: string, loaded: Map<string, Project>): Task | null {
+    for (const candidate of loaded.values()) {
+      const found = candidate.taskIndex.get(taskId)?.task
+      if (found) return found
+    }
+    return null
+  }
+
+  /**
+   * Apply dependency-based scheduling and save, returning the number of tasks adjusted.
+   *
+   * A dependency chain can leave the project it starts in, so this keeps following it:
+   * every task the pass moves is looked up in the index, and any project holding a task
+   * that waits on it gets its own pass, against its own config. A project with
+   * auto-scheduling off keeps its dates and still passes the change along.
+   */
   async scheduleAfterChange(project: Project, changedTaskId?: string): Promise<number> {
+    const loaded = new Map<string, Project>([[project.filePath, project]])
+    const dependentsOf = this.index?.dependentsMap() ?? new Map<string, string[]>()
+    let frontier: { project: Project; seeds: string[] | undefined }[] = [
+      { project, seeds: changedTaskId === undefined ? undefined : [changedTaskId] }
+    ]
+    let total = 0
+
+    for (let round = 0; round < ProjectStore.MAX_SCHEDULE_ROUNDS && frontier.length > 0; round++) {
+      const nextSeeds = new Map<string, Set<string>>()
+      for (const job of frontier) {
+        const moved = await this.schedulePass(job.project, job.seeds, loaded)
+        total += moved.length
+        for (const [path, ids] of this.dependentsElsewhere(
+          dependentsOf,
+          job.project,
+          job.seeds ? [...job.seeds, ...moved] : moved
+        )) {
+          const bucket = nextSeeds.get(path) ?? new Set<string>()
+          for (const id of ids) bucket.add(id)
+          nextSeeds.set(path, bucket)
+        }
+      }
+
+      frontier = []
+      for (const [path, ids] of nextSeeds) {
+        const target = loaded.get(path) ?? (await this.loadProjectByPath(path))
+        if (!target) continue
+        loaded.set(path, target)
+        frontier.push({ project: target, seeds: [...ids] })
+      }
+    }
+    return total
+  }
+
+  /** Schedules one project and saves it, returning the ids whose dates moved. */
+  private async schedulePass(
+    project: Project,
+    seeds: string[] | undefined,
+    loaded: Map<string, Project>
+  ): Promise<string[]> {
     const config = this.configFor(project)
-    if (!config.autoSchedule) return 0
+    if (!config.autoSchedule) return []
     const { patches } = computeSchedule(
       project.tasks,
-      changedTaskId,
+      seeds,
       config.statuses,
       config.pullForwardOnEarlyFinish,
-      this.externalPredecessors(project)
+      this.externalPredecessors(project, loaded)
     )
-    if (patches.length === 0) return 0
+    if (patches.length === 0) return []
 
     for (const p of patches) {
       updateTaskInTree(project.tasks, p.taskId, { start: p.start, due: p.due })
       this.markDirty(project, [p.taskId], 'fm')
     }
     await this.saveProject(project)
-    return patches.length
+    return patches.map((p) => p.taskId)
+  }
+
+  /** Tasks outside `project` waiting on any of `movedIds`, grouped by their project. */
+  private dependentsElsewhere(
+    dependentsOf: Map<string, string[]>,
+    project: Project,
+    movedIds: string[]
+  ): Map<string, string[]> {
+    const byProject = new Map<string, string[]>()
+    for (const movedId of movedIds) {
+      for (const dependentId of dependentsOf.get(movedId) ?? []) {
+        if (project.taskIndex.has(dependentId)) continue
+        const ref = this.index?.task(dependentId)
+        if (!ref?.projectPath || ref.archived) continue
+        const list = byProject.get(ref.projectPath) ?? []
+        if (!list.includes(dependentId)) list.push(dependentId)
+        byProject.set(ref.projectPath, list)
+      }
+    }
+    return byProject
   }
 }

--- a/src/store/Scheduler.ts
+++ b/src/store/Scheduler.ts
@@ -159,8 +159,8 @@ export function computeSchedule(
     startOf.set(t.id, t.start)
     dueOf.set(t.id, t.due)
     if (!pullForward || !t.completed || !t.due || t.completed >= t.due) continue
-    // An external's completion date was stamped against its own project's palette, which
-    // is not the one passed here, so its own status can't be re-checked from this side.
+    // An external's completion date was stamped against its own project's palette, not
+    // the one passed here, so its status can't be re-checked from this side.
     if (!externalIds.has(t.id) && !isTerminalStatus(t.status, statuses)) continue
     dueOf.set(t.id, t.completed)
     daysSavedBy.set(t.id, daysBetween(t.completed, t.due))

--- a/src/store/Scheduler.ts
+++ b/src/store/Scheduler.ts
@@ -61,9 +61,9 @@ export function wouldCreateCycle(tasks: Task[], fromId: string, toId: string): b
 }
 
 /**
- * Date patches derived from the dependency graph. `changedTaskId` scopes the pass to
- * that task's downstream dependents. Terminal-status tasks never move; their dates are
- * a record of what happened.
+ * Date patches derived from the dependency graph. `changed` scopes the pass to the
+ * downstream dependents of the task ids it names. Terminal-status tasks never move;
+ * their dates are a record of what happened.
  *
  * With `pullForward`, a predecessor that finished early counts as ending on its
  * completion date and its dependents move up by the days saved, keeping their existing
@@ -71,7 +71,8 @@ export function wouldCreateCycle(tasks: Task[], fromId: string, toId: string): b
  */
 export function computeSchedule(
   tasks: Task[],
-  changedTaskId?: string,
+  /** The tasks whose dates just moved. Absent reschedules the whole tree. */
+  changed?: string | string[],
   statuses: StatusConfig[] = [],
   pullForward = false,
   /** Predecessors in other projects. They constrain dates here but are never moved. */
@@ -99,10 +100,11 @@ export function computeSchedule(
     predecessorsOf.set(t.id, validDeps)
   }
 
+  const seeds = changed === undefined ? [] : typeof changed === 'string' ? [changed] : changed
   let scopeIds: Set<string> | null = null
-  if (changedTaskId) {
+  if (seeds.length > 0) {
     scopeIds = new Set<string>()
-    const queue = [changedTaskId]
+    const queue = [...seeds]
     while (queue.length > 0) {
       const id = queue.shift()
       if (id === undefined) break
@@ -157,7 +159,9 @@ export function computeSchedule(
     startOf.set(t.id, t.start)
     dueOf.set(t.id, t.due)
     if (!pullForward || !t.completed || !t.due || t.completed >= t.due) continue
-    if (!isTerminalStatus(t.status, statuses)) continue
+    // An external's completion date was stamped against its own project's palette, which
+    // is not the one passed here, so its own status can't be re-checked from this side.
+    if (!externalIds.has(t.id) && !isTerminalStatus(t.status, statuses)) continue
     dueOf.set(t.id, t.completed)
     daysSavedBy.set(t.id, daysBetween(t.completed, t.due))
   }

--- a/src/store/VaultIndex.test.ts
+++ b/src/store/VaultIndex.test.ts
@@ -1,4 +1,5 @@
 import type { App, Plugin } from 'obsidian'
+import { TFile } from 'obsidian'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { makeFakeApp, type FakeVault } from '../../test/fakeVault'
 import { DEFAULT_SETTINGS, type PMSettings } from '../types'
@@ -254,6 +255,18 @@ describe('VaultIndex', () => {
       // t2 already depends on t1, so making t1 depend on t2 closes the loop.
       expect(index.wouldCreateCycle('t1', 't2')).toBe(true)
       expect(index.wouldCreateCycle('t2', 't1')).toBe(false)
+    })
+
+    it('picks up a dependency added after the first read', async () => {
+      index.register(fakePlugin())
+      expect(index.dependentsMap().get('t2')).toBeUndefined()
+
+      await vault.modify(
+        expectDefined(vault.getAbstractFileByPath('A_tasks/one.md') as TFile | null),
+        `---\npm-task: true\nid: t1\nprojectId: p1\ntitle: One\nstatus: todo\ndependencies:\n  - t2\n---\n`
+      )
+
+      expect(index.dependentsMap().get('t2')).toEqual(['t1'])
     })
   })
 

--- a/src/store/VaultIndex.ts
+++ b/src/store/VaultIndex.ts
@@ -79,6 +79,8 @@ export class VaultIndex {
     children: new Map()
   }
   private treeDirty = true
+  private cachedDependents = new Map<string, string[]>()
+  private dependentsDirty = true
   /** False until the first build, so a view can tell "none yet" from "none at all". */
   ready = false
 
@@ -95,6 +97,7 @@ export class VaultIndex {
     this.taskById.clear()
     this.tasksByProject.clear()
     this.treeDirty = true
+    this.dependentsDirty = true
     for (const file of this.app.vault.getMarkdownFiles()) this.read(file)
     this.resolveUnowned()
     this.ready = true
@@ -324,8 +327,12 @@ export class VaultIndex {
     return [...this.tasks.values()].filter((ref) => ref.dependencies.includes(taskId))
   }
 
-  /** Predecessor id -> ids of everything waiting on it, across every project. */
+  /**
+   * Predecessor id -> ids of everything waiting on it, across every project. Cached, so a
+   * reschedule that walks a chain through several projects builds it once.
+   */
   dependentsMap(): Map<string, string[]> {
+    if (!this.dependentsDirty) return this.cachedDependents
     const map = new Map<string, string[]>()
     for (const ref of this.tasks.values()) {
       for (const depId of ref.dependencies) {
@@ -334,6 +341,8 @@ export class VaultIndex {
         else map.set(depId, [ref.id])
       }
     }
+    this.cachedDependents = map
+    this.dependentsDirty = false
     return map
   }
 
@@ -393,6 +402,7 @@ export class VaultIndex {
     }
     this.tasks.set(path, ref)
     this.taskById.set(ref.id, ref)
+    this.dependentsDirty = true
     this.own(ref)
   }
 
@@ -506,6 +516,7 @@ export class VaultIndex {
       this.tasks.delete(normalized)
       if (this.taskById.get(task.id) === task) this.taskById.delete(task.id)
       if (task.projectPath) this.tasksByProject.get(task.projectPath)?.delete(normalized)
+      this.dependentsDirty = true
       return true
     }
     const project = this.projects.get(normalized)

--- a/src/store/VaultIndex.ts
+++ b/src/store/VaultIndex.ts
@@ -327,10 +327,7 @@ export class VaultIndex {
     return [...this.tasks.values()].filter((ref) => ref.dependencies.includes(taskId))
   }
 
-  /**
-   * Predecessor id -> ids of everything waiting on it, across every project. Cached, so a
-   * reschedule that walks a chain through several projects builds it once.
-   */
+  /** Predecessor id -> ids of everything waiting on it, across every project. */
   dependentsMap(): Map<string, string[]> {
     if (!this.dependentsDirty) return this.cachedDependents
     const map = new Map<string, string[]>()

--- a/src/views/gantt/GanttLinkHandler.ts
+++ b/src/views/gantt/GanttLinkHandler.ts
@@ -65,8 +65,8 @@ export function handleLinkDotClick(
 
   cancelLink(link)
 
-  // The two bars can belong to different projects, so the dependency is written to the
-  // successor's own project rather than to whichever bar was clicked last.
+  // The two bars can belong to different projects, and the dependency belongs to the
+  // successor's.
   const successor = scope.taskById(successorId)
   const project = scope.projectOf(successorId)
   if (!successor || !project) {
@@ -79,7 +79,6 @@ export function handleLinkDotClick(
     return
   }
 
-  // A predecessor chain can leave this project and come back, so the check spans the vault.
   if (plugin.index.wouldCreateCycle(successorId, predecessorId)) {
     new Notice('That link would create a dependency cycle.')
     return

--- a/src/views/gantt/GanttLinkHandler.ts
+++ b/src/views/gantt/GanttLinkHandler.ts
@@ -1,6 +1,6 @@
 import { Notice } from 'obsidian'
 import type PMPlugin from '../../main'
-import type { Project, Task } from '../../types'
+import type { ProjectScope } from '../../store'
 import { safeAsync } from '../../utils'
 
 export interface LinkState {
@@ -30,7 +30,7 @@ export function handleLinkDotClick(
   side: 'left' | 'right',
   link: LinkState,
   plugin: PMPlugin,
-  project: Project,
+  scope: ProjectScope,
   onRefresh: () => Promise<void>
 ): void {
   if (!link.active) {
@@ -65,21 +65,27 @@ export function handleLinkDotClick(
 
   cancelLink(link)
 
-  const allTasks = flattenAll(project.tasks)
-  const successor = allTasks.find((t) => t.id === successorId)
-  if (successor?.dependencies?.includes(predecessorId)) {
+  // The two bars can belong to different projects, so the dependency is written to the
+  // successor's own project rather than to whichever bar was clicked last.
+  const successor = scope.taskById(successorId)
+  const project = scope.projectOf(successorId)
+  if (!successor || !project) {
+    new Notice('That task is no longer in this view.')
+    return
+  }
+
+  if (successor.dependencies.includes(predecessorId)) {
     new Notice('This dependency already exists.')
     return
   }
 
-  // The reverse edge would close a cycle.
-  const predecessor = allTasks.find((t) => t.id === predecessorId)
-  if (predecessor?.dependencies?.includes(successorId)) {
-    new Notice('Reverse dependency exists — would create a cycle.')
+  // A predecessor chain can leave this project and come back, so the check spans the vault.
+  if (plugin.index.wouldCreateCycle(successorId, predecessorId)) {
+    new Notice('That link would create a dependency cycle.')
     return
   }
 
-  const deps = [...(successor?.dependencies ?? []), predecessorId]
+  const deps = [...successor.dependencies, predecessorId]
   void safeAsync(async () => {
     try {
       await plugin.store.updateTask(project, successorId, { dependencies: deps })
@@ -91,17 +97,4 @@ export function handleLinkDotClick(
     await plugin.store.scheduleAfterChange(project, successorId)
     await onRefresh()
   })()
-}
-
-// Local copy: importing TaskTreeOps here would be circular.
-function flattenAll(tasks: Task[]): Task[] {
-  const result: Task[] = []
-  const walk = (list: Task[]) => {
-    for (const t of list) {
-      result.push(t)
-      if (t.subtasks.length) walk(t.subtasks)
-    }
-  }
-  walk(tasks)
-  return result
 }

--- a/src/views/gantt/GanttTaskBarRenderer.ts
+++ b/src/views/gantt/GanttTaskBarRenderer.ts
@@ -165,7 +165,7 @@ export function renderTaskBar(g: SVGGElement, task: Task, row: number, _depth: n
     })
     dot.addEventListener('click', (e: MouseEvent) => {
       e.stopPropagation()
-      handleLinkDotClick(dot, task.id, side, ctx.link, ctx.plugin, project, ctx.onRefresh)
+      handleLinkDotClick(dot, task.id, side, ctx.link, ctx.plugin, ctx.scope, ctx.onRefresh)
     })
     barGroup.appendChild(dot)
   }

--- a/src/views/table/TableView.ts
+++ b/src/views/table/TableView.ts
@@ -170,10 +170,8 @@ export class TableView implements SubView {
         break
       case 'set-due-date':
         await this.plugin.store.updateTasks(project, ids, { due: action.due })
-        if (this.plugin.store.configFor(project).autoSchedule) {
-          for (const id of ids) {
-            await this.plugin.store.scheduleAfterChange(project, id)
-          }
+        for (const id of ids) {
+          await this.plugin.store.scheduleAfterChange(project, id)
         }
         break
       case 'set-progress':


### PR DESCRIPTION
Moving a task's dates now moves its dependents in other projects too, not only the ones in the same project. The reschedule pass ran over one project's tree and saved only that project, so a chain crossing a project boundary stopped there.

A gantt link drawn between bars in different projects was also written to whichever bar was clicked last, and lost when that was the wrong project; its cycle check now spans the vault.