### PR TITLE
give each project a folder of its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- A project keeps its note and its task notes together in a folder of its own
+- An existing project moves into its own folder when the vault is opened, keeping its filters, saved views, and open tabs
+- A new sub-project is created inside its parent's folder
+- Renaming a project note renames its folder, and renaming its folder renames the note
+- Deleting a project deletes its folder, unless a sub-project sits inside it
 - The tags offered in the task editor are listed alphabetically
 - Custom fields in the task editor use the same controls as the task's own properties, so a custom date opens the date picker and a custom select the same popover as status
 - Project members, the global team members, and task assignees are picked from the same control, which searches the people in your vault and offers to create the note for a new name

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ import {
   confirmDialog
 } from './ui/ModalFactory'
 import { Notifier } from './components/Notifier'
-import { migrateProjects } from './migration'
+import { migrateProjects, migrateProjectLayout } from './migration'
 import { dedupePeople, displayName, safeAsync } from './utils'
 
 export default class PMPlugin extends Plugin {
@@ -334,6 +334,7 @@ export default class PMPlugin extends Plugin {
   /** The startup work that reads the index: migration, pruning, and the first due sweep. */
   private async startupSweep(): Promise<void> {
     await migrateProjects(this)
+    await migrateProjectLayout(this)
     await this.cleanupStaleProjectFilters()
     this.notifier.check()
   }

--- a/src/migration.test.ts
+++ b/src/migration.test.ts
@@ -1,0 +1,119 @@
+import type { App } from 'obsidian'
+import { TFile } from 'obsidian'
+import { describe, expect, it } from 'vitest'
+import { makeFakeApp } from '../test/fakeVault'
+import { migrateProjectLayout } from './migration'
+import type PMPlugin from './main'
+import { ProjectStore, VaultIndex } from './store'
+import { DEFAULT_SETTINGS, makeDefaultFilter, type PMSettings } from './types'
+
+const projectNote = (id: string, title: string): string =>
+  ['---', 'pm-project: true', `id: ${id}`, `title: ${title}`, 'taskIds:', '  - t1', '---', ''].join('\n')
+
+const taskNote = (id: string, title: string, projectId: string): string =>
+  ['---', 'pm-task: true', `id: ${id}`, `projectId: ${projectId}`, `title: ${title}`, 'status: todo', '---', ''].join(
+    '\n'
+  )
+
+interface FakeLeaf {
+  state: Record<string, unknown>
+  getViewState: () => { type: string; state: Record<string, unknown> }
+  setViewState: (viewState: { type: string; state: Record<string, unknown> }) => void
+}
+
+function fakeLeaf(state: Record<string, unknown>): FakeLeaf {
+  const leaf: FakeLeaf = {
+    state,
+    getViewState: () => ({ type: 'pm-project', state: leaf.state }),
+    setViewState: (viewState) => {
+      leaf.state = viewState.state
+    }
+  }
+  return leaf
+}
+
+async function legacyVault(leaves: FakeLeaf[]): Promise<{ plugin: PMPlugin; app: App; settings: PMSettings }> {
+  const { app, vault } = makeFakeApp({ liveMetadataCache: true })
+  const typed = app as unknown as App
+  await vault.create('Projects/Roadmap.md', projectNote('p1', 'Roadmap'))
+  await vault.create('Projects/Roadmap_tasks/design.md', taskNote('t1', 'Design', 'p1'))
+  await vault.create('Projects/Roadmap_tasks/Archive/old.md', taskNote('t2', 'Old', 'p1'))
+
+  const settings: PMSettings = structuredClone(DEFAULT_SETTINGS)
+  const index = new VaultIndex(typed, () => settings)
+  index.build()
+  const store = new ProjectStore(typed, () => settings, index)
+
+  const plugin = {
+    app: {
+      ...app,
+      workspace: {
+        iterateAllLeaves: (visit: (leaf: FakeLeaf) => void) => {
+          for (const leaf of leaves) visit(leaf)
+        }
+      }
+    },
+    index,
+    store,
+    settings,
+    saveSettings: async () => {}
+  } as unknown as PMPlugin
+
+  return { plugin, app: typed, settings }
+}
+
+describe('migrateProjectLayout', () => {
+  it('moves a project and its tasks into a folder of its own', async () => {
+    const { plugin, app } = await legacyVault([])
+
+    await migrateProjectLayout(plugin)
+
+    expect(app.vault.getAbstractFileByPath('Projects/Roadmap/Roadmap.md')).toBeInstanceOf(TFile)
+    expect(app.vault.getAbstractFileByPath('Projects/Roadmap/_tasks/design.md')).toBeInstanceOf(TFile)
+    expect(app.vault.getAbstractFileByPath('Projects/Roadmap/_tasks/Archive/old.md')).toBeInstanceOf(TFile)
+    expect(app.vault.getAbstractFileByPath('Projects/Roadmap_tasks')).toBeNull()
+  })
+
+  it('carries the filters, saved views and collapsed state over to the new path', async () => {
+    const { plugin, settings } = await legacyVault([])
+    settings.projectFilters['project:Projects/Roadmap.md'] = { filter: makeDefaultFilter(), activeSavedViewId: null }
+    settings.scopeViews['subtree:Projects/Roadmap.md'] = []
+    settings.collapsedTasks['Projects/Roadmap.md'] = ['t1']
+    settings.collapsedProjects.push('Projects/Roadmap.md')
+
+    await migrateProjectLayout(plugin)
+
+    expect(settings.projectFilters['project:Projects/Roadmap/Roadmap.md']).toBeDefined()
+    expect(settings.projectFilters['project:Projects/Roadmap.md']).toBeUndefined()
+    expect(settings.scopeViews['subtree:Projects/Roadmap/Roadmap.md']).toBeDefined()
+    expect(settings.collapsedTasks['Projects/Roadmap/Roadmap.md']).toEqual(['t1'])
+    expect(settings.collapsedProjects).toEqual(['Projects/Roadmap/Roadmap.md'])
+  })
+
+  it('retargets the tabs the workspace restored before it ran', async () => {
+    const scoped = fakeLeaf({ scope: { kind: 'subtree', path: 'Projects/Roadmap.md' } })
+    const overview = fakeLeaf({ filePath: 'Projects/Roadmap.md' })
+    const task = fakeLeaf({ filePath: 'Projects/Roadmap_tasks/design.md', projectPath: 'Projects/Roadmap.md' })
+    const unrelated = fakeLeaf({ filePath: 'Notes/idea.md' })
+    const { plugin } = await legacyVault([scoped, overview, task, unrelated])
+
+    await migrateProjectLayout(plugin)
+
+    expect(scoped.state.scope).toEqual({ kind: 'subtree', path: 'Projects/Roadmap/Roadmap.md' })
+    expect(overview.state.filePath).toBe('Projects/Roadmap/Roadmap.md')
+    expect(task.state.filePath).toBe('Projects/Roadmap/_tasks/design.md')
+    expect(task.state.projectPath).toBe('Projects/Roadmap/Roadmap.md')
+    expect(unrelated.state.filePath).toBe('Notes/idea.md')
+  })
+
+  it('does nothing on a second run', async () => {
+    const { plugin, app } = await legacyVault([])
+    await migrateProjectLayout(plugin)
+    const before = app.vault.getAbstractFileByPath('Projects/Roadmap/Roadmap.md')
+
+    await migrateProjectLayout(plugin)
+
+    expect(app.vault.getAbstractFileByPath('Projects/Roadmap/Roadmap.md')).toBe(before)
+    expect(app.vault.getAbstractFileByPath('Projects/Roadmap/Roadmap')).toBeNull()
+  })
+})

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -1,5 +1,6 @@
 import { Notice, TFile } from 'obsidian'
 import type PMPlugin from './main'
+import type { ScopeSpec } from './store'
 import { parseFrontmatter, isOldFormat } from './store/YamlParser'
 
 /** Rewrites projects whose tasks are embedded in frontmatter as one file per task. */
@@ -31,4 +32,113 @@ export async function migrateProjects(plugin: PMPlugin): Promise<void> {
   if (migrated > 0) {
     new Notice(`Project Manager: Migrated ${migrated} project(s) to new format.`)
   }
+}
+
+interface ProjectMove {
+  from: string
+  to: string
+  tasksFrom: string
+  tasksTo: string
+}
+
+/**
+ * Moves every project that still sits beside a `<name>_tasks` folder into a folder of its
+ * own, then follows the moved paths through the settings and any open tab. Idempotent: a
+ * project that already owns its folder is skipped, so a run interrupted halfway finishes
+ * on the next launch.
+ */
+export async function migrateProjectLayout(plugin: PMPlugin): Promise<void> {
+  const moves: ProjectMove[] = []
+
+  for (const path of plugin.index.projectPaths()) {
+    try {
+      const to = await plugin.store.moveProjectIntoOwnFolder(path)
+      if (!to) continue
+      moves.push({
+        from: path,
+        to,
+        tasksFrom: path.replace(/\.md$/, '_tasks'),
+        tasksTo: `${to.slice(0, to.lastIndexOf('/'))}/_tasks`
+      })
+    } catch (e) {
+      console.error(`[PM] Failed to move "${path}" into its own folder:`, e)
+      new Notice(`Project Manager: Could not move "${path}" into its own folder. Check console for details.`)
+    }
+  }
+
+  if (moves.length === 0) return
+
+  remapProjectSettings(plugin, moves)
+  retargetOpenViews(plugin, moves)
+  await plugin.saveSettings()
+  new Notice(`Project Manager: Moved ${moves.length} project(s) into their own folders.`)
+}
+
+function movedPath(path: string, moves: ProjectMove[]): string | null {
+  for (const move of moves) {
+    if (path === move.from) return move.to
+    if (path === move.tasksFrom) return move.tasksTo
+    if (path.startsWith(move.tasksFrom + '/')) return move.tasksTo + path.slice(move.tasksFrom.length)
+  }
+  return null
+}
+
+/** Per-project filters, saved views and collapsed state are keyed by the project's path. */
+function remapProjectSettings(plugin: PMPlugin, moves: ProjectMove[]): void {
+  const { projectFilters, scopeViews, collapsedTasks, collapsedProjects } = plugin.settings
+
+  for (const { from, to } of moves) {
+    for (const kind of ['project', 'subtree']) {
+      const oldKey = `${kind}:${from}`
+      const newKey = `${kind}:${to}`
+      const filter = projectFilters[oldKey]
+      if (filter) {
+        projectFilters[newKey] = filter
+        Reflect.deleteProperty(projectFilters, oldKey)
+      }
+      const views = scopeViews[oldKey]
+      if (views) {
+        scopeViews[newKey] = views
+        Reflect.deleteProperty(scopeViews, oldKey)
+      }
+    }
+
+    const collapsed = collapsedTasks[from]
+    if (collapsed) {
+      collapsedTasks[to] = collapsed
+      Reflect.deleteProperty(collapsedTasks, from)
+    }
+
+    const at = collapsedProjects.indexOf(from)
+    if (at !== -1) collapsedProjects[at] = to
+  }
+}
+
+/** The workspace restores its tabs before this runs, so open views still hold old paths. */
+function retargetOpenViews(plugin: PMPlugin, moves: ProjectMove[]): void {
+  plugin.app.workspace.iterateAllLeaves((leaf) => {
+    const viewState = leaf.getViewState()
+    const state = { ...(viewState.state as Record<string, unknown>) }
+    let changed = false
+
+    for (const key of ['filePath', 'projectPath']) {
+      const value = state[key]
+      const moved = typeof value === 'string' ? movedPath(value, moves) : null
+      if (moved) {
+        state[key] = moved
+        changed = true
+      }
+    }
+
+    const scope = state.scope as ScopeSpec | undefined
+    if (scope && scope.kind !== 'vault') {
+      const moved = movedPath(scope.path, moves)
+      if (moved) {
+        state.scope = { ...scope, path: moved }
+        changed = true
+      }
+    }
+
+    if (changed) void leaf.setViewState({ ...viewState, state })
+  })
 }

--- a/src/modals/ProjectCreateModal.ts
+++ b/src/modals/ProjectCreateModal.ts
@@ -1,7 +1,7 @@
 import { App, ButtonComponent, ExtraButtonComponent, Modal, setIcon } from 'obsidian'
 import type PMPlugin from '../main'
 import { DEFAULT_PROJECT_COLOR, DEFAULT_PROJECT_ICON } from '../types'
-import { projectFilePath } from '../store'
+import { projectFilePath, projectFolderOf } from '../store'
 import { safeAsync } from '../utils'
 import { renderPersonPicker } from '../ui/PersonPicker'
 import { renderPropRow } from '../ui/FormField'
@@ -29,6 +29,7 @@ export class ProjectCreateModal extends Modal {
   private header!: HTMLElement
   private titleInput!: HTMLTextAreaElement
   private titleError!: HTMLElement
+  private crumbFolder!: HTMLElement
   private pathHint!: HTMLElement
   private iconHost!: HTMLElement
   private submit!: ButtonComponent
@@ -83,7 +84,7 @@ export class ProjectCreateModal extends Modal {
     const crumb = this.header.createDiv('pm-te-crumb')
     const folderIcon = crumb.createSpan({ cls: 'pm-te-crumb-icon' })
     setIcon(folderIcon, 'folder')
-    crumb.createSpan({ cls: 'pm-te-crumb-name', text: this.plugin.settings.projectsFolder || this.app.vault.getName() })
+    this.crumbFolder = crumb.createSpan({ cls: 'pm-te-crumb-name', text: this.targetFolder() })
     const sep = crumb.createSpan({ cls: 'pm-te-crumb-sep' })
     setIcon(sep, 'chevron-right')
     crumb.createSpan({ text: 'New project' })
@@ -190,6 +191,7 @@ export class ProjectCreateModal extends Modal {
             onChange: (path) => {
               this.draft.parentPath = path
               draw()
+              this.refreshValidity()
             }
           })
         }
@@ -263,6 +265,7 @@ export class ProjectCreateModal extends Modal {
     const path = title ? this.targetPath(title) : ''
     const taken = !!path && !!this.app.vault.getAbstractFileByPath(path)
 
+    this.crumbFolder.setText(this.targetFolder())
     this.pathHint.lastElementChild?.setText(path)
     this.pathHint.toggleClass('pm-hidden', !path)
     if (taken) {
@@ -277,14 +280,21 @@ export class ProjectCreateModal extends Modal {
     this.submit.setDisabled(!title || taken)
   }
 
+  /** A sub-project goes inside its parent's folder; a root project in the projects folder. */
+  private targetFolder(): string {
+    const parentPath = this.draft.parentPath
+    if (!parentPath) return this.plugin.settings.projectsFolder || this.app.vault.getName()
+    return projectFolderOf(this.app, parentPath) ?? parentPath.slice(0, parentPath.lastIndexOf('/'))
+  }
+
   private targetPath(title: string): string {
-    return projectFilePath(title, this.plugin.settings.projectsFolder)
+    return projectFilePath(title, this.targetFolder())
   }
 
   private readonly create = safeAsync(async () => {
     const title = this.draft.title.trim()
     if (!title || this.app.vault.getAbstractFileByPath(this.targetPath(title))) return
-    const project = await this.plugin.store.createProject(title, this.plugin.settings.projectsFolder, {
+    const project = await this.plugin.store.createProject(title, this.targetFolder(), {
       icon: this.draft.icon,
       color: this.draft.color,
       description: this.draft.description,

--- a/src/store/ArchiveOps.ts
+++ b/src/store/ArchiveOps.ts
@@ -2,11 +2,7 @@ import type { App } from 'obsidian'
 import { TFile, normalizePath } from 'obsidian'
 import type { Project, Task } from '../types'
 import { findTaskById } from './TaskIndex'
-import { ensureFolder, moveTaskAttachmentFolder } from './vaultFs'
-
-function projectTaskFolder(project: Project): string {
-  return project.filePath.replace(/\.md$/, '_tasks')
-}
+import { ensureFolder, moveTaskAttachmentFolder, projectTaskFolder } from './vaultFs'
 
 function subtree(task: Task): Task[] {
   return [task, ...task.subtasks.flatMap(subtree)]
@@ -52,7 +48,7 @@ export async function archiveTask(
   const task = findTaskById(project, taskId)
   if (!task) return
 
-  const archiveFolder = normalizePath(projectTaskFolder(project) + '/Archive')
+  const archiveFolder = normalizePath(projectTaskFolder(app, project.filePath) + '/Archive')
   await ensureFolder(app, archiveFolder)
 
   for (const t of subtree(task)) {
@@ -69,7 +65,7 @@ export async function unarchiveTask(
   const task = findTaskById(project, taskId)
   if (!task) return
 
-  const taskFolder = normalizePath(projectTaskFolder(project))
+  const taskFolder = normalizePath(projectTaskFolder(app, project.filePath))
   for (const t of subtree(task)) {
     if (await moveTaskFile(app, t, taskFolder, markSelfWrite)) t.archived = false
   }

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -319,14 +319,14 @@ describe('ProjectStore round-trip', () => {
     const store = new ProjectStore(app as unknown as App, () => SETTINGS)
     await store.createProject('Platform', 'Projects')
     const child = await store.createProject('Billing', 'Work')
-    await store.updateProject(child, { parentPath: 'Projects/Platform.md' })
+    await store.updateProject(child, { parentPath: 'Projects/Platform/Platform.md' })
 
     const content = await vault.cachedRead(fileAt(app as unknown as App, child.filePath))
-    expect(content).toContain('parent: "[[Projects/Platform]]"')
+    expect(content).toContain('parent: "[[Projects/Platform/Platform]]"')
 
     const store2 = new ProjectStore(app as unknown as App, () => SETTINGS)
     const reloaded = await store2.loadProject(fileAt(app as unknown as App, child.filePath))
-    expect(reloaded?.parentPath).toBe('Projects/Platform.md')
+    expect(reloaded?.parentPath).toBe('Projects/Platform/Platform.md')
   })
 
   it('migrates an old-format (embedded tasks) project on load and save', async () => {
@@ -514,8 +514,8 @@ describe('ProjectStore task attachments', () => {
 
     const file = await store.saveTaskAttachment(project, task, 'pic.png', new ArrayBuffer(4))
 
-    expect(file.path).toBe('Projects/Imgs_tasks/shot/attachments/pic.png')
-    expect(vault.getAbstractFileByPath('Projects/Imgs_tasks/shot/attachments/pic.png')).not.toBeNull()
+    expect(file.path).toBe('Projects/Imgs/_tasks/shot/attachments/pic.png')
+    expect(vault.getAbstractFileByPath('Projects/Imgs/_tasks/shot/attachments/pic.png')).not.toBeNull()
   })
 
   it('disambiguates a colliding attachment name', async () => {
@@ -526,8 +526,8 @@ describe('ProjectStore task attachments', () => {
     const first = await store.saveTaskAttachment(project, task, 'pic.png', new ArrayBuffer(4))
     const second = await store.saveTaskAttachment(project, task, 'pic.png', new ArrayBuffer(4))
 
-    expect(first.path).toBe('Projects/Imgs_tasks/shot/attachments/pic.png')
-    expect(second.path).toBe('Projects/Imgs_tasks/shot/attachments/pic 1.png')
+    expect(first.path).toBe('Projects/Imgs/_tasks/shot/attachments/pic.png')
+    expect(second.path).toBe('Projects/Imgs/_tasks/shot/attachments/pic 1.png')
   })
 
   it('trashes the attachments folder when the task is deleted', async () => {
@@ -538,8 +538,8 @@ describe('ProjectStore task attachments', () => {
 
     await store.deleteTask(project, task.id)
 
-    expect(vault.getAbstractFileByPath('Projects/Imgs_tasks/shot/attachments/pic.png')).toBeNull()
-    expect(vault.getAbstractFileByPath('Projects/Imgs_tasks/shot')).toBeNull()
+    expect(vault.getAbstractFileByPath('Projects/Imgs/_tasks/shot/attachments/pic.png')).toBeNull()
+    expect(vault.getAbstractFileByPath('Projects/Imgs/_tasks/shot')).toBeNull()
   })
 
   it('moves the attachments folder when the task is renamed', async () => {
@@ -550,8 +550,8 @@ describe('ProjectStore task attachments', () => {
 
     await store.updateTask(project, task.id, { title: 'Photo' })
 
-    expect(vault.getAbstractFileByPath('Projects/Imgs_tasks/shot/attachments/pic.png')).toBeNull()
-    expect(vault.getAbstractFileByPath('Projects/Imgs_tasks/photo/attachments/pic.png')).not.toBeNull()
+    expect(vault.getAbstractFileByPath('Projects/Imgs/_tasks/shot/attachments/pic.png')).toBeNull()
+    expect(vault.getAbstractFileByPath('Projects/Imgs/_tasks/photo/attachments/pic.png')).not.toBeNull()
   })
 
   it('moves the attachments folder when the task is archived and back when unarchived', async () => {
@@ -561,12 +561,12 @@ describe('ProjectStore task attachments', () => {
     await store.saveTaskAttachment(project, task, 'pic.png', new ArrayBuffer(4))
 
     await store.archiveTask(project, task.id)
-    expect(vault.getAbstractFileByPath('Projects/Imgs_tasks/shot/attachments/pic.png')).toBeNull()
-    expect(vault.getAbstractFileByPath('Projects/Imgs_tasks/Archive/shot/attachments/pic.png')).not.toBeNull()
+    expect(vault.getAbstractFileByPath('Projects/Imgs/_tasks/shot/attachments/pic.png')).toBeNull()
+    expect(vault.getAbstractFileByPath('Projects/Imgs/_tasks/Archive/shot/attachments/pic.png')).not.toBeNull()
 
     await store.unarchiveTask(project, task.id)
-    expect(vault.getAbstractFileByPath('Projects/Imgs_tasks/Archive/shot/attachments/pic.png')).toBeNull()
-    expect(vault.getAbstractFileByPath('Projects/Imgs_tasks/shot/attachments/pic.png')).not.toBeNull()
+    expect(vault.getAbstractFileByPath('Projects/Imgs/_tasks/Archive/shot/attachments/pic.png')).toBeNull()
+    expect(vault.getAbstractFileByPath('Projects/Imgs/_tasks/shot/attachments/pic.png')).not.toBeNull()
   })
 })
 
@@ -582,7 +582,7 @@ describe('ProjectStore archiving', () => {
 
     for (const task of [parent, child, grandchild]) {
       expect(task.archived).toBe(true)
-      expect(task.filePath).toMatch(/^Projects\/Tree_tasks\/Archive\//)
+      expect(task.filePath).toMatch(/^Projects\/Tree\/_tasks\/Archive\//)
       expect(vault.getAbstractFileByPath(expectDefined(task.filePath))).not.toBeNull()
     }
   })
@@ -598,7 +598,7 @@ describe('ProjectStore archiving', () => {
 
     for (const task of [parent, child]) {
       expect(task.archived).toBe(false)
-      expect(task.filePath).toBe(`Projects/Tree_tasks/${task.title.toLowerCase()}.md`)
+      expect(task.filePath).toBe(`Projects/Tree/_tasks/${task.title.toLowerCase()}.md`)
       expect(vault.getAbstractFileByPath(expectDefined(task.filePath))).not.toBeNull()
     }
   })
@@ -613,7 +613,7 @@ describe('ProjectStore archiving', () => {
     await store.archiveTask(project, parent.id)
 
     expect(child.archived).toBe(true)
-    expect(child.filePath).toBe('Projects/Tree_tasks/Archive/child.md')
+    expect(child.filePath).toBe('Projects/Tree/_tasks/Archive/child.md')
   })
 })
 
@@ -905,8 +905,8 @@ describe('ProjectStore concurrent-save race', () => {
     const second = store.updateTask(project, b.id, { title: 'B new' })
     await Promise.all([first, second])
 
-    expect(vault.getAbstractFileByPath('Projects/Race_tasks/a-new.md')).not.toBeNull()
-    expect(vault.getAbstractFileByPath('Projects/Race_tasks/b-new.md')).not.toBeNull()
+    expect(vault.getAbstractFileByPath('Projects/Race/_tasks/a-new.md')).not.toBeNull()
+    expect(vault.getAbstractFileByPath('Projects/Race/_tasks/b-new.md')).not.toBeNull()
     expect(vault.getAbstractFileByPath(aOldPath)).toBeNull()
     expect(vault.getAbstractFileByPath(bOldPath)).toBeNull()
   })
@@ -980,9 +980,9 @@ describe('ProjectStore.moveTaskToProject', () => {
     expect(from.tasks).toHaveLength(0)
     expect(to.tasks.map((t) => t.id)).toEqual([parent.id])
     expect(to.tasks[0].subtasks.map((t) => t.id)).toEqual([child.id])
-    expect(vault.getAbstractFileByPath('Projects/From_tasks/parent.md')).toBeNull()
-    expect(vault.getAbstractFileByPath('Work/To_tasks/parent.md')).not.toBeNull()
-    expect(vault.getAbstractFileByPath('Work/To_tasks/child.md')).not.toBeNull()
+    expect(vault.getAbstractFileByPath('Projects/From/_tasks/parent.md')).toBeNull()
+    expect(vault.getAbstractFileByPath('Work/To/_tasks/parent.md')).not.toBeNull()
+    expect(vault.getAbstractFileByPath('Work/To/_tasks/child.md')).not.toBeNull()
 
     const store2 = new ProjectStore(app, () => SETTINGS)
     const reloaded = await store2.loadProject(fileAt(app, to.filePath))
@@ -997,7 +997,7 @@ describe('ProjectStore.moveTaskToProject', () => {
 
     await store.moveTaskToProject(from, to, task.id)
 
-    const content = await app.vault.cachedRead(fileAt(app, 'Work/To_tasks/solo.md'))
+    const content = await app.vault.cachedRead(fileAt(app, 'Work/To/_tasks/solo.md'))
     expect(content).toContain(`projectId: "${to.id}"`)
   })
 
@@ -1046,7 +1046,7 @@ describe('ProjectStore.importNoteAsTask', () => {
     expect(result).toBe('imported')
     expect(vault.getAbstractFileByPath('Notes/Idea.md')).toBeInstanceOf(TFile)
 
-    const created = vault.getAbstractFileByPath('Projects/Import_tasks/idea.md')
+    const created = vault.getAbstractFileByPath('Projects/Import/_tasks/idea.md')
     if (!(created instanceof TFile)) throw new Error('imported task file missing')
     const content = await vault.read(created)
     expect(content).toContain('pm-task: true')
@@ -1060,7 +1060,7 @@ describe('ProjectStore.importNoteAsTask', () => {
     expect(result).toBe('imported')
     expect(vault.getAbstractFileByPath('Notes/Idea.md')).toBeNull()
 
-    const moved = vault.getAbstractFileByPath('Projects/Import_tasks/idea.md')
+    const moved = vault.getAbstractFileByPath('Projects/Import/_tasks/idea.md')
     if (!(moved instanceof TFile)) throw new Error('imported task file missing')
     const content = await vault.read(moved)
     expect(content).toContain('pm-task: true')
@@ -1078,7 +1078,7 @@ describe('ProjectStore.importNoteAsTask', () => {
 
   it('skips notes that are already tasks', async () => {
     const { store, vault, project } = await importInto('copy')
-    const existing = vault.getAbstractFileByPath('Projects/Import_tasks/idea.md')
+    const existing = vault.getAbstractFileByPath('Projects/Import/_tasks/idea.md')
     if (!(existing instanceof TFile)) throw new Error('imported task file missing')
     const before = await vault.read(existing)
 
@@ -1128,7 +1128,7 @@ describe('ProjectStore.importTaskForest', () => {
     const task = makeTask({ title: 'Old', archived: true })
 
     await store.importTaskForest(project, [task], new Map([[task.id, source]]), 'copy')
-    expect(vault.getAbstractFileByPath('Projects/Arch_tasks/Archive/old.md')).toBeInstanceOf(TFile)
+    expect(vault.getAbstractFileByPath('Projects/Arch/_tasks/Archive/old.md')).toBeInstanceOf(TFile)
     expect(vault.getAbstractFileByPath('Notes/Old.md')).toBeInstanceOf(TFile)
   })
 })
@@ -1287,5 +1287,115 @@ describe('ProjectStore cross-project scheduling', () => {
     index.build()
 
     await expect(store.scheduleAfterChange(one, a.id)).resolves.toBeGreaterThan(0)
+  })
+})
+
+describe('ProjectStore project folders', () => {
+  const flush = (): Promise<void> => new Promise((resolve) => window.setTimeout(resolve, 0))
+
+  const syncedStore = (): ReturnType<typeof newIndexedStore> => {
+    const made = newIndexedStore()
+    made.store.registerVaultSync({ registerEvent: () => {}, register: () => {} } as unknown as Plugin)
+    return made
+  }
+
+  it('creates a project in a folder of its own', async () => {
+    const { store, app } = newStore()
+    const project = await store.createProject('Roadmap', 'Projects')
+    const task = await addNamed(store, project, 'Design')
+
+    expect(project.filePath).toBe('Projects/Roadmap/Roadmap.md')
+    expect(task.filePath).toBe('Projects/Roadmap/_tasks/design.md')
+    expect(app.vault.getAbstractFileByPath('Projects/Roadmap/_tasks/design.md')).toBeInstanceOf(TFile)
+  })
+
+  it('moves a project that still sits beside its task folder into its own folder', async () => {
+    const { store, app } = newIndexedStore()
+    await app.vault.create(
+      'Projects/Legacy.md',
+      ['---', 'pm-project: true', 'id: p1', 'title: Legacy', 'taskIds: []', '---', ''].join('\n')
+    )
+    await app.vault.createFolder('Projects/Legacy_tasks')
+    await app.vault.create(
+      'Projects/Legacy_tasks/first.md',
+      ['---', 'pm-task: true', 'id: t1', 'title: First', 'status: todo', '---', ''].join('\n')
+    )
+
+    const moved = await store.moveProjectIntoOwnFolder('Projects/Legacy.md')
+
+    expect(moved).toBe('Projects/Legacy/Legacy.md')
+    expect(app.vault.getAbstractFileByPath('Projects/Legacy/_tasks/first.md')).toBeInstanceOf(TFile)
+    expect(app.vault.getAbstractFileByPath('Projects/Legacy.md')).toBeNull()
+    expect(app.vault.getAbstractFileByPath('Projects/Legacy_tasks')).toBeNull()
+
+    const reloaded = await store.loadProjectByPath('Projects/Legacy/Legacy.md')
+    expect(flattenTasks(expectDefined(reloaded).tasks).map((f) => f.task.title)).toEqual(['First'])
+  })
+
+  it('leaves a project that already owns its folder alone', async () => {
+    const { store } = newStore()
+    const project = await store.createProject('Roadmap', 'Projects')
+    await expect(store.moveProjectIntoOwnFolder(project.filePath)).resolves.toBeNull()
+  })
+
+  it('trashes the whole folder when a project is deleted', async () => {
+    const { store, app } = newStore()
+    const project = await store.createProject('Doomed', 'Projects')
+    await addNamed(store, project, 'Card')
+
+    await store.deleteProject(project)
+
+    expect(app.vault.getAbstractFileByPath('Projects/Doomed')).toBeNull()
+  })
+
+  it('spares a sub-project nested in the folder of a deleted project', async () => {
+    const { store, index, app } = newIndexedStore()
+    const parent = await store.createProject('Parent', 'Projects')
+    const child = await store.createProject('Child', 'Projects/Parent')
+    index.build()
+
+    await store.deleteProject(parent)
+
+    expect(app.vault.getAbstractFileByPath(parent.filePath)).toBeNull()
+    expect(app.vault.getAbstractFileByPath('Projects/Parent/_tasks')).toBeNull()
+    expect(app.vault.getAbstractFileByPath(child.filePath)).toBeInstanceOf(TFile)
+  })
+
+  it('renames the folder when the project note is renamed', async () => {
+    const { store, app } = syncedStore()
+    const project = await store.createProject('Alpha', 'Projects')
+    const task = await addNamed(store, project, 'Card')
+
+    await app.fileManager.renameFile(fileAt(app, project.filePath), 'Projects/Alpha/Beta.md')
+    await flush()
+
+    expect(app.vault.getAbstractFileByPath('Projects/Beta/Beta.md')).toBeInstanceOf(TFile)
+    expect(project.filePath).toBe('Projects/Beta/Beta.md')
+    expect(
+      app.vault.getAbstractFileByPath(`Projects/Beta/_tasks/${expectDefined(task.filePath).split('/').pop()}`)
+    ).toBeInstanceOf(TFile)
+  })
+
+  it('renames the project note when its folder is renamed', async () => {
+    const { store, app } = syncedStore()
+    const project = await store.createProject('Alpha', 'Projects')
+
+    const folder = expectDefined(app.vault.getAbstractFileByPath('Projects/Alpha'))
+    await app.vault.rename(folder, 'Projects/Gamma')
+    await flush()
+
+    expect(app.vault.getAbstractFileByPath('Projects/Gamma/Gamma.md')).toBeInstanceOf(TFile)
+    expect(project.filePath).toBe('Projects/Gamma/Gamma.md')
+  })
+
+  it('takes the task folder along when a project note leaves its folder', async () => {
+    const { store, app } = syncedStore()
+    const project = await store.createProject('Alpha', 'Projects')
+    await addNamed(store, project, 'Card')
+
+    await app.fileManager.renameFile(fileAt(app, project.filePath), 'Work/Alpha.md')
+    await flush()
+
+    expect(app.vault.getAbstractFileByPath('Work/Alpha_tasks/card.md')).toBeInstanceOf(TFile)
   })
 })

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -34,7 +34,16 @@ import {
   taskFilePath,
   TASK_SLUG_MAX_LENGTH
 } from './YamlSerializer'
-import { ensureFolder, moveProjectTaskFolder, moveTaskAttachmentFolder, resolveVaultLink } from './vaultFs'
+import {
+  ensureFolder,
+  keepProjectStorageWithNote,
+  moveTaskAttachmentFolder,
+  projectFolderOf,
+  projectTaskFolder,
+  renameProjectFolderNote,
+  resolveVaultLink,
+  TASK_FOLDER_NAME
+} from './vaultFs'
 import type { ImportNoteOptions, TaskSource } from './TaskSource'
 
 /** 'fm' writes via processFrontMatter; 'full' rewrites the body too, via vault.process. */
@@ -80,9 +89,11 @@ function fileNameFromPath(path: string): string {
 }
 
 /**
- * All read/write operations against the vault. `Projects/<name>.md` holds project
- * metadata; `Projects/<name>_tasks/<slug>.md` holds one file per task. The in-memory
- * `Project.tasks` tree is assembled from those files on load.
+ * All read/write operations against the vault. A project owns a folder:
+ * `Projects/<name>/<name>.md` holds its metadata and `Projects/<name>/_tasks/<slug>.md`
+ * holds one file per task. A project that has not been migrated yet still sits beside a
+ * `Projects/<name>_tasks/` folder and reads the same way. The in-memory `Project.tasks`
+ * tree is assembled from those files on load.
  */
 export class ProjectStore implements TaskSource {
   private saveQueues = new Map<string, Promise<void>>()
@@ -196,6 +207,7 @@ export class ProjectStore implements TaskSource {
     plugin.registerEvent(
       this.app.vault.on('rename', (file, oldPath) => {
         if (file instanceof TFile) void this.followProjectRename(oldPath, file.path)
+        else if (file instanceof TFolder) void this.followProjectFolderRename(oldPath, file.path)
         this.syncPath(file.path)
         this.syncPath(oldPath)
       })
@@ -206,13 +218,55 @@ export class ProjectStore implements TaskSource {
     })
   }
 
-  /** A renamed project note takes its task folder with it, so its tasks stay attached. */
+  /** A renamed project note takes its folder, or failing that its task folder, with it. */
   private async followProjectRename(oldPath: string, newPath: string): Promise<void> {
+    if (!this.projectCache.has(oldPath) && !this.isProjectNote(newPath)) return
     try {
-      await moveProjectTaskFolder(this.app, oldPath, newPath)
+      const notePath = await keepProjectStorageWithNote(this.app, oldPath, newPath, (p) => this.markSelfWrite(p))
+      await this.rekeyProject(oldPath, notePath)
     } catch (e) {
       console.error(`[PM] Failed to move the task folder for "${newPath}":`, e)
     }
+  }
+
+  /** A renamed project folder takes its note's name with it, so the pair keeps matching. */
+  private async followProjectFolderRename(oldPath: string, newPath: string): Promise<void> {
+    try {
+      const oldName = oldPath.slice(oldPath.lastIndexOf('/') + 1)
+      const moved = await renameProjectFolderNote(this.app, oldPath, newPath, (file) => this.isProjectNote(file.path))
+      if (moved) await this.rekeyProject(`${oldPath}/${oldName}.md`, moved)
+    } catch (e) {
+      console.error(`[PM] Failed to rename the project note in "${newPath}":`, e)
+    }
+  }
+
+  private isProjectNote(path: string): boolean {
+    const file = this.app.vault.getAbstractFileByPath(path)
+    if (!(file instanceof TFile)) return false
+    return this.app.metadataCache.getFileCache(file)?.frontmatter?.[FRONTMATTER_KEY] === true
+  }
+
+  /** Moves the live project, its queue and its pending writes onto the note's new path. */
+  private async rekeyProject(oldPath: string, newPath: string): Promise<void> {
+    if (oldPath === newPath) return
+    const cached = this.projectCache.get(oldPath)
+    if (!cached) return
+    this.projectCache.delete(oldPath)
+    this.projectCache.set(newPath, cached)
+    const dirty = this.dirtyTasks.get(oldPath)
+    if (dirty) {
+      this.dirtyTasks.delete(oldPath)
+      this.dirtyTasks.set(newPath, dirty)
+    }
+    const queued = this.saveQueues.get(oldPath)
+    if (queued) {
+      this.saveQueues.delete(oldPath)
+      this.saveQueues.set(newPath, queued)
+    }
+    const project = await cached
+    if (!project) return
+    project.filePath = newPath
+    this.emitChange(newPath)
   }
 
   /** An external write landed: reload the live project so every holder sees it. */
@@ -220,7 +274,7 @@ export class ProjectStore implements TaskSource {
     if (this.projectCache.size === 0) return
     if (this.peekSelfWrite(path)) return
     for (const key of this.projectCache.keys()) {
-      if (path === key || path.startsWith(key.replace(/\.md$/, '_tasks') + '/')) {
+      if (path === key || path.startsWith(projectTaskFolder(this.app, key) + '/')) {
         const pending = this.reloadTimers.get(key)
         if (pending !== undefined) window.clearTimeout(pending)
         this.reloadTimers.set(
@@ -284,10 +338,6 @@ export class ProjectStore implements TaskSource {
     await ensureFolder(this.app, folderPath)
   }
 
-  private projectTaskFolder(project: Project): string {
-    return project.filePath.replace(/\.md$/, '_tasks')
-  }
-
   async loadProjects(paths: string[]): Promise<Project[]> {
     const loaded = await Promise.all(paths.map((path) => this.loadProjectByPath(path)))
     const projects = loaded.filter((p): p is Project => p !== null)
@@ -344,7 +394,7 @@ export class ProjectStore implements TaskSource {
         // Old format: no per-task files on disk yet.
         this.markAllDirty(project, 'full')
       } else {
-        const taskFolder = this.projectTaskFolder(project)
+        const taskFolder = projectTaskFolder(this.app, project.filePath)
         const taskIds = Array.isArray(frontmatter.taskIds) ? (frontmatter.taskIds as string[]) : []
         project.tasks = await this.loadTasksFromFolder(taskFolder, taskIds)
         rebuildTaskIndex(project)
@@ -520,7 +570,9 @@ export class ProjectStore implements TaskSource {
     try {
       project.updatedAt = new Date().toISOString()
 
-      const taskFolder = this.projectTaskFolder(project)
+      const own = projectFolderOf(this.app, project.filePath)
+      if (own) await this.ensureFolder(own)
+      const taskFolder = projectTaskFolder(this.app, project.filePath)
       await this.ensureFolder(taskFolder)
 
       await this.saveDirtyTasks(project, taskFolder, dirty)
@@ -677,7 +729,7 @@ export class ProjectStore implements TaskSource {
 
   /** Pre-flight check so callers can surface the conflict inline instead of on save. */
   findTaskFileConflict(project: Project, task: Task): TaskFileNameConflictError | null {
-    const baseFolder = this.projectTaskFolder(project)
+    const baseFolder = projectTaskFolder(this.app, project.filePath)
     const folder = task.archived ? normalizePath(baseFolder + '/Archive') : baseFolder
     const desired = normalizePath(resolveTaskPath(task, folder, task.filePath))
     if (desired === task.filePath) return null
@@ -688,9 +740,39 @@ export class ProjectStore implements TaskSource {
   async createProject(title: string, folder: string, patch?: ProjectPatch): Promise<Project> {
     const project = makeProject(title, projectFilePath(title, folder))
     if (patch) Object.assign(project, patch)
-    await this.ensureFolder(this.projectTaskFolder(project))
     await this.saveProject(project)
     return project
+  }
+
+  /**
+   * The task folder moves first: once it is gone from beside the note, the rename below
+   * reads as a plain move and the vault listener has nothing left to follow.
+   */
+  async moveProjectIntoOwnFolder(projectPath: string): Promise<string | null> {
+    const file = this.app.vault.getAbstractFileByPath(projectPath)
+    if (!(file instanceof TFile) || projectFolderOf(this.app, projectPath)) return null
+
+    const dir = projectPath.slice(0, projectPath.lastIndexOf('/'))
+    const target = normalizePath(dir ? `${dir}/${file.basename}` : file.basename)
+    if (this.app.vault.getAbstractFileByPath(target) instanceof TFile) return null
+
+    const tasks = this.app.vault.getAbstractFileByPath(projectTaskFolder(this.app, projectPath))
+    await this.ensureFolder(target)
+    if (tasks instanceof TFolder) {
+      const tasksTarget = normalizePath(`${target}/${TASK_FOLDER_NAME}`)
+      if (!this.app.vault.getAbstractFileByPath(tasksTarget)) {
+        this.markSelfWrite(tasks.path)
+        this.markSelfWrite(tasksTarget)
+        await this.app.vault.rename(tasks, tasksTarget)
+      }
+    }
+
+    const notePath = normalizePath(`${target}/${file.name}`)
+    this.markSelfWrite(projectPath)
+    this.markSelfWrite(notePath)
+    await this.app.fileManager.renameFile(file, notePath)
+    await this.rekeyProject(projectPath, notePath)
+    return notePath
   }
 
   async insertTask(project: Project, task: Task, parentId: string | null = null): Promise<void> {
@@ -720,7 +802,7 @@ export class ProjectStore implements TaskSource {
       status: opts.status,
       priority: opts.priority
     })
-    const folder = this.projectTaskFolder(project)
+    const folder = projectTaskFolder(this.app, project.filePath)
     await this.ensureFolder(folder)
     const newFilePath = taskFilePath(task.title, folder)
     const newContent = serializeTask(task, project, null, this.statusesFor(project))
@@ -748,7 +830,7 @@ export class ProjectStore implements TaskSource {
     sources: Map<string, TFile>,
     handling: 'move' | 'copy'
   ): Promise<number> {
-    const baseFolder = this.projectTaskFolder(project)
+    const baseFolder = projectTaskFolder(this.app, project.filePath)
     await this.ensureFolder(baseFolder)
     let imported = 0
 
@@ -791,7 +873,7 @@ export class ProjectStore implements TaskSource {
     // Filenames come from the title slug within one flat folder, so a clone keeping
     // the source title would write over the original. Reserve a free "(copy)" title
     // for every node, checking the clones we're adding so siblings don't collide.
-    const baseFolder = this.projectTaskFolder(project)
+    const baseFolder = projectTaskFolder(this.app, project.filePath)
     const claimed = new Set<string>()
     const usedTitles = new Set(flattenTasks(project.tasks).map((f) => f.task.title))
     const claimName = (task: Task): void => {
@@ -854,7 +936,7 @@ export class ProjectStore implements TaskSource {
     indexRemoveSubtree(from, task)
     if (oldParentId) this.markDirty(from, [oldParentId], 'full')
 
-    const targetFolder = this.projectTaskFolder(to)
+    const targetFolder = projectTaskFolder(this.app, to.filePath)
     await this.ensureFolder(targetFolder)
     for (const moved of [task, ...flattenTasks(task.subtasks).map((ft) => ft.task)]) {
       // The file lands in the target folder under the same name; dropping filePath here
@@ -995,7 +1077,7 @@ export class ProjectStore implements TaskSource {
       }
     }
 
-    const folder = this.projectTaskFolder(project)
+    const folder = projectTaskFolder(this.app, project.filePath)
     for (const removed of oldSubtree) {
       if (liveIds.has(removed.id)) continue
       project.taskIndex.delete(removed.id)
@@ -1043,7 +1125,7 @@ export class ProjectStore implements TaskSource {
   }
 
   async deleteTasks(project: Project, taskIds: string[]): Promise<void> {
-    const folder = this.projectTaskFolder(project)
+    const folder = projectTaskFolder(this.app, project.filePath)
     const dirtyParents = new Set<string>()
     for (const id of taskIds) {
       const parentId = findParentId(project, id)
@@ -1074,7 +1156,7 @@ export class ProjectStore implements TaskSource {
     const parentId = findParentId(project, taskId)
     const task = findTaskById(project, taskId)
     if (task) {
-      await this.deleteTaskFiles(task, this.projectTaskFolder(project))
+      await this.deleteTaskFiles(task, projectTaskFolder(this.app, project.filePath))
       indexRemoveSubtree(project, task)
     }
     deleteTaskFromTree(project.tasks, taskId)
@@ -1107,7 +1189,7 @@ export class ProjectStore implements TaskSource {
 
   /** Keeps a pasted or dropped file with the task, not in the vault-wide default folder. */
   async saveTaskAttachment(project: Project, task: Task, fileName: string, data: ArrayBuffer): Promise<TFile> {
-    const taskPath = task.filePath ?? taskFilePath(task.title, this.projectTaskFolder(project))
+    const taskPath = task.filePath ?? taskFilePath(task.title, projectTaskFolder(this.app, project.filePath))
     const dir = normalizePath(`${this.taskFolder(taskPath)}/attachments`)
     this.markSelfWrite(this.taskFolder(taskPath))
     this.markSelfWrite(dir)
@@ -1129,10 +1211,14 @@ export class ProjectStore implements TaskSource {
   }
 
   async deleteProject(project: Project): Promise<void> {
-    const taskFolder = this.projectTaskFolder(project)
-    const folder = this.app.vault.getAbstractFileByPath(taskFolder)
-    if (folder instanceof TFolder) {
-      await this.deleteFolderRecursive(folder)
+    // The whole folder goes, unless a sub-project is nested in it and would go with it.
+    const own = projectFolderOf(this.app, project.filePath)
+    const holdsOthers = own !== null && this.projectPathsInside(own).some((path) => path !== project.filePath)
+    const doomed = own && !holdsOthers ? own : projectTaskFolder(this.app, project.filePath)
+    const target = this.app.vault.getAbstractFileByPath(doomed)
+    if (target instanceof TFolder) {
+      this.markSelfWrite(project.filePath)
+      await this.deleteFolderRecursive(target)
     }
     const file = this.app.vault.getAbstractFileByPath(project.filePath)
     if (file instanceof TFile) {
@@ -1143,6 +1229,10 @@ export class ProjectStore implements TaskSource {
     this.saveQueues.delete(project.filePath)
     this.projectCache.delete(project.filePath)
     this.emitChange(project.filePath)
+  }
+
+  private projectPathsInside(folder: string): string[] {
+    return (this.index?.projectPaths() ?? []).filter((path) => path.startsWith(folder + '/'))
   }
 
   private async deleteFolderRecursive(folder: TFolder): Promise<void> {

--- a/src/store/TaskSource.ts
+++ b/src/store/TaskSource.ts
@@ -40,6 +40,11 @@ export interface TaskSource {
   loadProjectBody(project: Project): Promise<void>
 
   createProject(title: string, folder: string, patch?: ProjectPatch): Promise<Project>
+  /**
+   * Moves a project that still sits beside its `<name>_tasks` folder into a folder of its
+   * own. Returns the note's new path, or null when the project already owns a folder.
+   */
+  moveProjectIntoOwnFolder(projectPath: string): Promise<string | null>
   saveProject(project: Project): Promise<void>
   updateProject(project: Project, patch: ProjectPatch): Promise<void>
   deleteProject(project: Project): Promise<void>

--- a/src/store/VaultIndex.test.ts
+++ b/src/store/VaultIndex.test.ts
@@ -55,6 +55,20 @@ describe('VaultIndex', () => {
     expect(index.projectPaths()).toEqual(['Projects/Roadmap.md'])
   })
 
+  it('attributes tasks in a project folder to that project, and nests sub-projects', async () => {
+    await vault.create('Projects/Roadmap/Roadmap.md', projectNote('p1', 'Roadmap'))
+    await vault.create('Projects/Roadmap/_tasks/one.md', taskNote('t1', 'One', 'p1'))
+    await vault.create('Projects/Roadmap/_tasks/Archive/two.md', taskNote('t2', 'Two', 'p1'))
+    await vault.create('Projects/Roadmap/_tasks/loose.md', projectNote('p3', 'Loose'))
+    await vault.create('Projects/Roadmap/Q3/Q3.md', projectNote('p2', 'Q3', 'parent: "[[Roadmap]]"\n'))
+    index.build()
+
+    expect(index.projectPaths()).toEqual(['Projects/Roadmap/Q3/Q3.md', 'Projects/Roadmap/Roadmap.md'])
+    expect(index.projectPathForTask('Projects/Roadmap/_tasks/one.md')).toBe('Projects/Roadmap/Roadmap.md')
+    expect(index.projectPathForTask('Projects/Roadmap/_tasks/Archive/two.md')).toBe('Projects/Roadmap/Roadmap.md')
+    expect(index.childRefs('Projects/Roadmap/Roadmap.md').map((ref) => ref.path)).toEqual(['Projects/Roadmap/Q3/Q3.md'])
+  })
+
   it('skips excluded folders', async () => {
     await vault.create('Projects/Roadmap.md', projectNote('p1', 'Roadmap'))
     await vault.create('Templates/Project template.md', projectNote('tpl', 'Template'))

--- a/src/store/YamlSerializer.ts
+++ b/src/store/YamlSerializer.ts
@@ -153,6 +153,8 @@ export function taskFilePath(taskTitle: string, folder: string): string {
   return `${folder}/${taskSlug(taskTitle)}.md`
 }
 
+/** A project owns a folder named after it, holding its note and its `_tasks/`. */
 export function projectFilePath(projectTitle: string, folder: string): string {
-  return normalizePath(`${folder}/${sanitizeFileName(projectTitle)}.md`)
+  const name = sanitizeFileName(projectTitle)
+  return normalizePath(`${folder}/${name}/${name}.md`)
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -51,7 +51,7 @@ export {
   resolvePerson
 } from './people'
 export type { PersonCandidate, PersonLinkState, PersonMatch, PersonRef } from './people'
-export { projectPathForTaskPath } from './vaultFs'
+export { projectFolderOf, projectPathForTaskPath, projectTaskFolder, TASK_FOLDER_NAME } from './vaultFs'
 export { hydrateTasks } from './YamlHydrator'
 export { appendYaml, isOldFormat, parseFrontmatter } from './YamlParser'
 export { projectFilePath, serializeProject, serializeTask } from './YamlSerializer'

--- a/src/store/vaultFs.test.ts
+++ b/src/store/vaultFs.test.ts
@@ -1,0 +1,72 @@
+import type { App } from 'obsidian'
+import { describe, expect, it } from 'vitest'
+import { makeFakeApp } from '../../test/fakeVault'
+import { projectFolderOf, projectPathForTaskPath, projectTaskFolder } from './vaultFs'
+
+async function vaultWith(paths: string[]): Promise<App> {
+  const { app, vault } = makeFakeApp()
+  for (const path of paths) {
+    if (path.endsWith('/')) await vault.createFolder(path.slice(0, -1))
+    else await vault.create(path, '')
+  }
+  return app as unknown as App
+}
+
+describe('projectPathForTaskPath', () => {
+  it('reads a task in a project folder', () => {
+    expect(projectPathForTaskPath('Projects/Roadmap/_tasks/design.md')).toBe('Projects/Roadmap/Roadmap.md')
+  })
+
+  it('reads an archived task in a project folder', () => {
+    expect(projectPathForTaskPath('Projects/Roadmap/_tasks/Archive/old.md')).toBe('Projects/Roadmap/Roadmap.md')
+  })
+
+  it('reads a task beside a project that has not moved yet', () => {
+    expect(projectPathForTaskPath('Projects/Roadmap_tasks/design.md')).toBe('Projects/Roadmap.md')
+    expect(projectPathForTaskPath('Projects/Roadmap_tasks/Archive/old.md')).toBe('Projects/Roadmap.md')
+  })
+
+  it('reads a task in a nested sub-project', () => {
+    expect(projectPathForTaskPath('Projects/Roadmap/Q3/_tasks/ship.md')).toBe('Projects/Roadmap/Q3/Q3.md')
+  })
+
+  it('ignores a note outside any task storage', () => {
+    expect(projectPathForTaskPath('Notes/idea.md')).toBeNull()
+    expect(projectPathForTaskPath('_tasks/loose.md')).toBeNull()
+  })
+})
+
+describe('projectTaskFolder', () => {
+  it('puts task storage inside the folder a project owns', async () => {
+    const app = await vaultWith(['Projects/Roadmap/Roadmap.md'])
+    expect(projectFolderOf(app, 'Projects/Roadmap/Roadmap.md')).toBe('Projects/Roadmap')
+    expect(projectTaskFolder(app, 'Projects/Roadmap/Roadmap.md')).toBe('Projects/Roadmap/_tasks')
+  })
+
+  it('keeps a project that has not moved yet beside its task folder', async () => {
+    const app = await vaultWith(['Projects/Roadmap.md', 'Projects/Roadmap_tasks/'])
+    expect(projectFolderOf(app, 'Projects/Roadmap.md')).toBeNull()
+    expect(projectTaskFolder(app, 'Projects/Roadmap.md')).toBe('Projects/Roadmap_tasks')
+  })
+
+  it('keeps the storage of a note renamed inside the folder it owns', async () => {
+    const app = await vaultWith(['Projects/Roadmap/Plan.md', 'Projects/Roadmap/_tasks/'])
+    expect(projectTaskFolder(app, 'Projects/Roadmap/Plan.md')).toBe('Projects/Roadmap/_tasks')
+  })
+
+  it('does not hand a sub-project the folder note owner storage', async () => {
+    const app = await vaultWith([
+      'Projects/Roadmap/Roadmap.md',
+      'Projects/Roadmap/_tasks/',
+      'Projects/Roadmap/Loose.md'
+    ])
+    expect(projectFolderOf(app, 'Projects/Roadmap/Loose.md')).toBeNull()
+    expect(projectTaskFolder(app, 'Projects/Roadmap/Loose.md')).toBe('Projects/Roadmap/Loose_tasks')
+  })
+
+  it('gives a project at the vault root its own folder', async () => {
+    const app = await vaultWith(['Roadmap/Roadmap.md'])
+    expect(projectTaskFolder(app, 'Roadmap/Roadmap.md')).toBe('Roadmap/_tasks')
+    expect(projectTaskFolder(app, 'Roadmap.md')).toBe('Roadmap_tasks')
+  })
+})

--- a/src/store/vaultFs.ts
+++ b/src/store/vaultFs.ts
@@ -1,5 +1,39 @@
 import type { App } from 'obsidian'
-import { TFolder, normalizePath } from 'obsidian'
+import { TFile, TFolder, normalizePath } from 'obsidian'
+
+/** The task storage folder inside a project's own folder. */
+export const TASK_FOLDER_NAME = '_tasks'
+
+function folderOf(path: string): string {
+  const at = path.lastIndexOf('/')
+  return at === -1 ? '' : path.slice(0, at)
+}
+
+function nameOf(path: string): string {
+  return path.slice(path.lastIndexOf('/') + 1).replace(/\.md$/, '')
+}
+
+/**
+ * The folder a project owns, holding its note and its `_tasks/`. A project note named
+ * after its folder owns it; so does one whose folder nobody else claims and which already
+ * holds task storage, which is what a note renamed on its own looks like. Null for a
+ * legacy project sitting beside a `<name>_tasks` folder.
+ */
+export function projectFolderOf(app: App, projectPath: string): string | null {
+  const dir = folderOf(projectPath)
+  if (!dir) return null
+  const folderName = nameOf(dir)
+  if (folderName === nameOf(projectPath)) return dir
+  if (app.vault.getAbstractFileByPath(`${dir}/${folderName}.md`) instanceof TFile) return null
+  return app.vault.getAbstractFileByPath(`${dir}/${TASK_FOLDER_NAME}`) instanceof TFolder ? dir : null
+}
+
+/** Where a project's task notes live, in either layout. */
+export function projectTaskFolder(app: App, projectPath: string): string {
+  const own = projectFolderOf(app, projectPath)
+  if (own) return normalizePath(`${own}/${TASK_FOLDER_NAME}`)
+  return normalizePath(projectPath.replace(/\.md$/, '_tasks'))
+}
 
 /**
  * Keeps a task's attachment folder with its note across renames and archiving. A no-op
@@ -21,33 +55,70 @@ export async function moveTaskAttachmentFolder(
 }
 
 /**
- * Keeps a project's `_tasks/` folder with its note across a rename, since the folder name
- * is what attaches the tasks to the project. Reports whether anything moved.
+ * Keeps a renamed project note attached to its tasks. A note renamed inside the folder it
+ * owns takes the folder with it, so the pair keeps matching; a note moved anywhere else
+ * takes its task folder along as a sibling. Returns where the note ended up.
  */
-export async function moveProjectTaskFolder(
+export async function keepProjectStorageWithNote(
   app: App,
   oldProjectPath: string,
-  newProjectPath: string
-): Promise<boolean> {
-  const from = normalizePath(oldProjectPath.replace(/\.md$/, '') + '_tasks')
+  newProjectPath: string,
+  markSelfWrite: (path: string) => void
+): Promise<string> {
+  const oldDir = folderOf(oldProjectPath)
+  if (oldDir && nameOf(oldDir) === nameOf(oldProjectPath) && folderOf(newProjectPath) === oldDir) {
+    const target = normalizePath(`${folderOf(oldDir)}/${nameOf(newProjectPath)}`)
+    const folder = app.vault.getAbstractFileByPath(oldDir)
+    if (!(folder instanceof TFolder) || app.vault.getAbstractFileByPath(target)) return newProjectPath
+    markSelfWrite(oldDir)
+    markSelfWrite(target)
+    await app.vault.rename(folder, target)
+    return normalizePath(`${target}/${nameOf(newProjectPath)}.md`)
+  }
+
+  const from = normalizePath(projectTaskFolder(app, oldProjectPath))
   const to = normalizePath(newProjectPath.replace(/\.md$/, '') + '_tasks')
-  if (from === to) return false
   const folder = app.vault.getAbstractFileByPath(from)
-  if (!(folder instanceof TFolder)) return false
-  if (app.vault.getAbstractFileByPath(to)) return false
-  await app.vault.rename(folder, to)
-  return true
+  if (from !== to && folder instanceof TFolder && !app.vault.getAbstractFileByPath(to)) {
+    markSelfWrite(from)
+    markSelfWrite(to)
+    await app.vault.rename(folder, to)
+  }
+  return newProjectPath
 }
 
 /**
- * The project a task note belongs to, from its path alone: tasks live in
- * `<project>_tasks/`, archived ones a level deeper in `Archive/`. Null for any path
- * outside that layout.
+ * Renames a project folder's note along with the folder, so the pair keeps matching.
+ * Returns the note's new path, or null when the folder holds no note of its old name.
+ */
+export async function renameProjectFolderNote(
+  app: App,
+  oldFolderPath: string,
+  newFolderPath: string,
+  isProjectNote: (file: TFile) => boolean
+): Promise<string | null> {
+  const note = app.vault.getAbstractFileByPath(`${newFolderPath}/${nameOf(oldFolderPath)}.md`)
+  if (!(note instanceof TFile) || !isProjectNote(note)) return null
+  const target = normalizePath(`${newFolderPath}/${nameOf(newFolderPath)}.md`)
+  if (app.vault.getAbstractFileByPath(target)) return null
+  await app.fileManager.renameFile(note, target)
+  return target
+}
+
+/**
+ * The project a task note belongs to, from its path alone: tasks live in the project
+ * folder's `_tasks/`, or beside a legacy project in `<project>_tasks/`, archived ones a
+ * level deeper in `Archive/`. Null for any path outside that layout.
  */
 export function projectPathForTaskPath(taskPath: string): string | null {
   const parts = normalizePath(taskPath).split('/')
   parts.pop()
   if (parts[parts.length - 1] === 'Archive') parts.pop()
+  if (parts[parts.length - 1] === TASK_FOLDER_NAME) {
+    parts.pop()
+    const folder = parts.join('/')
+    return folder ? `${folder}/${parts[parts.length - 1]}.md` : null
+  }
   const folder = parts.join('/')
   if (!folder.endsWith('_tasks')) return null
   return folder.slice(0, -'_tasks'.length) + '.md'

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -1,7 +1,7 @@
 import { ButtonComponent, ExtraButtonComponent, ItemView, Menu, WorkspaceLeaf } from 'obsidian'
 import type PMPlugin from '../main'
 import { type Project, type ViewMode, type FilterState, type SavedView, makeDefaultFilter, makeId } from '../types'
-import { personKeyer, ProjectScope, resolveScopePaths, scopeKey, type ScopeSpec } from '../store'
+import { personKeyer, ProjectScope, projectFolderOf, resolveScopePaths, scopeKey, type ScopeSpec } from '../store'
 import { truncateTitle, safeAsync } from '../utils'
 import type { SubView } from './SubView'
 import { TableView } from './table/TableView'
@@ -445,7 +445,9 @@ export class ProjectView extends ItemView {
     if (!scope || !primary) return
     const path = scope.spec.kind === 'vault' ? primary.filePath : scope.spec.path
     const projectPath = scope.spec.kind === 'project' || scope.spec.kind === 'subtree' ? path : primary.filePath
-    const folder = projectPath.slice(0, projectPath.lastIndexOf('/'))
+    // A project owns its folder, so "the containing folder" is the one holding that folder.
+    const own = projectFolderOf(this.app, projectPath)
+    const folder = (own ?? projectPath).slice(0, (own ?? projectPath).lastIndexOf('/'))
 
     const options: { label: string; spec: ScopeSpec }[] = [
       { label: 'This project', spec: { kind: 'project', path: projectPath } },


### PR DESCRIPTION
A project now keeps its note and its task notes in one folder: `Projects/Roadmap/Roadmap.md` alongside `Projects/Roadmap/_tasks/`, and a new sub-project is created inside its parent's folder. Renaming the note renames the folder and vice versa, and deleting a project deletes its folder unless a sub-project sits inside it.

Projects used to be a note plus a sibling `<name>_tasks/` folder tied together only by naming, so moving one without the other detached the tasks. Existing vaults are moved on first open, with filters, saved views, and open tabs following the new paths; projects still in the old layout keep loading.