### PR TITLE
rename a project's note and folder when its title is edited in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Renaming a project from its settings page left its note and folder named after the old title
+
 ## [2.0.0] - 2026-08-25
 
 ### Highlights

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -1393,6 +1393,37 @@ describe('ProjectStore project folders', () => {
     ).toBeInstanceOf(TFile)
   })
 
+  it('renames the note and its folder when the title is edited', async () => {
+    const { store, app } = syncedStore()
+    const project = await store.createProject('Alpha', 'Projects')
+    const task = await addNamed(store, project, 'Card')
+
+    await store.updateProject(project, { title: 'Beta' })
+    await flush()
+
+    expect(project.filePath).toBe('Projects/Beta/Beta.md')
+    expect(app.vault.getAbstractFileByPath('Projects/Alpha')).toBeNull()
+    const content = await app.vault.cachedRead(fileAt(app, 'Projects/Beta/Beta.md'))
+    expect(content).toContain('title: "Beta"')
+    expect(
+      app.vault.getAbstractFileByPath(`Projects/Beta/_tasks/${expectDefined(task.filePath).split('/').pop()}`)
+    ).toBeInstanceOf(TFile)
+  })
+
+  it('leaves the note where it is when the new title collides with an existing note', async () => {
+    const { store, app } = syncedStore()
+    await store.createProject('Beta', 'Projects')
+    const project = await store.createProject('Alpha', 'Projects')
+
+    await store.updateProject(project, { title: 'Beta' })
+    await flush()
+
+    expect(project.filePath).toBe('Projects/Alpha/Alpha.md')
+    expect(project.title).toBe('Beta')
+    const content = await app.vault.cachedRead(fileAt(app, 'Projects/Alpha/Alpha.md'))
+    expect(content).toContain('title: "Beta"')
+  })
+
   it('keeps a project attached to its tasks when its folder is renamed', async () => {
     const { store, app } = syncedStore()
     const project = await store.createProject('Alpha', 'Projects')

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -3,7 +3,7 @@ import { App, Notice, TFile, TFolder, normalizePath } from 'obsidian'
 import type { PMSettings, Project, ProjectPatch, ResolvedProjectConfig, StatusConfig, Task } from '../types'
 import { DEFAULT_SETTINGS, makeProject, makeTask } from '../types'
 import { today } from '../dates'
-import { isTerminalStatus } from '../utils'
+import { isTerminalStatus, sanitizeFileName } from '../utils'
 import { archiveTask as doArchiveTask, unarchiveTask as doUnarchiveTask } from './ArchiveOps'
 import { resolveProjectConfig } from './ProjectConfig'
 import { computeSchedule } from './Scheduler'
@@ -549,9 +549,36 @@ export class ProjectStore implements TaskSource {
 
   /** Patch-only, so the editor's stale draft can't overwrite fields it didn't change. */
   async updateProject(project: Project, patch: ProjectPatch): Promise<void> {
+    const previousPath = project.filePath
     Object.assign(project, patch)
     if (patch.description !== undefined) this.hydratedBodies.add(project)
+    if (patch.title !== undefined) await this.renameProjectFile(project, previousPath)
     await this.saveProject(project)
+  }
+
+  /** A title edited in the settings view takes the note, and the folder it owns, with it. */
+  private async renameProjectFile(project: Project, currentPath: string): Promise<void> {
+    const file = this.app.vault.getAbstractFileByPath(currentPath)
+    if (!(file instanceof TFile)) return
+    const desiredBasename = sanitizeFileName(project.title)
+    if (!desiredBasename) return
+    const dir = folderOf(currentPath)
+    const target = normalizePath(dir ? `${dir}/${desiredBasename}.md` : `${desiredBasename}.md`)
+    if (target === currentPath || this.app.vault.getAbstractFileByPath(target)) return
+
+    // The note takes its folder with it; skip the whole rename if that folder's new
+    // name is already taken, rather than leaving the note and its folder mismatched.
+    const own = projectFolderOf(this.app, currentPath)
+    if (own) {
+      const folderTarget = normalizePath(`${folderOf(own)}/${desiredBasename}`)
+      if (folderTarget !== own && this.app.vault.getAbstractFileByPath(folderTarget)) return
+    }
+
+    this.markSelfWrite(currentPath)
+    this.markSelfWrite(target)
+    await this.app.fileManager.renameFile(file, target)
+    const notePath = await keepProjectStorageWithNote(this.app, currentPath, target, (p) => this.markSelfWrite(p))
+    await this.rekeyProject(currentPath, notePath)
   }
 
   private async doSaveProject(project: Project): Promise<void> {


### PR DESCRIPTION
Editing a project's Name field in its settings page only rewrote the frontmatter title and heading; the note file and its folder kept the old name, so the two drifted out of sync. The title patch now also renames the note via the link-aware rename API, which carries the project's folder and task storage along and updates any wikilinks pointing at the old name elsewhere in the vault. If the new name collides with an existing note or folder, the rename is skipped and only the title text is saved.

Closes #61