### PR TITLE
archive completed tasks after a configurable number of days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Completed tasks move to the project's archive after the number of days set in the new auto-archive setting ([#204](https://github.com/StepanKropachev/obsidian-pm/issues/204))
+- A project can override the auto-archive window in the project settings
+- The archive completed tasks command moves finished tasks into the archive right away
+
 ### Fixed
 
 - Renaming a project from its settings page left its note and folder named after the old title

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Task hierarchy and dependencies don't resolve on the TaskNotes side (it uses pro
 | Notifications on/off | Master switch for due date reminders, separate from lead time |
 | Auto-schedule | When a blocking task moves, its dependents shift to match. Cycles are refused. |
 | Pull dependents forward on early finish | Off by default. When a task is completed before its due date, its dependents move earlier by the days it saved, keeping any slack they already had. |
-| Auto-archive completed tasks | Days a completed task waits before moving to the project's archive. 0 turns it off. |
+| Auto-archive completed tasks | Move completed tasks to the project's archive after this many days. Set it to 0 to keep them in place. |
 | Hide done in Gantt | Skip completed and cancelled tasks on the timeline |
 | Show subtasks in Kanban | Render subtasks as their own cards, not just inside the parent |
 | Custom statuses | Edit labels, colors, and icons for each status |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Card-based board grouped by status. Drag cards between columns to update status 
 - **Subtasks** — Nest tasks to any depth. Collapse/expand hierarchies across all views.
 - **Dependencies** — Link blocking/dependent tasks. Visualized as arrows on the Gantt chart.
 - **Milestones** — Zero-duration tasks for key dates and deliverables.
-- **Archive** — Archive completed tasks without deleting. Toggle visibility at any time.
+- **Archive** — Archive completed tasks without deleting. Toggle visibility at any time. Completed tasks can also be archived automatically once they have been done for a set number of days, or on demand with **Project Manager: Archive completed tasks**.
 
 ### Scheduling & time
 - **Drag-and-drop scheduling** — Reschedule tasks by dragging bars on the Gantt chart.
@@ -62,7 +62,7 @@ Card-based board grouped by status. Drag cards between columns to update status 
 ### Customization
 - **Custom fields** — Add per-project fields: text, number, date, select, multi-select, person, checkbox, URL.
 - **Custom statuses & priorities** — Edit labels, colors, and icons for each status and priority level.
-- **Per-project settings** — A project can define its own statuses and priorities and override the default view, auto-scheduling, early-finish pull-forward, and board display options. Project-defined statuses replace the global ones everywhere in that project, from kanban columns to pickers; statuses still in use by tasks always stay visible.
+- **Per-project settings** — A project can define its own statuses and priorities and override the default view, auto-scheduling, early-finish pull-forward, the auto-archive window, and board display options. Project-defined statuses replace the global ones everywhere in that project, from kanban columns to pickers; statuses still in use by tasks always stay visible.
 - **Saved views** — Save filter/sort combinations in Table view and switch between them instantly.
 - **Team roster** — Manage a global team list for assignment across all projects, plus per-project team members.
 
@@ -144,6 +144,7 @@ Task hierarchy and dependencies don't resolve on the TaskNotes side (it uses pro
 | Notifications on/off | Master switch for due date reminders, separate from lead time |
 | Auto-schedule | When a blocking task moves, its dependents shift to match. Cycles are refused. |
 | Pull dependents forward on early finish | Off by default. When a task is completed before its due date, its dependents move earlier by the days it saved, keeping any slack they already had. |
+| Auto-archive completed tasks | Days a completed task waits before moving to the project's archive. 0 turns it off. |
 | Hide done in Gantt | Skip completed and cancelled tasks on the timeline |
 | Show subtasks in Kanban | Render subtasks as their own cards, not just inside the parent |
 | Custom statuses | Edit labels, colors, and icons for each status |

--- a/src/components/AutoArchiver.test.ts
+++ b/src/components/AutoArchiver.test.ts
@@ -1,0 +1,138 @@
+import type { App } from 'obsidian'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { makeFakeApp } from '../../test/fakeVault'
+import { today } from '../dates'
+import type PMPlugin from '../main'
+import { ProjectStore, VaultIndex } from '../store'
+import { findTask } from '../store/TaskTreeOps'
+import { DEFAULT_SETTINGS, makeTask, type PMSettings, type Project, type Task } from '../types'
+import { AutoArchiver } from './AutoArchiver'
+
+const daysAgo = (days: number): string => today().subtract({ days }).toString()
+
+describe('AutoArchiver', () => {
+  let app: App
+  let index: VaultIndex
+  let store: ProjectStore
+  let settings: PMSettings
+  let notices: string[]
+  let archiver: AutoArchiver
+
+  beforeEach(() => {
+    app = makeFakeApp({ liveMetadataCache: true }).app as unknown as App
+    settings = structuredClone(DEFAULT_SETTINGS)
+    index = new VaultIndex(app, () => settings)
+    store = new ProjectStore(app, () => settings, index)
+    notices = []
+    const plugin = {
+      app,
+      index,
+      store,
+      settings,
+      showNotice: (msg: string) => notices.push(msg),
+      saveSettings: () => Promise.resolve()
+    } as unknown as PMPlugin
+    archiver = new AutoArchiver(plugin)
+  })
+
+  async function addTask(project: Project, title: string, patch: Partial<Task> = {}): Promise<Task> {
+    const task = makeTask({ title })
+    await store.insertTask(project, task)
+    if (Object.keys(patch).length) await store.updateTask(project, task.id, patch)
+    return task
+  }
+
+  const done = (completed: string): Partial<Task> => ({ status: 'done', completed })
+
+  function archived(project: Project, task: Task): boolean {
+    return findTask(project.tasks, task.id)?.archived === true
+  }
+
+  it('does nothing when no project has a window', async () => {
+    const project = await store.createProject('Roadmap', 'Projects')
+    const old = await addTask(project, 'Old', done(daysAgo(30)))
+    index.build()
+
+    await archiver.check()
+
+    expect(archived(project, old)).toBe(false)
+    expect(settings.lastAutoArchiveDate).toBe('')
+  })
+
+  it('archives what has been complete for longer than the window', async () => {
+    settings.autoArchiveDays = 7
+    const project = await store.createProject('Roadmap', 'Projects')
+    const old = await addTask(project, 'Old', done(daysAgo(30)))
+    const fresh = await addTask(project, 'Fresh', done(daysAgo(2)))
+    const open = await addTask(project, 'Open')
+    index.build()
+
+    await archiver.check()
+
+    expect(archived(project, old)).toBe(true)
+    expect(findTask(project.tasks, old.id)?.filePath).toMatch(/\/Archive\//)
+    expect(archived(project, fresh)).toBe(false)
+    expect(archived(project, open)).toBe(false)
+    expect(settings.lastAutoArchiveDate).toBe(today().toString())
+    expect(notices).toEqual(['Archived 1 completed task(s) in 1 project(s).'])
+  })
+
+  it('never archives a completed task carrying no completion date', async () => {
+    settings.autoArchiveDays = 7
+    const project = await store.createProject('Roadmap', 'Projects')
+    const undated = await addTask(project, 'Undated', { status: 'done', completed: '' })
+    index.build()
+
+    await archiver.check()
+
+    expect(archived(project, undated)).toBe(false)
+  })
+
+  it("follows a project's own window over the global one", async () => {
+    settings.autoArchiveDays = 30
+    const project = await store.createProject('Roadmap', 'Projects')
+    const task = await addTask(project, 'Old', done(daysAgo(10)))
+    await store.updateProject(project, { config: { autoArchiveDays: 7 } })
+    index.build()
+
+    await archiver.check()
+
+    expect(archived(project, task)).toBe(true)
+  })
+
+  it('runs once a day', async () => {
+    settings.autoArchiveDays = 7
+    settings.lastAutoArchiveDate = today().toString()
+    const project = await store.createProject('Roadmap', 'Projects')
+    const old = await addTask(project, 'Old', done(daysAgo(30)))
+    index.build()
+
+    await archiver.check()
+
+    expect(archived(project, old)).toBe(false)
+  })
+
+  it('leaves a task another project still depends on', async () => {
+    settings.autoArchiveDays = 7
+    const library = await store.createProject('Library', 'Projects')
+    const consumer = await store.createProject('App', 'Projects')
+    const api = await addTask(library, 'API', done(daysAgo(30)))
+    await addTask(consumer, 'Client', { dependencies: [api.id] })
+    index.build()
+
+    await archiver.check()
+
+    expect(archived(library, api)).toBe(false)
+  })
+
+  it('takes everything completed when the command runs against a project with no window', async () => {
+    const project = await store.createProject('Roadmap', 'Projects')
+    const todayDone = await addTask(project, 'Just finished', done(today().toString()))
+    index.build()
+
+    const plans = await archiver.plan([project.filePath], true)
+    await archiver.apply(plans)
+
+    expect(archived(project, todayDone)).toBe(true)
+  })
+})

--- a/src/components/AutoArchiver.ts
+++ b/src/components/AutoArchiver.ts
@@ -14,9 +14,9 @@ export interface ArchivePlan {
 }
 
 /**
- * Moves tasks that have been complete for longer than their project's window into its
- * archive folder. The pass is keyed on the date rather than on elapsed time, so a vault
- * that stayed closed for a week catches up the next time it opens.
+ * Moves tasks complete for longer than their project's window into its archive folder.
+ * The pass is keyed on the date rather than on elapsed time, so a vault that stayed closed
+ * for a week catches up the next time it opens.
  */
 export class AutoArchiver {
   private running = false
@@ -33,7 +33,6 @@ export class AutoArchiver {
     )
   }
 
-  /** The daily pass over every project that has a window set. */
   async check(): Promise<void> {
     const settings = this.plugin.settings
     const configured = this.plugin.index
@@ -56,12 +55,10 @@ export class AutoArchiver {
   }
 
   /**
-   * Which tasks would move, one entry per project. The index says whether a project holds
-   * anything old enough, so only the projects that do are loaded. `includeDisabled` covers
-   * the command, where a project with no window archives everything it has finished.
-   *
-   * Dependencies are settled across the whole plan rather than project by project, because
-   * a task can wait on one in another project.
+   * The index says which projects hold anything old enough, so only those are loaded, and
+   * `includeDisabled` takes in the ones whose window is off. Dependencies are resolved
+   * across the whole plan rather than project by project, because a task can wait on one
+   * in another project.
    */
   async plan(projectPaths: string[], includeDisabled: boolean): Promise<ArchivePlan[]> {
     const entries: { project: Project; candidate: ArchiveCandidate }[] = []
@@ -104,7 +101,6 @@ export class AutoArchiver {
     return [...plans.values()]
   }
 
-  /** Returns how many tasks moved. */
   async apply(plans: ArchivePlan[]): Promise<number> {
     let tasks = 0
     for (const plan of plans) {

--- a/src/components/AutoArchiver.ts
+++ b/src/components/AutoArchiver.ts
@@ -1,0 +1,116 @@
+import type PMPlugin from '../main'
+import type { Project } from '../types'
+import type { ArchiveCandidate } from '../store'
+import { collectArchivable, withoutBlockedDependents } from '../store'
+import { today } from '../dates'
+import { isTerminalStatus, safeAsync } from '../utils'
+
+const CHECK_INTERVAL_MS = 60 * 60 * 1000
+
+export interface ArchivePlan {
+  project: Project
+  rootIds: string[]
+  tasks: number
+}
+
+/**
+ * Moves tasks that have been complete for longer than their project's window into its
+ * archive folder. The pass is keyed on the date rather than on elapsed time, so a vault
+ * that stayed closed for a week catches up the next time it opens.
+ */
+export class AutoArchiver {
+  private running = false
+
+  constructor(private plugin: PMPlugin) {}
+
+  /** The first pass runs once the index is built; this only schedules the later ones. */
+  start(): void {
+    this.plugin.registerInterval(
+      window.setInterval(
+        safeAsync(() => this.check()),
+        CHECK_INTERVAL_MS
+      )
+    )
+  }
+
+  /** The daily pass over every project that has a window set. */
+  async check(): Promise<void> {
+    const settings = this.plugin.settings
+    const configured = this.plugin.index
+      .projectRefs()
+      .some((ref) => (ref.autoArchiveDays ?? settings.autoArchiveDays) > 0)
+    if (!configured) return
+
+    const stamp = today().toString()
+    if (settings.lastAutoArchiveDate === stamp || this.running) return
+    this.running = true
+    try {
+      const plans = await this.plan(this.plugin.index.projectPaths(), false)
+      const tasks = await this.apply(plans)
+      settings.lastAutoArchiveDate = stamp
+      await this.plugin.saveSettings()
+      if (tasks) this.plugin.showNotice(`Archived ${tasks} completed task(s) in ${plans.length} project(s).`)
+    } finally {
+      this.running = false
+    }
+  }
+
+  /**
+   * Which tasks would move, one entry per project. The index says whether a project holds
+   * anything old enough, so only the projects that do are loaded. `includeDisabled` covers
+   * the command, where a project with no window archives everything it has finished.
+   *
+   * Dependencies are settled across the whole plan rather than project by project, because
+   * a task can wait on one in another project.
+   */
+  async plan(projectPaths: string[], includeDisabled: boolean): Promise<ArchivePlan[]> {
+    const entries: { project: Project; candidate: ArchiveCandidate }[] = []
+    for (const path of projectPaths) {
+      const ref = this.plugin.index.projectRef(path)
+      if (!ref) continue
+      const days = ref.autoArchiveDays ?? this.plugin.settings.autoArchiveDays
+      if (days === 0 && !includeDisabled) continue
+      const cutoff = today().subtract({ days }).toString()
+
+      const complete = this.plugin.index.completeStatuses(ref)
+      const anyOldEnough = this.plugin.index
+        .taskRefs(path)
+        .some((task) => !task.archived && complete.has(task.status) && !!task.completed && task.completed <= cutoff)
+      if (!anyOldEnough) continue
+
+      const project = await this.plugin.store.loadProjectByPath(path)
+      if (!project) continue
+      const statuses = this.plugin.store.configFor(project).statuses
+      for (const candidate of collectArchivable(project, (status) => isTerminalStatus(status, statuses), cutoff)) {
+        entries.push({ project, candidate })
+      }
+    }
+
+    const kept = new Set(
+      withoutBlockedDependents(
+        entries.map((entry) => entry.candidate),
+        this.plugin.index
+      ).map((candidate) => candidate.rootId)
+    )
+
+    const plans = new Map<Project, ArchivePlan>()
+    for (const { project, candidate } of entries) {
+      if (!kept.has(candidate.rootId)) continue
+      const plan = plans.get(project) ?? { project, rootIds: [], tasks: 0 }
+      plan.rootIds.push(candidate.rootId)
+      plan.tasks += candidate.ids.length
+      plans.set(project, plan)
+    }
+    return [...plans.values()]
+  }
+
+  /** Returns how many tasks moved. */
+  async apply(plans: ArchivePlan[]): Promise<number> {
+    let tasks = 0
+    for (const plan of plans) {
+      await this.plugin.store.archiveTasks(plan.project, plan.rootIds)
+      tasks += plan.tasks
+    }
+    return tasks
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import {
   confirmDialog
 } from './ui/ModalFactory'
 import { Notifier } from './components/Notifier'
+import { AutoArchiver } from './components/AutoArchiver'
 import { migrateProjects, migrateProjectLayout } from './migration'
 import { dedupePeople, displayName, safeAsync } from './utils'
 
@@ -29,6 +30,7 @@ export default class PMPlugin extends Plugin {
   store!: TaskSource
   index!: VaultIndex
   notifier!: Notifier
+  autoArchiver!: AutoArchiver
   router!: PMViewRouter
   /** Paths deliberately sent to the markdown editor, which the swap then leaves alone. */
   private markdownEscapes = new Set<string>()
@@ -69,6 +71,7 @@ export default class PMPlugin extends Plugin {
     this.store = new ProjectStore(this.app, () => this.settings, this.index)
     this.store.registerVaultSync(this)
     this.notifier = new Notifier(this)
+    this.autoArchiver = new AutoArchiver(this)
     this.router = new PMViewRouter(this)
 
     this.registerView(PM_PROJECT_VIEW_TYPE, (leaf) => new ProjectView(leaf, this))
@@ -152,6 +155,14 @@ export default class PMPlugin extends Plugin {
       callback: () => {
         this.index.build()
         this.showNotice(`Found ${this.index.projectRefs().length} project(s).`)
+      }
+    })
+
+    this.addCommand({
+      id: 'archive-completed-tasks',
+      name: 'Archive completed tasks',
+      callback: () => {
+        void this.archiveCompletedTasks()
       }
     })
 
@@ -240,6 +251,7 @@ export default class PMPlugin extends Plugin {
 
     this.addSettingTab(new PMSettingTab(this.app, this))
     this.notifier.start()
+    this.autoArchiver.start()
   }
 
   onunload(): void {
@@ -331,12 +343,35 @@ export default class PMPlugin extends Plugin {
     return path === '' || this.app.vault.getAbstractFileByPath(path) !== null
   }
 
-  /** The startup work that reads the index: migration, pruning, and the first due sweep. */
+  /**
+   * Archives what the open project view covers, or the whole vault when none is open.
+   * A project with no window of its own archives everything it has finished.
+   */
+  private async archiveCompletedTasks(): Promise<void> {
+    const scoped = this.app.workspace.getActiveViewOfType(ProjectView)?.projectScope?.projects.map((p) => p.filePath)
+    const plans = await this.autoArchiver.plan(scoped?.length ? scoped : this.index.projectPaths(), true)
+    const tasks = plans.reduce((sum, plan) => sum + plan.tasks, 0)
+    if (!tasks) {
+      this.showNotice('No completed tasks are ready to archive.')
+      return
+    }
+    const ok = await confirmDialog(
+      this.app,
+      `Archive ${tasks} completed task(s) in ${plans.length} project(s)?`,
+      'Archive'
+    )
+    if (!ok) return
+    await this.autoArchiver.apply(plans)
+    this.showNotice(`Archived ${tasks} task(s).`)
+  }
+
+  /** The startup work that reads the index: migration, pruning, and the first due and archive sweeps. */
   private async startupSweep(): Promise<void> {
     await migrateProjects(this)
     await migrateProjectLayout(this)
     await this.cleanupStaleProjectFilters()
     this.notifier.check()
+    await this.autoArchiver.check()
   }
 
   async cleanupStaleProjectFilters(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -343,10 +343,7 @@ export default class PMPlugin extends Plugin {
     return path === '' || this.app.vault.getAbstractFileByPath(path) !== null
   }
 
-  /**
-   * Archives what the open project view covers, or the whole vault when none is open.
-   * A project with no window of its own archives everything it has finished.
-   */
+  /** A project with no window of its own archives everything it has finished. */
   private async archiveCompletedTasks(): Promise<void> {
     const scoped = this.app.workspace.getActiveViewOfType(ProjectView)?.projectScope?.projects.map((p) => p.filePath)
     const plans = await this.autoArchiver.plan(scoped?.length ? scoped : this.index.projectPaths(), true)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -205,7 +205,7 @@ export class PMSettingTab extends PluginSettingTab {
         items: [
           {
             name: 'Auto-archive completed tasks',
-            desc: "Days a completed task waits before moving to the project's archive. 0 turns it off.",
+            desc: "Move completed tasks to the project's archive after this many days. Set it to 0 to keep them in place.",
             aliases: ['archive', 'cleanup', 'done'],
             control: {
               type: 'slider',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -201,6 +201,24 @@ export class PMSettingTab extends PluginSettingTab {
       },
       {
         type: 'group',
+        heading: 'Archive',
+        items: [
+          {
+            name: 'Auto-archive completed tasks',
+            desc: "Days a completed task waits before moving to the project's archive. 0 turns it off.",
+            aliases: ['archive', 'cleanup', 'done'],
+            control: {
+              type: 'slider',
+              key: 'autoArchiveDays',
+              min: 0,
+              max: 90,
+              step: 1
+            }
+          }
+        ]
+      },
+      {
+        type: 'group',
         heading: 'Notifications',
         items: [
           {
@@ -240,6 +258,11 @@ export class PMSettingTab extends PluginSettingTab {
 
   async setControlValue(key: string, value: unknown): Promise<void> {
     await super.setControlValue(key, value)
+    // Today's pass ran against the old window, so it has to run again to reflect the new one.
+    if (key === 'autoArchiveDays') {
+      this.plugin.settings.lastAutoArchiveDate = ''
+      await this.plugin.autoArchiver.check()
+    }
     this.plugin.refreshViews()
     this.refreshDomState()
   }

--- a/src/store/ArchiveOps.test.ts
+++ b/src/store/ArchiveOps.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { makeProject, makeTask, type Project, type Task } from '../types'
+import type { TaskRef } from './VaultIndex'
+import { collectArchivable, withoutBlockedDependents } from './ArchiveOps'
+
+const isComplete = (status: string): boolean => status === 'done'
+
+function project(tasks: Task[]): Project {
+  const p = makeProject('Roadmap', 'Projects/Roadmap.md')
+  p.tasks = tasks
+  return p
+}
+
+function done(id: string, completed: string, overrides: Partial<Task> = {}): Task {
+  return makeTask({ id, title: id, status: 'done', completed, ...overrides })
+}
+
+function ref(id: string, dependencies: string[], archived = false): TaskRef {
+  return {
+    id,
+    path: `Projects/Roadmap_tasks/${id}.md`,
+    projectId: 'p1',
+    projectPath: 'Projects/Roadmap.md',
+    title: id,
+    status: 'todo',
+    priority: 'medium',
+    start: '',
+    due: '',
+    completed: '',
+    dependencies,
+    assignees: [],
+    archived
+  }
+}
+
+const index = (refs: TaskRef[]) => ({ allTaskRefs: () => refs })
+
+describe('collectArchivable', () => {
+  it('picks tasks completed on or before the cutoff', () => {
+    const p = project([done('old', '2026-08-01'), done('fresh', '2026-08-20')])
+
+    expect(collectArchivable(p, isComplete, '2026-08-10')).toEqual([{ rootId: 'old', ids: ['old'] }])
+  })
+
+  it('leaves a completed task carrying no completion date', () => {
+    const p = project([done('undated', '')])
+
+    expect(collectArchivable(p, isComplete, '2026-08-10')).toEqual([])
+  })
+
+  it('leaves a task whose status is not complete', () => {
+    const p = project([makeTask({ id: 'open', status: 'in-progress', completed: '2026-08-01' })])
+
+    expect(collectArchivable(p, isComplete, '2026-08-10')).toEqual([])
+  })
+
+  it('keeps a whole subtree in place when one descendant is still live', () => {
+    const p = project([
+      done('parent', '2026-08-01', {
+        subtasks: [done('child', '2026-08-01'), makeTask({ id: 'live', status: 'todo' })]
+      })
+    ])
+
+    expect(collectArchivable(p, isComplete, '2026-08-10')).toEqual([])
+  })
+
+  it('takes the subtree with its root and reports every task that moves', () => {
+    const p = project([done('parent', '2026-08-01', { subtasks: [done('child', '2026-08-02')] })])
+
+    expect(collectArchivable(p, isComplete, '2026-08-10')).toEqual([{ rootId: 'parent', ids: ['parent', 'child'] }])
+  })
+
+  it('counts an already archived descendant as settled without moving it again', () => {
+    const p = project([done('parent', '2026-08-01', { subtasks: [done('child', '', { archived: true })] })])
+
+    expect(collectArchivable(p, isComplete, '2026-08-10')).toEqual([{ rootId: 'parent', ids: ['parent'] }])
+  })
+
+  it('skips a root that is already archived', () => {
+    const p = project([done('gone', '2026-08-01', { archived: true })])
+
+    expect(collectArchivable(p, isComplete, '2026-08-10')).toEqual([])
+  })
+})
+
+describe('withoutBlockedDependents', () => {
+  const candidate = (rootId: string, ids = [rootId]) => ({ rootId, ids })
+
+  it('drops a task a live one still depends on', () => {
+    const kept = withoutBlockedDependents([candidate('a')], index([ref('a', []), ref('open', ['a'])]))
+
+    expect(kept).toEqual([])
+  })
+
+  it('keeps a task whose dependents are archived', () => {
+    const kept = withoutBlockedDependents([candidate('a')], index([ref('a', []), ref('gone', ['a'], true)]))
+
+    expect(kept).toEqual([candidate('a')])
+  })
+
+  it('keeps predecessor and dependent when both are archived in the same pass', () => {
+    const kept = withoutBlockedDependents([candidate('a'), candidate('b')], index([ref('a', []), ref('b', ['a'])]))
+
+    expect(kept.map((c) => c.rootId)).toEqual(['a', 'b'])
+  })
+
+  it('drops a predecessor when the task waiting on it is dropped first', () => {
+    const kept = withoutBlockedDependents(
+      [candidate('a'), candidate('b')],
+      index([ref('a', []), ref('b', ['a']), ref('open', ['b'])])
+    )
+
+    expect(kept).toEqual([])
+  })
+
+  it('protects a dependency pointing into the middle of a moving subtree', () => {
+    const kept = withoutBlockedDependents(
+      [candidate('parent', ['parent', 'child'])],
+      index([ref('parent', []), ref('child', []), ref('open', ['child'])])
+    )
+
+    expect(kept).toEqual([])
+  })
+})

--- a/src/store/ArchiveOps.ts
+++ b/src/store/ArchiveOps.ts
@@ -72,7 +72,7 @@ export async function unarchiveTask(
   }
 }
 
-/** A task that is due to be archived, with every descendant that moves along with it. */
+/** A task to archive, and every descendant moving with it. */
 export interface ArchiveCandidate {
   rootId: string
   ids: string[]

--- a/src/store/ArchiveOps.ts
+++ b/src/store/ArchiveOps.ts
@@ -2,6 +2,7 @@ import type { App } from 'obsidian'
 import { TFile, normalizePath } from 'obsidian'
 import type { Project, Task } from '../types'
 import { findTaskById } from './TaskIndex'
+import type { TaskRef } from './VaultIndex'
 import { ensureFolder, moveTaskAttachmentFolder, projectTaskFolder } from './vaultFs'
 
 function subtree(task: Task): Task[] {
@@ -68,5 +69,61 @@ export async function unarchiveTask(
   const taskFolder = normalizePath(projectTaskFolder(app, project.filePath))
   for (const t of subtree(task)) {
     if (await moveTaskFile(app, t, taskFolder, markSelfWrite)) t.archived = false
+  }
+}
+
+/** A task that is due to be archived, with every descendant that moves along with it. */
+export interface ArchiveCandidate {
+  rootId: string
+  ids: string[]
+}
+
+function archivable(task: Task, isComplete: (status: string) => boolean, cutoff: string): boolean {
+  if (task.archived) return true
+  if (!isComplete(task.status)) return false
+  if (!task.completed || task.completed > cutoff) return false
+  return task.subtasks.every((sub) => archivable(sub, isComplete, cutoff))
+}
+
+/**
+ * Top-level tasks finished on or before `cutoff`, subtree included. A subtree moves as a
+ * unit, so one live descendant keeps the whole thing in place, and a task carrying no
+ * completion date is never picked: there is nothing to measure its age against.
+ */
+export function collectArchivable(
+  project: Project,
+  isComplete: (status: string) => boolean,
+  cutoff: string
+): ArchiveCandidate[] {
+  return project.tasks
+    .filter((task) => !task.archived && archivable(task, isComplete, cutoff))
+    .map((task) => ({
+      rootId: task.id,
+      ids: subtree(task)
+        .filter((t) => !t.archived)
+        .map((t) => t.id)
+    }))
+}
+
+/**
+ * Drops candidates something live still depends on. The scheduler ignores archived
+ * predecessors, so archiving one would move the dates of a task nobody touched; a
+ * predecessor waits until everything waiting on it is archived too.
+ */
+export function withoutBlockedDependents(
+  candidates: ArchiveCandidate[],
+  index: { allTaskRefs(): TaskRef[] }
+): ArchiveCandidate[] {
+  let kept = candidates
+  for (;;) {
+    const moving = new Set(kept.flatMap((candidate) => candidate.ids))
+    const needed = new Set<string>()
+    for (const ref of index.allTaskRefs()) {
+      if (ref.archived || moving.has(ref.id)) continue
+      for (const id of ref.dependencies) needed.add(id)
+    }
+    const next = kept.filter((candidate) => !candidate.ids.some((id) => needed.has(id)))
+    if (next.length === kept.length) return next
+    kept = next
   }
 }

--- a/src/store/ProjectConfig.ts
+++ b/src/store/ProjectConfig.ts
@@ -30,6 +30,7 @@ export function resolveProjectConfig(project: Project, settings: PMSettings): Re
     defaultView: config?.defaultView ?? settings.defaultView,
     autoSchedule: config?.autoSchedule ?? settings.autoSchedule,
     pullForwardOnEarlyFinish: config?.pullForwardOnEarlyFinish ?? settings.pullForwardOnEarlyFinish,
+    autoArchiveDays: config?.autoArchiveDays ?? settings.autoArchiveDays,
     showSubtreeConnections: config?.showSubtreeConnections ?? settings.showSubtreeConnections,
     lineBorders: config?.lineBorders ?? settings.lineBorders,
     kanbanShowSubtasks: config?.kanbanShowSubtasks ?? settings.kanbanShowSubtasks,

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -604,6 +604,23 @@ describe('ProjectStore archiving', () => {
     }
   })
 
+  it('archives several tasks in one save', async () => {
+    const { store, vault } = newStore()
+    const project = await store.createProject('Tree', 'Projects')
+    const first = await addNamed(store, project, 'First')
+    const second = await addNamed(store, project, 'Second')
+    const child = await addNamed(store, project, 'Child', second.id)
+    const projectWrites = vault.modifyCount.get(project.filePath) ?? 0
+
+    await store.archiveTasks(project, [first.id, second.id])
+
+    for (const task of [first, second, child]) {
+      expect(task.archived).toBe(true)
+      expect(vault.getAbstractFileByPath(expectDefined(task.filePath))).not.toBeNull()
+    }
+    expect((vault.modifyCount.get(project.filePath) ?? 0) - projectWrites).toBe(1)
+  })
+
   it('leaves an already archived subtask in place when its parent is archived', async () => {
     const { store } = newStore()
     const project = await store.createProject('Tree', 'Projects')

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -1182,6 +1182,14 @@ export class ProjectStore implements TaskSource {
     await this.saveProject(project)
   }
 
+  /** Archives several tasks, and their subtrees, in one save. */
+  async archiveTasks(project: Project, taskIds: string[]): Promise<void> {
+    for (const taskId of taskIds) {
+      await doArchiveTask(this.app, project, taskId, (path) => this.markSelfWrite(path))
+    }
+    await this.saveProject(project)
+  }
+
   async unarchiveTask(project: Project, taskId: string): Promise<void> {
     await doUnarchiveTask(this.app, project, taskId, (path) => this.markSelfWrite(path))
     await this.saveProject(project)

--- a/src/store/TaskSource.ts
+++ b/src/store/TaskSource.ts
@@ -74,6 +74,8 @@ export interface TaskSource {
   deleteTask(project: Project, taskId: string): Promise<void>
   deleteTasks(project: Project, taskIds: string[]): Promise<void>
   archiveTask(project: Project, taskId: string): Promise<void>
+  /** Archives several tasks, and their subtrees, in one save. */
+  archiveTasks(project: Project, taskIds: string[]): Promise<void>
   unarchiveTask(project: Project, taskId: string): Promise<void>
 
   /** Runs dependency-based auto-scheduling; a no-op when the project's config disables it. */

--- a/src/store/TaskSource.ts
+++ b/src/store/TaskSource.ts
@@ -74,7 +74,6 @@ export interface TaskSource {
   deleteTask(project: Project, taskId: string): Promise<void>
   deleteTasks(project: Project, taskIds: string[]): Promise<void>
   archiveTask(project: Project, taskId: string): Promise<void>
-  /** Archives several tasks, and their subtrees, in one save. */
   archiveTasks(project: Project, taskIds: string[]): Promise<void>
   unarchiveTask(project: Project, taskId: string): Promise<void>
 

--- a/src/store/VaultIndex.ts
+++ b/src/store/VaultIndex.ts
@@ -22,6 +22,8 @@ export interface ProjectRef {
   ownStatusIds: string[] | null
   /** Which of those its own palette marks complete. Null inherits the global palette. */
   completeStatusIds: string[] | null
+  /** Days before a completed task is archived. Null inherits the global setting. */
+  autoArchiveDays: number | null
 }
 
 export interface TaskRef {
@@ -51,12 +53,20 @@ function insideTaskFolder(path: string): boolean {
   return parts.some((segment) => segment.endsWith('_tasks'))
 }
 
-function ownStatusesOf(frontmatter: Record<string, unknown>): Partial<StatusConfig>[] | null {
+function projectConfigOf(frontmatter: Record<string, unknown>): Record<string, unknown> | null {
   const config = frontmatter.config
-  if (!config || typeof config !== 'object') return null
-  const statuses = (config as Record<string, unknown>).statuses
+  return config && typeof config === 'object' ? (config as Record<string, unknown>) : null
+}
+
+function ownStatusesOf(frontmatter: Record<string, unknown>): Partial<StatusConfig>[] | null {
+  const statuses = projectConfigOf(frontmatter)?.statuses
   if (!Array.isArray(statuses) || statuses.length === 0) return null
   return (statuses as Partial<StatusConfig>[]).filter((entry) => typeof entry?.id === 'string')
+}
+
+function ownAutoArchiveDays(frontmatter: Record<string, unknown>): number | null {
+  const days = projectConfigOf(frontmatter)?.autoArchiveDays
+  return typeof days === 'number' && Number.isFinite(days) && days >= 0 ? Math.floor(days) : null
 }
 
 /**
@@ -374,7 +384,8 @@ export class VaultIndex {
       teamMembers: stringList(frontmatter.teamMembers),
       parentPath: resolveVaultLink(this.app, frontmatter.parent, path),
       ownStatusIds: own ? own.map((entry) => entry.id as string) : null,
-      completeStatusIds: own ? own.filter((entry) => entry.complete === true).map((entry) => entry.id as string) : null
+      completeStatusIds: own ? own.filter((entry) => entry.complete === true).map((entry) => entry.id as string) : null,
+      autoArchiveDays: ownAutoArchiveDays(frontmatter)
     }
     this.projects.set(path, ref)
     this.projectPathById.set(ref.id, path)

--- a/src/store/YamlHydrator.ts
+++ b/src/store/YamlHydrator.ts
@@ -159,6 +159,9 @@ function hydrateProjectConfig(raw: unknown): ProjectConfig | undefined {
   }
   if (typeof r.autoSchedule === 'boolean') config.autoSchedule = r.autoSchedule
   if (typeof r.pullForwardOnEarlyFinish === 'boolean') config.pullForwardOnEarlyFinish = r.pullForwardOnEarlyFinish
+  if (typeof r.autoArchiveDays === 'number' && Number.isFinite(r.autoArchiveDays) && r.autoArchiveDays >= 0) {
+    config.autoArchiveDays = Math.floor(r.autoArchiveDays)
+  }
   if (typeof r.showSubtreeConnections === 'boolean') config.showSubtreeConnections = r.showSubtreeConnections
   if (
     r.lineBorders === 'none' ||

--- a/src/store/YamlSerializer.ts
+++ b/src/store/YamlSerializer.ts
@@ -13,6 +13,7 @@ function serializeProjectConfig(config: ProjectConfig | undefined): Record<strin
   if (config.defaultView) out.defaultView = config.defaultView
   if (config.autoSchedule !== undefined) out.autoSchedule = config.autoSchedule
   if (config.pullForwardOnEarlyFinish !== undefined) out.pullForwardOnEarlyFinish = config.pullForwardOnEarlyFinish
+  if (config.autoArchiveDays !== undefined) out.autoArchiveDays = config.autoArchiveDays
   if (config.showSubtreeConnections !== undefined) out.showSubtreeConnections = config.showSubtreeConnections
   if (config.lineBorders) out.lineBorders = config.lineBorders
   if (config.kanbanShowSubtasks !== undefined) out.kanbanShowSubtasks = config.kanbanShowSubtasks

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,5 @@
-export { archiveTask, unarchiveTask } from './ArchiveOps'
+export { archiveTask, collectArchivable, unarchiveTask, withoutBlockedDependents } from './ArchiveOps'
+export type { ArchiveCandidate } from './ArchiveOps'
 export { ProjectStore, TaskFileNameConflictError } from './ProjectStore'
 export type { ImportNoteOptions, TaskSource } from './TaskSource'
 export { computeSchedule, wouldCreateCycle } from './Scheduler'

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,7 @@ export interface ProjectConfig {
   defaultView?: ViewMode
   autoSchedule?: boolean
   pullForwardOnEarlyFinish?: boolean
+  autoArchiveDays?: number
   showSubtreeConnections?: boolean
   lineBorders?: LineBorders
   kanbanShowSubtasks?: boolean
@@ -143,6 +144,7 @@ export interface ResolvedProjectConfig {
   defaultView: ViewMode
   autoSchedule: boolean
   pullForwardOnEarlyFinish: boolean
+  autoArchiveDays: number
   showSubtreeConnections: boolean
   lineBorders: LineBorders
   kanbanShowSubtasks: boolean
@@ -191,6 +193,10 @@ export interface PMSettings {
   globalTeamMembers: string[]
   notificationsEnabled: boolean
   notificationLeadDays: number
+  /** Days after completion before a task moves to its project's archive. 0 turns it off. */
+  autoArchiveDays: number
+  /** The day the archive sweep last ran, so it runs at most once a day. */
+  lastAutoArchiveDate: string
   autoSchedule: boolean
   pullForwardOnEarlyFinish: boolean
   showSubtreeConnections: boolean
@@ -246,6 +252,8 @@ export const DEFAULT_SETTINGS: PMSettings = {
   showTagColors: true,
   notificationsEnabled: true,
   notificationLeadDays: 2,
+  autoArchiveDays: 0,
+  lastAutoArchiveDate: '',
   autoSchedule: true,
   pullForwardOnEarlyFinish: false,
   saveTaskOnClose: true,

--- a/src/views/ProjectEditView.ts
+++ b/src/views/ProjectEditView.ts
@@ -110,7 +110,7 @@ export class ProjectEditView extends ItemView {
   private patchConfig<K extends keyof ProjectConfig>(key: K, value: ProjectConfig[K] | undefined): void {
     const entries = Object.entries({ ...this.project?.config, [key]: value }).filter(([, v]) => v !== undefined)
     this.save({ config: entries.length ? Object.fromEntries(entries) : undefined })
-    // Today's archive pass ran against the old window; the next one picks up this project.
+    // Today's pass ran against the old window, so it has to run again.
     if (key === 'autoArchiveDays') this.plugin.settings.lastAutoArchiveDate = ''
   }
 

--- a/src/views/ProjectEditView.ts
+++ b/src/views/ProjectEditView.ts
@@ -110,6 +110,8 @@ export class ProjectEditView extends ItemView {
   private patchConfig<K extends keyof ProjectConfig>(key: K, value: ProjectConfig[K] | undefined): void {
     const entries = Object.entries({ ...this.project?.config, [key]: value }).filter(([, v]) => v !== undefined)
     this.save({ config: entries.length ? Object.fromEntries(entries) : undefined })
+    // Today's archive pass ran against the old window; the next one picks up this project.
+    if (key === 'autoArchiveDays') this.plugin.settings.lastAutoArchiveDate = ''
   }
 
   private section(title: string, hint = ''): HTMLElement {
@@ -368,6 +370,13 @@ export class ProjectEditView extends ItemView {
     row('Pull forward on early finish', 'pullForwardOnEarlyFinish', [
       { value: true, label: 'On' },
       { value: false, label: 'Off' }
+    ])
+    row('Auto-archive completed tasks', 'autoArchiveDays', [
+      { value: 0, label: 'Never' },
+      { value: 7, label: 'After 7 days' },
+      { value: 14, label: 'After 14 days' },
+      { value: 30, label: 'After 30 days' },
+      { value: 90, label: 'After 90 days' }
     ])
     row('Subtree connections in table', 'showSubtreeConnections', [
       { value: true, label: 'Show' },


### PR DESCRIPTION
Completed tasks move into their project's archive folder once they have been done for the number of days set in settings, globally or per project. A new command runs the same pass on demand. Off by default.

Until now a finished task stayed on the board and in the table until someone archived it by hand. Closes #204.