### PR TITLE
fix project folder moves at the vault root and after a rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A project keeps its note and its task notes together in a folder of its own
 - An existing project moves into its own folder when the vault is opened, keeping its filters, saved views, and open tabs
 - A new sub-project is created inside its parent's folder
-- Renaming a project note renames its folder, and renaming its folder renames the note
+- Renaming a project note renames the folder it owns, so the two keep matching
 - Deleting a project deletes its folder, unless a sub-project sits inside it
 - The tags offered in the task editor are listed alphabetically
 - Custom fields in the task editor use the same controls as the task's own properties, so a custom date opens the date picker and a custom select the same popover as status

--- a/src/migration.test.ts
+++ b/src/migration.test.ts
@@ -7,6 +7,11 @@ import type PMPlugin from './main'
 import { ProjectStore, VaultIndex } from './store'
 import { DEFAULT_SETTINGS, makeDefaultFilter, type PMSettings } from './types'
 
+const expectDefined = <T>(value: T | null | undefined): T => {
+  if (value == null) throw new Error('expected value to be defined')
+  return value
+}
+
 const projectNote = (id: string, title: string): string =>
   ['---', 'pm-project: true', `id: ${id}`, `title: ${title}`, 'taskIds:', '  - t1', '---', ''].join('\n')
 
@@ -104,6 +109,29 @@ describe('migrateProjectLayout', () => {
     expect(task.state.filePath).toBe('Projects/Roadmap/_tasks/design.md')
     expect(task.state.projectPath).toBe('Projects/Roadmap/Roadmap.md')
     expect(unrelated.state.filePath).toBe('Notes/idea.md')
+  })
+
+  it('repoints a sub-project at its parent new path', async () => {
+    const { plugin, app } = await legacyVault([])
+    await app.vault.create(
+      'Projects/Q3.md',
+      [
+        '---',
+        'pm-project: true',
+        'id: p2',
+        'title: Q3',
+        'parent: "[[Projects/Roadmap]]"',
+        'taskIds: []',
+        '---',
+        ''
+      ].join('\n')
+    )
+    plugin.index.build()
+
+    await migrateProjectLayout(plugin)
+
+    const child = expectDefined(await plugin.store.loadProjectByPath('Projects/Q3/Q3.md'))
+    expect(child.parentPath).toBe('Projects/Roadmap/Roadmap.md')
   })
 
   it('does nothing on a second run', async () => {

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -49,6 +49,13 @@ interface ProjectMove {
  */
 export async function migrateProjectLayout(plugin: PMPlugin): Promise<void> {
   const moves: ProjectMove[] = []
+  // Read before the first move: a sub-project's parent link stops resolving once the
+  // parent note moves, so the index can no longer answer who belongs to whom.
+  const childrenOf = new Map<string, string[]>()
+  for (const path of plugin.index.projectPaths()) {
+    const children = plugin.index.childRefs(path).map((ref) => ref.path)
+    if (children.length) childrenOf.set(path, children)
+  }
 
   for (const path of plugin.index.projectPaths()) {
     try {
@@ -67,6 +74,12 @@ export async function migrateProjectLayout(plugin: PMPlugin): Promise<void> {
   }
 
   if (moves.length === 0) return
+
+  for (const { from, to } of moves) {
+    for (const child of childrenOf.get(from) ?? []) {
+      await plugin.store.repointProjectParent(movedPath(child, moves) ?? child, to)
+    }
+  }
 
   remapProjectSettings(plugin, moves)
   retargetOpenViews(plugin, moves)

--- a/src/modals/ProjectCreateModal.ts
+++ b/src/modals/ProjectCreateModal.ts
@@ -1,7 +1,7 @@
 import { App, ButtonComponent, ExtraButtonComponent, Modal, setIcon } from 'obsidian'
 import type PMPlugin from '../main'
 import { DEFAULT_PROJECT_COLOR, DEFAULT_PROJECT_ICON } from '../types'
-import { projectFilePath, projectFolderOf } from '../store'
+import { folderOf, projectFilePath, projectFolderOf } from '../store'
 import { safeAsync } from '../utils'
 import { renderPersonPicker } from '../ui/PersonPicker'
 import { renderPropRow } from '../ui/FormField'
@@ -284,7 +284,7 @@ export class ProjectCreateModal extends Modal {
   private targetFolder(): string {
     const parentPath = this.draft.parentPath
     if (!parentPath) return this.plugin.settings.projectsFolder || this.app.vault.getName()
-    return projectFolderOf(this.app, parentPath) ?? parentPath.slice(0, parentPath.lastIndexOf('/'))
+    return projectFolderOf(this.app, parentPath) ?? folderOf(parentPath)
   }
 
   private targetPath(title: string): string {

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -1,5 +1,5 @@
 import type { App, Plugin } from 'obsidian'
-import { TFile } from 'obsidian'
+import { TFile, TFolder } from 'obsidian'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { makeFakeApp, type FakeVault } from '../../test/fakeVault'
 import { today } from '../dates'
@@ -13,6 +13,7 @@ import {
   type Task
 } from '../types'
 import { ProjectStore } from './ProjectStore'
+import { projectTaskFolder } from './vaultFs'
 import { addDays } from './Scheduler'
 import { buildTaskIndex } from './TaskIndex'
 import { findTask, flattenTasks } from './TaskTreeOps'
@@ -1291,7 +1292,10 @@ describe('ProjectStore cross-project scheduling', () => {
 })
 
 describe('ProjectStore project folders', () => {
-  const flush = (): Promise<void> => new Promise((resolve) => window.setTimeout(resolve, 0))
+  /** The store follows a rename a tick later, so the move needs two turns to land. */
+  const flush = async (): Promise<void> => {
+    for (let i = 0; i < 3; i++) await new Promise((resolve) => window.setTimeout(resolve, 0))
+  }
 
   const syncedStore = (): ReturnType<typeof newIndexedStore> => {
     const made = newIndexedStore()
@@ -1330,6 +1334,19 @@ describe('ProjectStore project folders', () => {
 
     const reloaded = await store.loadProjectByPath('Projects/Legacy/Legacy.md')
     expect(flattenTasks(expectDefined(reloaded).tasks).map((f) => f.task.title)).toEqual(['First'])
+  })
+
+  it('moves a project sitting at the vault root into a folder beside it', async () => {
+    const { store, app } = newIndexedStore()
+    await app.vault.create(
+      'Stress test.md',
+      ['---', 'pm-project: true', 'id: p1', 'title: Stress test', 'taskIds: []', '---', ''].join('\n')
+    )
+
+    const moved = await store.moveProjectIntoOwnFolder('Stress test.md')
+
+    expect(moved).toBe('Stress test/Stress test.md')
+    expect(app.vault.getAbstractFileByPath('Stress test/Stress test.md')).toBeInstanceOf(TFile)
   })
 
   it('leaves a project that already owns its folder alone', async () => {
@@ -1376,16 +1393,35 @@ describe('ProjectStore project folders', () => {
     ).toBeInstanceOf(TFile)
   })
 
-  it('renames the project note when its folder is renamed', async () => {
+  it('keeps a project attached to its tasks when its folder is renamed', async () => {
     const { store, app } = syncedStore()
     const project = await store.createProject('Alpha', 'Projects')
+    await addNamed(store, project, 'Card')
 
     const folder = expectDefined(app.vault.getAbstractFileByPath('Projects/Alpha'))
     await app.vault.rename(folder, 'Projects/Gamma')
     await flush()
 
-    expect(app.vault.getAbstractFileByPath('Projects/Gamma/Gamma.md')).toBeInstanceOf(TFile)
-    expect(project.filePath).toBe('Projects/Gamma/Gamma.md')
+    // The note keeps its own name; the folder it sits in is what moved.
+    expect(app.vault.getAbstractFileByPath('Projects/Gamma/Alpha.md')).toBeInstanceOf(TFile)
+    expect(projectTaskFolder(app, 'Projects/Gamma/Alpha.md')).toBe('Projects/Gamma/_tasks')
+    expect(app.vault.getAbstractFileByPath('Projects/Gamma/_tasks/card.md')).toBeInstanceOf(TFile)
+  })
+
+  it('leaves the task folder alone when a note renamed inside its project folder never owned its name', async () => {
+    const { store, app } = syncedStore()
+    await app.vault.create(
+      'Projects/Alpha/Loose.md',
+      ['---', 'pm-project: true', 'id: p1', 'title: Loose', 'taskIds: []', '---', ''].join('\n')
+    )
+    await app.vault.createFolder('Projects/Alpha/_tasks')
+    await store.loadProjectByPath('Projects/Alpha/Loose.md')
+
+    await app.fileManager.renameFile(fileAt(app, 'Projects/Alpha/Loose.md'), 'Projects/Alpha/Renamed.md')
+    await flush()
+
+    expect(app.vault.getAbstractFileByPath('Projects/Alpha/_tasks')).toBeInstanceOf(TFolder)
+    expect(app.vault.getAbstractFileByPath('Projects/Alpha/Renamed_tasks')).toBeNull()
   })
 
   it('takes the task folder along when a project note leaves its folder', async () => {

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -36,11 +36,11 @@ import {
 } from './YamlSerializer'
 import {
   ensureFolder,
+  folderOf,
   keepProjectStorageWithNote,
   moveTaskAttachmentFolder,
   projectFolderOf,
   projectTaskFolder,
-  renameProjectFolderNote,
   resolveVaultLink,
   TASK_FOLDER_NAME
 } from './vaultFs'
@@ -206,8 +206,11 @@ export class ProjectStore implements TaskSource {
     plugin.registerEvent(this.app.vault.on('delete', onChange))
     plugin.registerEvent(
       this.app.vault.on('rename', (file, oldPath) => {
-        if (file instanceof TFile) void this.followProjectRename(oldPath, file.path)
-        else if (file instanceof TFolder) void this.followProjectFolderRename(oldPath, file.path)
+        // Obsidian is still finishing this rename, and moving files while it does blocks
+        // it, so the follow-up waits for the current one to settle.
+        if (file instanceof TFile) {
+          window.setTimeout(() => void this.followProjectRename(oldPath, file.path), 0)
+        }
         this.syncPath(file.path)
         this.syncPath(oldPath)
       })
@@ -226,17 +229,6 @@ export class ProjectStore implements TaskSource {
       await this.rekeyProject(oldPath, notePath)
     } catch (e) {
       console.error(`[PM] Failed to move the task folder for "${newPath}":`, e)
-    }
-  }
-
-  /** A renamed project folder takes its note's name with it, so the pair keeps matching. */
-  private async followProjectFolderRename(oldPath: string, newPath: string): Promise<void> {
-    try {
-      const oldName = oldPath.slice(oldPath.lastIndexOf('/') + 1)
-      const moved = await renameProjectFolderNote(this.app, oldPath, newPath, (file) => this.isProjectNote(file.path))
-      if (moved) await this.rekeyProject(`${oldPath}/${oldName}.md`, moved)
-    } catch (e) {
-      console.error(`[PM] Failed to rename the project note in "${newPath}":`, e)
     }
   }
 
@@ -746,13 +738,17 @@ export class ProjectStore implements TaskSource {
 
   /**
    * The task folder moves first: once it is gone from beside the note, the rename below
-   * reads as a plain move and the vault listener has nothing left to follow.
+   * reads as a plain move and the vault listener has nothing left to follow. The note goes
+   * through `vault.rename`, not `fileManager.renameFile`: its name does not change, so the
+   * wikilinks that name it keep resolving, and Obsidian's link pass stalls for a long time
+   * on a note taking its folder's name. The one link that does name a path, a sub-project's
+   * `parent`, is rewritten here.
    */
   async moveProjectIntoOwnFolder(projectPath: string): Promise<string | null> {
     const file = this.app.vault.getAbstractFileByPath(projectPath)
     if (!(file instanceof TFile) || projectFolderOf(this.app, projectPath)) return null
 
-    const dir = projectPath.slice(0, projectPath.lastIndexOf('/'))
+    const dir = folderOf(projectPath)
     const target = normalizePath(dir ? `${dir}/${file.basename}` : file.basename)
     if (this.app.vault.getAbstractFileByPath(target) instanceof TFile) return null
 
@@ -770,9 +766,21 @@ export class ProjectStore implements TaskSource {
     const notePath = normalizePath(`${target}/${file.name}`)
     this.markSelfWrite(projectPath)
     this.markSelfWrite(notePath)
-    await this.app.fileManager.renameFile(file, notePath)
+    await this.app.vault.rename(file, notePath)
     await this.rekeyProject(projectPath, notePath)
     return notePath
+  }
+
+  /** The `parent` link names a path, so a parent that moved has to be written again. */
+  async repointProjectParent(childPath: string, parentPath: string): Promise<void> {
+    const child = this.app.vault.getAbstractFileByPath(childPath)
+    if (!(child instanceof TFile)) return
+    this.markSelfWrite(childPath)
+    await this.app.fileManager.processFrontMatter(child, (fm: Record<string, unknown>) => {
+      fm.parent = `[[${parentPath.replace(/\.md$/, '')}]]`
+    })
+    const live = await this.projectCache.get(childPath)
+    if (live) live.parentPath = parentPath
   }
 
   async insertTask(project: Project, task: Task, parentId: string | null = null): Promise<void> {

--- a/src/store/TaskSource.ts
+++ b/src/store/TaskSource.ts
@@ -45,6 +45,8 @@ export interface TaskSource {
    * own. Returns the note's new path, or null when the project already owns a folder.
    */
   moveProjectIntoOwnFolder(projectPath: string): Promise<string | null>
+  /** Writes a sub-project's `parent` link again, for when the parent note moved. */
+  repointProjectParent(childPath: string, parentPath: string): Promise<void>
   saveProject(project: Project): Promise<void>
   updateProject(project: Project, patch: ProjectPatch): Promise<void>
   deleteProject(project: Project): Promise<void>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -51,7 +51,7 @@ export {
   resolvePerson
 } from './people'
 export type { PersonCandidate, PersonLinkState, PersonMatch, PersonRef } from './people'
-export { projectFolderOf, projectPathForTaskPath, projectTaskFolder, TASK_FOLDER_NAME } from './vaultFs'
+export { folderOf, projectFolderOf, projectPathForTaskPath, projectTaskFolder, TASK_FOLDER_NAME } from './vaultFs'
 export { hydrateTasks } from './YamlHydrator'
 export { appendYaml, isOldFormat, parseFrontmatter } from './YamlParser'
 export { projectFilePath, serializeProject, serializeTask } from './YamlSerializer'

--- a/src/store/vaultFs.ts
+++ b/src/store/vaultFs.ts
@@ -4,7 +4,8 @@ import { TFile, TFolder, normalizePath } from 'obsidian'
 /** The task storage folder inside a project's own folder. */
 export const TASK_FOLDER_NAME = '_tasks'
 
-function folderOf(path: string): string {
+/** The folder holding a path, empty for anything at the vault root. */
+export function folderOf(path: string): string {
   const at = path.lastIndexOf('/')
   return at === -1 ? '' : path.slice(0, at)
 }
@@ -66,14 +67,19 @@ export async function keepProjectStorageWithNote(
   markSelfWrite: (path: string) => void
 ): Promise<string> {
   const oldDir = folderOf(oldProjectPath)
-  if (oldDir && nameOf(oldDir) === nameOf(oldProjectPath) && folderOf(newProjectPath) === oldDir) {
-    const target = normalizePath(`${folderOf(oldDir)}/${nameOf(newProjectPath)}`)
-    const folder = app.vault.getAbstractFileByPath(oldDir)
-    if (!(folder instanceof TFolder) || app.vault.getAbstractFileByPath(target)) return newProjectPath
-    markSelfWrite(oldDir)
-    markSelfWrite(target)
-    await app.vault.rename(folder, target)
-    return normalizePath(`${target}/${nameOf(newProjectPath)}.md`)
+  const stayed = folderOf(newProjectPath) === oldDir
+  if (oldDir && stayed) {
+    if (nameOf(oldDir) === nameOf(oldProjectPath)) {
+      const target = normalizePath(`${folderOf(oldDir)}/${nameOf(newProjectPath)}`)
+      const folder = app.vault.getAbstractFileByPath(oldDir)
+      if (!(folder instanceof TFolder) || app.vault.getAbstractFileByPath(target)) return newProjectPath
+      markSelfWrite(oldDir)
+      markSelfWrite(target)
+      await app.vault.rename(folder, target)
+      return normalizePath(`${target}/${nameOf(newProjectPath)}.md`)
+    }
+    // Storage already sits in the folder the note stayed in; the new name changes nothing.
+    if (app.vault.getAbstractFileByPath(`${oldDir}/${TASK_FOLDER_NAME}`) instanceof TFolder) return newProjectPath
   }
 
   const from = normalizePath(projectTaskFolder(app, oldProjectPath))
@@ -85,24 +91,6 @@ export async function keepProjectStorageWithNote(
     await app.vault.rename(folder, to)
   }
   return newProjectPath
-}
-
-/**
- * Renames a project folder's note along with the folder, so the pair keeps matching.
- * Returns the note's new path, or null when the folder holds no note of its old name.
- */
-export async function renameProjectFolderNote(
-  app: App,
-  oldFolderPath: string,
-  newFolderPath: string,
-  isProjectNote: (file: TFile) => boolean
-): Promise<string | null> {
-  const note = app.vault.getAbstractFileByPath(`${newFolderPath}/${nameOf(oldFolderPath)}.md`)
-  if (!(note instanceof TFile) || !isProjectNote(note)) return null
-  const target = normalizePath(`${newFolderPath}/${nameOf(newFolderPath)}.md`)
-  if (app.vault.getAbstractFileByPath(target)) return null
-  await app.fileManager.renameFile(note, target)
-  return target
 }
 
 /**

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -1,7 +1,15 @@
 import { ButtonComponent, ExtraButtonComponent, ItemView, Menu, WorkspaceLeaf } from 'obsidian'
 import type PMPlugin from '../main'
 import { type Project, type ViewMode, type FilterState, type SavedView, makeDefaultFilter, makeId } from '../types'
-import { personKeyer, ProjectScope, projectFolderOf, resolveScopePaths, scopeKey, type ScopeSpec } from '../store'
+import {
+  folderOf,
+  personKeyer,
+  ProjectScope,
+  projectFolderOf,
+  resolveScopePaths,
+  scopeKey,
+  type ScopeSpec
+} from '../store'
 import { truncateTitle, safeAsync } from '../utils'
 import type { SubView } from './SubView'
 import { TableView } from './table/TableView'
@@ -447,7 +455,7 @@ export class ProjectView extends ItemView {
     const projectPath = scope.spec.kind === 'project' || scope.spec.kind === 'subtree' ? path : primary.filePath
     // A project owns its folder, so "the containing folder" is the one holding that folder.
     const own = projectFolderOf(this.app, projectPath)
-    const folder = (own ?? projectPath).slice(0, (own ?? projectPath).lastIndexOf('/'))
+    const folder = folderOf(own ?? projectPath)
 
     const options: { label: string; spec: ScopeSpec }[] = [
       { label: 'This project', spec: { kind: 'project', path: projectPath } },


### PR DESCRIPTION
A project sitting at the vault root migrated into a folder named after its path minus the last character, and renaming a project note that did not carry its folder's name converted its task folder back to the old sibling shape.

Migration now moves the project note with `vault.rename`: its name does not change, so the wikilinks naming it keep resolving, while Obsidian's link-updating rename stalls for tens of seconds on a note taking its parent folder's name. The one link that does name a path, a sub-project's `parent`, is rewritten directly.