### PR TITLE
link the overview title to the tasks

### DIFF
--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -79,11 +79,17 @@
 }
 
 .pm-overview-title {
+  display: inline-block;
+  max-width: 100%;
   font-size: 20px;
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  cursor: pointer;
+}
+.pm-overview-title:hover {
+  color: var(--text-accent);
 }
 
 .pm-overview-subline {

--- a/src/views/ProjectOverviewView.ts
+++ b/src/views/ProjectOverviewView.ts
@@ -153,7 +153,11 @@ export class ProjectOverviewView extends ItemView {
     renderGlyph(tile, { icon: project.icon, color: project.color })
 
     const identity = header.createDiv('pm-overview-identity')
-    identity.createDiv({ cls: 'pm-overview-title', text: project.title })
+    const title = identity.createDiv({ cls: 'pm-overview-title', text: project.title })
+    title.addEventListener(
+      'click',
+      safeAsync(() => this.plugin.router.openScope({ kind: 'project', path: project.filePath }, this.leaf))
+    )
     const children = this.plugin.index.childRefs(project.filePath).length
     const bits = [`${rollup.done} of ${rollup.total} tasks done`]
     if (children) bits.push(children === 1 ? '1 sub-project' : `${children} sub-projects`)
@@ -162,11 +166,8 @@ export class ProjectOverviewView extends ItemView {
 
     new ButtonComponent(header)
       .setButtonText('Edit project')
-      .onClick(safeAsync(() => this.plugin.router.openProjectEdit(project.filePath, this.leaf)))
-    new ButtonComponent(header)
-      .setButtonText('Open tasks')
       .setCta()
-      .onClick(safeAsync(() => this.plugin.router.openScope({ kind: 'project', path: project.filePath }, this.leaf)))
+      .onClick(safeAsync(() => this.plugin.router.openProjectEdit(project.filePath, this.leaf)))
   }
 
   private section(parent: HTMLElement, title: string, note = ''): HTMLElement {


### PR DESCRIPTION
The overview header carried two buttons where one action mattered: "Open tasks" as the CTA and a plain "Edit project" beside it. Move opening the tasks onto the title itself, drop the button, and let editing take the accent.

Before:
<img width="1239" height="323" alt="image" src="https://github.com/user-attachments/assets/e0712f03-b0a7-4671-874d-5df4775a9fb3" />

After:
<img width="1235" height="255" alt="image" src="https://github.com/user-attachments/assets/fb039716-a895-4e71-895b-17fc3f10292a" />

