### PR TITLE
add a year zoom level to the gantt timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The timeline has a year zoom level, showing quarters under each year ([#50](https://github.com/StepanKropachev/obsidian-pm/issues/50), [#77](https://github.com/StepanKropachev/obsidian-pm/issues/77), [#147](https://github.com/StepanKropachev/obsidian-pm/issues/147))
+
 ## [2.1.0] - 2026-08-27
+
+### Highlights
+
+- **Auto-archive:** Completed tasks move into the project's archive on their own after a number of days you choose, set once for every project or overridden by a project in its own settings, and the archive completed tasks command does the same sweep right away.
+- **Inherited custom fields:** Custom fields can be defined once for the whole vault or on a parent project, and every project underneath starts with them. Each project can still rename, retype, or hide a field it inherits, and a field it already had of its own can be merged into the inherited one, values and all.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Sortable, filterable task grid with inline editing. Save custom filter/sort comb
 
 ### Gantt
 
-Interactive timeline with draggable bars, resizable edges, and dependency arrows. Zoom from day to quarter. Drag to reschedule, resize to adjust duration. Milestones render as diamonds. A "today" line keeps you oriented.
+Interactive timeline with draggable bars, resizable edges, and dependency arrows. Zoom from day to year. Drag to reschedule, resize to adjust duration. Milestones render as diamonds. A "today" line keeps you oriented.
 
 <video src="https://github.com/user-attachments/assets/916f7100-44ef-401c-abb3-e003a0f7720a" autoplay loop muted playsinline width="400"></video>
 
@@ -138,7 +138,7 @@ Task hierarchy and dependencies don't resolve on the TaskNotes side (it uses pro
 | Open projects in | Overview page, or straight to the project's tasks |
 | Default tasks view | Table, Gantt, or Kanban |
 | Open tasks in | Modal or tab. On tab, task notes open in the task editor instead of Obsidian's. |
-| Gantt granularity | Default timeline scale (day / week / month / quarter) |
+| Gantt granularity | Default timeline scale (day / week / month / quarter / year) |
 | Gantt week labels | Week number, date range, or both |
 | Due date notifications | Reminders N days before due dates |
 | Notifications on/off | Master switch for due date reminders, separate from lead time |
@@ -243,7 +243,7 @@ Task description in Markdown goes here.
 |---|---|
 | Projects folder | Vault folder where project and task files are stored |
 | Default tasks view | Table, Gantt, or Kanban |
-| Gantt granularity | Default timeline scale (day / week / month / quarter) |
+| Gantt granularity | Default timeline scale (day / week / month / quarter / year) |
 | Gantt week labels | Week number, date range, or both |
 | Due date notifications | Reminders N days before due dates |
 | Custom statuses | Edit labels, colors, and icons for each status |

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -141,7 +141,7 @@ export class PMSettingTab extends PluginSettingTab {
             control: {
               type: 'dropdown',
               key: 'ganttGranularity',
-              options: { day: 'Day', week: 'Week', month: 'Month', quarter: 'Quarter' }
+              options: { day: 'Day', week: 'Week', month: 'Month', quarter: 'Quarter', year: 'Year' }
             }
           },
           {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type { TaskIndex } from './store/TaskIndex'
 
 export type TaskStatus = string
 export type TaskPriority = string
-export type GanttGranularity = 'day' | 'week' | 'month' | 'quarter'
+export type GanttGranularity = 'day' | 'week' | 'month' | 'quarter' | 'year'
 export type GanttWeekLabel = 'weekNumber' | 'dateRange' | 'both'
 export type ViewMode = 'table' | 'gantt' | 'kanban'
 export type LineBorders = 'none' | 'horizontal' | 'vertical' | 'both'

--- a/src/views/gantt/GanttHeaderRenderer.ts
+++ b/src/views/gantt/GanttHeaderRenderer.ts
@@ -39,7 +39,8 @@ export function renderTimelineHeader(ctx: RendererContext): void {
   if (granularity === 'day') renderDayHeader(g, ctx)
   else if (granularity === 'week') renderWeekHeader(g, ctx)
   else if (granularity === 'month') renderMonthHeader(g, ctx)
-  else renderQuarterHeader(g, ctx)
+  else if (granularity === 'quarter') renderQuarterHeader(g, ctx)
+  else renderYearHeader(g, ctx)
 
   ctx.headerSvgEl.appendChild(g)
 }
@@ -170,6 +171,39 @@ function renderQuarterHeader(g: SVGGElement, ctx: RendererContext): void {
     })
     text.textContent = `Q${q} ${date.year}`
     g.appendChild(text)
+    date = nextQStart
+  }
+}
+
+function renderYearHeader(g: SVGGElement, ctx: RendererContext): void {
+  renderYearBands(g, 0, 24, ctx)
+  const { startDate } = ctx.cfg
+  let date = Temporal.PlainDate.from({
+    year: startDate.year,
+    month: Math.floor((startDate.month - 1) / 3) * 3 + 1,
+    day: 1
+  })
+  while (Temporal.PlainDate.compare(date, ctx.cfg.endDate) < 0) {
+    const q = Math.floor((date.month - 1) / 3) + 1
+    const nextQStart = date.add({ months: 3 })
+    const x1 = Math.max(0, dateToX(ctx.cfg, date))
+    const x2 = Math.min(ctx.cfg.totalWidth, dateToX(ctx.cfg, nextQStart))
+    const text = svgEl('text', {
+      x: x1 + (x2 - x1) / 2,
+      y: 44,
+      class: 'pm-gantt-header-quarter'
+    })
+    text.textContent = `Q${q}`
+    g.appendChild(text)
+    g.appendChild(
+      svgEl('line', {
+        x1,
+        y1: 24,
+        x2: x1,
+        y2: HEADER_HEIGHT,
+        class: 'pm-gantt-header-tick'
+      })
+    )
     date = nextQStart
   }
 }

--- a/src/views/gantt/GanttRenderer.ts
+++ b/src/views/gantt/GanttRenderer.ts
@@ -56,7 +56,7 @@ export function renderGridLines(ctx: RendererContext, totalRows: number): void {
       (granularity === 'day' && isMonday) ||
       (granularity === 'week' && isMonday) ||
       (granularity === 'month' && isFirst) ||
-      (granularity === 'quarter' && isFirst && (d.month - 1) % 3 === 0)
+      ((granularity === 'quarter' || granularity === 'year') && isFirst && (d.month - 1) % 3 === 0)
 
     if (shouldDrawLine) {
       g.appendChild(

--- a/src/views/gantt/GanttView.ts
+++ b/src/views/gantt/GanttView.ts
@@ -94,8 +94,14 @@ export class GanttView implements SubView {
 
   private renderGranularityControls(): void {
     const bar = this.container.createDiv('pm-gantt-controls')
-    const levels: GanttGranularity[] = ['day', 'week', 'month', 'quarter']
-    const labels: Record<GanttGranularity, string> = { day: 'Day', week: 'Week', month: 'Month', quarter: 'Quarter' }
+    const levels: GanttGranularity[] = ['day', 'week', 'month', 'quarter', 'year']
+    const labels: Record<GanttGranularity, string> = {
+      day: 'Day',
+      week: 'Week',
+      month: 'Month',
+      quarter: 'Quarter',
+      year: 'Year'
+    }
 
     new SegmentedControl<GanttGranularity>(bar, {
       options: levels.map((level) => ({ id: level, label: labels[level] })),

--- a/src/views/gantt/TimelineConfig.test.ts
+++ b/src/views/gantt/TimelineConfig.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { makeTask } from '../../types'
+import { buildTimelineConfig, getSnapPoints, dateToX } from './TimelineConfig'
+import { Temporal } from '../../dates'
+
+const tasks = [makeTask({ start: '2026-03-10', due: '2026-04-20' })]
+
+describe('buildTimelineConfig', () => {
+  it('spans at least three years at year granularity', () => {
+    const cfg = buildTimelineConfig(tasks, 'year')
+    expect(cfg.totalDays).toBeGreaterThanOrEqual(1095)
+  })
+
+  it('starts a year timeline on the first of a month', () => {
+    const cfg = buildTimelineConfig(tasks, 'year')
+    expect(cfg.startDate.day).toBe(1)
+  })
+
+  it('gives a year column less width than a quarter column', () => {
+    expect(buildTimelineConfig(tasks, 'year').dayWidth).toBeLessThan(buildTimelineConfig(tasks, 'quarter').dayWidth)
+  })
+})
+
+describe('getSnapPoints', () => {
+  it('snaps to month starts at year granularity', () => {
+    const cfg = buildTimelineConfig(tasks, 'year')
+    const points = getSnapPoints(cfg)
+    const march = Temporal.PlainDate.from('2026-03-01')
+    expect(points).toContain(dateToX(cfg, march))
+    expect(points).not.toContain(dateToX(cfg, march.add({ days: 1 })))
+  })
+})

--- a/src/views/gantt/TimelineConfig.ts
+++ b/src/views/gantt/TimelineConfig.ts
@@ -12,7 +12,8 @@ export const DAY_WIDTH: Record<GanttGranularity, number> = {
   day: 44,
   week: 22,
   month: 9,
-  quarter: 5
+  quarter: 5,
+  year: 2
 }
 
 export interface TimelineCfg {
@@ -28,7 +29,8 @@ const MIN_DAYS: Record<GanttGranularity, number> = {
   day: 30,
   week: 90,
   month: 365,
-  quarter: 365
+  quarter: 365,
+  year: 1095
 }
 
 export function buildTimelineConfig(tasks: Task[], granularity: GanttGranularity): TimelineCfg {
@@ -58,7 +60,7 @@ export function buildTimelineConfig(tasks: Task[], granularity: GanttGranularity
     endDate = endDate.add({ days: extra })
   }
 
-  if (granularity === 'week' || granularity === 'month' || granularity === 'quarter') {
+  if (granularity !== 'day') {
     startDate = startDate.with({ day: 1 })
   }
 
@@ -84,7 +86,7 @@ export function xToDate(cfg: TimelineCfg, x: number): Temporal.PlainDate {
 
 /**
  * Snap-point X positions. day: every day border. week: Monday and Thursday.
- * month: 1st, ~8th, ~15th, ~22nd. quarter: the 1st of each month.
+ * month: 1st, ~8th, ~15th, ~22nd. quarter and year: the 1st of each month.
  */
 export function getSnapPoints(cfg: TimelineCfg): number[] {
   const points: number[] = []
@@ -101,8 +103,8 @@ export function getSnapPoints(cfg: TimelineCfg): number[] {
       if (d.dayOfWeek === 1 || d.dayOfWeek === 4) points.push(x)
     } else if (granularity === 'month') {
       if (d.day === 1 || d.day === 8 || d.day === 15 || d.day === 22) points.push(x)
-    } else if (granularity === 'quarter') {
-      if (d.day === 1) points.push(x)
+    } else if (d.day === 1) {
+      points.push(x)
     }
   }
   return points


### PR DESCRIPTION
The timeline has a year level after quarter: year bands above quarter labels, grid lines on quarter starts, about three years in view at once.

Closes #50, closes #77, closes #147