### PR TITLE
widen the collapse toggle click zone in projects view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The timeline has a year zoom level, showing quarters under each year ([#50](https://github.com/StepanKropachev/obsidian-pm/issues/50), [#77](https://github.com/StepanKropachev/obsidian-pm/issues/77), [#147](https://github.com/StepanKropachev/obsidian-pm/issues/147))
 
+### Fixed
+
+- The expand/collapse triangle was hard to click in the table, project list and Gantt views ([#266](https://github.com/dotpm/obsidian-pm/pull/266))
+
 ## [2.1.0] - 2026-08-27
 
 ### Highlights

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -92,7 +92,7 @@ Horizontal progress track with optional percent label.
 Obsidian-native collapse triangle for tree rows.
 
 - API: `new CollapseToggle(parent, { collapsed, onToggle, subject? })` (constructor-only); `subject` names what collapses in the aria label, defaulting to subtasks
-- CSS: `tree-item-icon collapse-icon pm-collapse-toggle`, `is-collapsed`
+- CSS: `tree-item-icon collapse-icon pm-collapse-toggle`, `is-collapsed`. A 28px square click target around a 14px icon; hover only recolors, like Obsidian's own collapse icon
 - Use when: expanding/collapsing subtask trees, or sub-projects in the project list
 
 ### Checkbox - `Checkbox.ts`

--- a/src/styles/gantt.css
+++ b/src/styles/gantt.css
@@ -71,7 +71,7 @@
 }
 
 .pm-gantt-label-spacer {
-  width: 16px;
+  width: 28px;
   flex-shrink: 0;
 }
 

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -226,6 +226,7 @@ button.pm-chip-btn--active:hover {
 }
 
 .pm-collapse-toggle {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -233,6 +234,12 @@ button.pm-chip-btn--active:hover {
   color: var(--text-muted);
   flex-shrink: 0;
   --icon-size: 14px;
+}
+/* Widen the hit zone past the small icon without changing how the row lays out. */
+.pm-collapse-toggle::after {
+  content: '';
+  position: absolute;
+  inset: -6px -8px;
 }
 .pm-collapse-toggle:hover {
   color: var(--text-normal);

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -226,20 +226,15 @@ button.pm-chip-btn--active:hover {
 }
 
 .pm-collapse-toggle {
-  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 28px;
+  height: 28px;
   cursor: pointer;
   color: var(--text-muted);
   flex-shrink: 0;
   --icon-size: 14px;
-}
-/* Widen the hit zone past the small icon without changing how the row lays out. */
-.pm-collapse-toggle::after {
-  content: '';
-  position: absolute;
-  inset: -6px -8px;
 }
 .pm-collapse-toggle:hover {
   color: var(--text-normal);


### PR DESCRIPTION
The 14px arrow was hard to hit. An overlay pseudo-element grows the target to roughly 30x26px, which stays inside the expand cell and the row height so nothing shifts and no neighbouring control loses clicks.

Before:

<img width="299" height="258" alt="Obsidian_g1nT6Q8qQA" src="https://github.com/user-attachments/assets/b4f57e05-c5d4-447a-910f-7544c3d88ac9" />

After:

<img width="313" height="320" alt="Obsidian_qMzo9I83ht" src="https://github.com/user-attachments/assets/fe5611bc-4d3b-4ad5-9ce8-620833dc35cd" />
