### PR TITLE
point the manifest, readme and pr template at the dotpm org

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Before you submit
 
-This plugin is maintained by one person in their spare time with a specific design vision and strict code standards. Please read this before opening a PR.
+This plugin is maintained in spare time with a specific design vision and strict code standards. Please read this before opening a PR.
 
 **PRs without a linked issue are closed without review.** New features and non-trivial changes must be discussed in an issue first — no exceptions.
 
@@ -19,8 +19,8 @@ Fixes #<!-- Issue number — required -->
 ## Checklist
 
 - [ ] I discussed this change in an issue and got a thumbs-up before writing code.
-- [ ] `npm run build` passes with zero errors.
-- [ ] `npx eslint src/` passes with zero warnings — includes no inline styles, sentence-case UI text, no unnecessary non-null assertions.
+- [ ] `pnpm build` passes with zero errors.
+- [ ] `pnpm check` passes with zero warnings — includes no inline styles, sentence-case UI text, no unnecessary non-null assertions.
 - [ ] New UI follows the Quiet Architect design system (no emojis, no hard corners, no 1px dividers, no pure black text, depth via tonal stacking).
 - [ ] New modals are created through `ModalFactory`, never instantiated directly.
 - [ ] No `element.style.*` assignments — CSS classes only.

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
 node_modules/
 main.js
 styles.css
-.claude/
-preview/
-CLAUDE.md
-DESIGN.md

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Stepan
+Copyright (c) 2026 Stepan Kropachev and dotpm contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 *Full-featured project management, natively in your vault.*
 
 [![Obsidian community plugin](https://img.shields.io/badge/Obsidian-Community%20Plugin-7c3aed?style=for-the-badge&logo=obsidian&logoColor=white)](https://community.obsidian.md/plugins/project-manager)
-[![Downloads](https://img.shields.io/github/downloads/StepanKropachev/obsidian-pm/total?style=for-the-badge&color=2ea44f)](https://github.com/StepanKropachev/obsidian-pm/releases)
-[![Stars](https://img.shields.io/github/stars/StepanKropachev/obsidian-pm?style=for-the-badge&color=007acc)](https://github.com/StepanKropachev/obsidian-pm/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/dotpm/obsidian-pm/total?style=for-the-badge&color=2ea44f)](https://github.com/dotpm/obsidian-pm/releases)
+[![Stars](https://img.shields.io/github/stars/dotpm/obsidian-pm?style=for-the-badge&color=007acc)](https://github.com/dotpm/obsidian-pm/stargazers)
 [![Support](https://img.shields.io/badge/Donate-Buy%20Me%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)](https://www.buymeacoffee.com/kropachev)
 
-**[Install from Obsidian](https://community.obsidian.md/plugins/project-manager)** · **[Website](https://stepankropachev.github.io/obsidian-pm-site/)** · **[Changelog](CHANGELOG.md)**
+**[Install from Obsidian](https://community.obsidian.md/plugins/project-manager)** · **[Website](https://dotpm.pm)** · **[Changelog](CHANGELOG.md)**
 
 </div>
 
@@ -187,7 +187,7 @@ Or open the listing directly: [community.obsidian.md/plugins/project-manager](ht
 
 1. Install the [BRAT plugin](https://github.com/TfTHacker/obsidian42-brat) from the community store.
 2. Open BRAT settings > **Add Beta Plugin**.
-3. Enter: `https://github.com/StepanKropachev/obsidian-pm`
+3. Enter: `https://github.com/dotpm/obsidian-pm`
 4. Enable the plugin in **Settings > Community plugins**.
 
 ### Manual

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "2.1.0",
   "minAppVersion": "1.13.0",
   "description": "Full-featured project management: stunning Gantt charts, Kanban boards, Table views, customizable fields, due date notifications.",
-  "author": "Stepan Kropachev",
-  "authorUrl": "https://github.com/StepanKropachev",
+  "author": "dotpm",
+  "authorUrl": "https://dotpm.pm",
   "isDesktopOnly": false
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "project-manager",
   "version": "2.1.0",
   "description": "Obsidian Project Manager Plugin",
+  "repository": "github:dotpm/obsidian-pm",
   "main": "main.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
The repository moved to github.com/dotpm/obsidian-pm. The manifest author, the README badges and install links, the website link, and the license now name the org and dotpm.pm; the old owner URLs keep working through GitHub's redirect. The PR template's checklist commands are updated to the pnpm scripts the repo actually uses.