### PR TITLE
rename the plugin to dotpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The timeline has a year zoom level, showing quarters under each year ([#50](https://github.com/StepanKropachev/obsidian-pm/issues/50), [#77](https://github.com/StepanKropachev/obsidian-pm/issues/77), [#147](https://github.com/StepanKropachev/obsidian-pm/issues/147))
 
+### Changed
+
+- The plugin is now called dotpm, matching the [dotpm](https://dotpm.pm) organization the repository moved to ([#269](https://github.com/dotpm/obsidian-pm/issues/269)). Commands are listed under **dotpm** in the Command Palette instead of **Project Manager**. Existing hotkeys, settings, and task files are unaffected, and updates continue as before.
+
 ## [2.1.0] - 2026-08-27
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# Project Manager for Obsidian
+# dotpm for Obsidian
 *Full-featured project management, natively in your vault.*
 
 [![Obsidian community plugin](https://img.shields.io/badge/Obsidian-Community%20Plugin-7c3aed?style=for-the-badge&logo=obsidian&logoColor=white)](https://community.obsidian.md/plugins/project-manager)
@@ -14,7 +14,7 @@
 
 Table views, Gantt charts, Kanban boards, custom fields, time tracking, smart scheduling — all stored as plain Markdown with YAML frontmatter. No external services. No sync subscriptions. Your data stays yours.
 
-<img width="1422" height="791" alt="Project Manager dashboard" src="https://github.com/user-attachments/assets/ca6bc67f-e656-45be-b93a-17410555ec1a" />
+<img width="1422" height="791" alt="dotpm dashboard" src="https://github.com/user-attachments/assets/ca6bc67f-e656-45be-b93a-17410555ec1a" />
 
 ## What's inside
 
@@ -50,7 +50,7 @@ Card-based board grouped by status. Drag cards between columns to update status 
 - **Subtasks** — Nest tasks to any depth. Collapse/expand hierarchies across all views.
 - **Dependencies** — Link blocking/dependent tasks. Visualized as arrows on the Gantt chart.
 - **Milestones** — Zero-duration tasks for key dates and deliverables.
-- **Archive** — Archive completed tasks without deleting. Toggle visibility at any time. Completed tasks can also be archived automatically once they have been done for a set number of days, or on demand with **Project Manager: Archive completed tasks**.
+- **Archive** — Archive completed tasks without deleting. Toggle visibility at any time. Completed tasks can also be archived automatically once they have been done for a set number of days, or on demand with **dotpm: Archive completed tasks**.
 
 ### Scheduling & time
 - **Drag-and-drop scheduling** — Reschedule tasks by dragging bars on the Gantt chart.
@@ -75,7 +75,7 @@ Card-based board grouped by status. Drag cards between columns to update status 
   - Delete
 
 ### Import
-You can add any existing note from your vault to project as a task. Run **Project Manager: Import notes as tasks** in the Command Palette, pick a project, select files, then choose default status, default priority, and whether to **move** files into the task folder or **copy** them. Already-imported notes are skipped.
+You can add any existing note from your vault to project as a task. Run **dotpm: Import notes as tasks** in the Command Palette, pick a project, select files, then choose default status, default priority, and whether to **move** files into the task folder or **copy** them. Already-imported notes are skipped.
 
 https://github.com/user-attachments/assets/64e386c5-09b5-42a6-9599-089cc54c98eb
 
@@ -102,7 +102,7 @@ There is no real-time multi-user editing. Two people editing the same task at on
 
 ## Using with TaskNotes
 
-Project Manager works alongside the [TaskNotes](https://github.com/callumalpass/tasknotes) plugin (4.10 or newer).
+dotpm works alongside the [TaskNotes](https://github.com/callumalpass/tasknotes) plugin (4.10 or newer).
 
 ### Import TaskNotes tasks
 
@@ -118,17 +118,17 @@ Choose **move** to turn the TaskNotes notes into task files inside the project's
 
 ### Align statuses and priorities
 
-**Settings > Import from TaskNotes** copies TaskNotes' status and priority palettes into Project Manager, so both plugins use the same values, names, and colors. Entries TaskNotes doesn't know are kept.
+**Settings > Import from TaskNotes** copies TaskNotes' status and priority palettes into dotpm, so both plugins use the same values, names, and colors. Entries TaskNotes doesn't know are kept.
 
-### Let TaskNotes see Project Manager tasks
+### Let TaskNotes see dotpm tasks
 
-TaskNotes can be configured to list and edit Project Manager tasks in place, without conversion:
+TaskNotes can be configured to list and edit dotpm tasks in place, without conversion:
 
 1. In TaskNotes settings, set task identification to **property** with name `pm-task` and value `true`.
 2. In its field mapping, map **scheduled** to `start`.
-3. Add your Project Manager status and priority values to TaskNotes' palettes.
+3. Add your dotpm status and priority values to TaskNotes' palettes.
 
-Task hierarchy and dependencies don't resolve on the TaskNotes side (it uses project links and `blockedBy`, Project Manager uses id references), but both plugins edit frontmatter non-destructively, so each one's extra fields survive the other's writes.
+Task hierarchy and dependencies don't resolve on the TaskNotes side (it uses project links and `blockedBy`, dotpm uses id references), but both plugins edit frontmatter non-destructively, so each one's extra fields survive the other's writes.
 
 ## Settings
 
@@ -178,7 +178,7 @@ Each task is a `.md` file in your vault supporting:
 ### From Obsidian (recommended)
 
 1. Open **Settings > Community plugins** and make sure Restricted mode is off.
-2. Click **Browse**, search for **Project Manager**, and click **Install**.
+2. Click **Browse**, search for **dotpm**, and click **Install**.
 3. Click **Enable**.
 
 Or open the listing directly: [community.obsidian.md/plugins/project-manager](https://community.obsidian.md/plugins/project-manager).

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "project-manager",
-  "name": "Project Manager",
+  "name": "dotpm",
   "version": "2.1.0",
   "minAppVersion": "1.13.0",
   "description": "Full-featured project management: stunning Gantt charts, Kanban boards, Table views, customizable fields, due date notifications.",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "project-manager",
   "version": "2.1.0",
-  "description": "Obsidian Project Manager Plugin",
+  "description": "dotpm — project management for Obsidian",
   "repository": "github:dotpm/obsidian-pm",
   "main": "main.js",
   "type": "module",

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -25,12 +25,12 @@ export async function migrateProjects(plugin: PMPlugin): Promise<void> {
       migrated++
     } catch (e) {
       console.error(`[PM] Migration failed for ${file.path}:`, e)
-      new Notice(`Project Manager: Migration failed for "${file.basename}". Check console for details.`)
+      new Notice(`dotpm: Migration failed for "${file.basename}". Check console for details.`)
     }
   }
 
   if (migrated > 0) {
-    new Notice(`Project Manager: Migrated ${migrated} project(s) to new format.`)
+    new Notice(`dotpm: Migrated ${migrated} project(s) to new format.`)
   }
 }
 
@@ -69,7 +69,7 @@ export async function migrateProjectLayout(plugin: PMPlugin): Promise<void> {
       })
     } catch (e) {
       console.error(`[PM] Failed to move "${path}" into its own folder:`, e)
-      new Notice(`Project Manager: Could not move "${path}" into its own folder. Check console for details.`)
+      new Notice(`dotpm: Could not move "${path}" into its own folder. Check console for details.`)
     }
   }
 
@@ -84,7 +84,7 @@ export async function migrateProjectLayout(plugin: PMPlugin): Promise<void> {
   remapProjectSettings(plugin, moves)
   retargetOpenViews(plugin, moves)
   await plugin.saveSettings()
-  new Notice(`Project Manager: Moved ${moves.length} project(s) into their own folders.`)
+  new Notice(`dotpm: Moved ${moves.length} project(s) into their own folders.`)
 }
 
 function movedPath(path: string, moves: ProjectMove[]): string | null {

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -401,7 +401,7 @@ export class ProjectStore implements TaskSource {
       return project
     } catch (e) {
       console.error(`[PM] Failed to load project ${file.path}:`, e)
-      new Notice(`Project Manager: Failed to load "${file.basename}". Check console for details.`)
+      new Notice(`dotpm: Failed to load "${file.basename}". Check console for details.`)
       return null
     }
   }
@@ -509,7 +509,7 @@ export class ProjectStore implements TaskSource {
         console.warn(`[PM] Task file no longer exists, skipping: ${file.path}`)
       } else {
         console.error(`[PM] Failed to load task ${file.path}:`, e)
-        new Notice(`Project Manager: Failed to load task "${file.basename}". Check console for details.`)
+        new Notice(`dotpm: Failed to load task "${file.basename}". Check console for details.`)
       }
       return { task: null, subtaskIds: [], parentId: null }
     }
@@ -630,7 +630,7 @@ export class ProjectStore implements TaskSource {
       for (const [id, kind] of dirty) this.markDirty(project, [id], kind)
       if (e instanceof TaskFileNameConflictError) throw e
       console.error(`[PM] Failed to save project "${project.title}":`, e)
-      new Notice(`Project Manager: Failed to save "${project.title}". Check console for details.`)
+      new Notice(`dotpm: Failed to save "${project.title}". Check console for details.`)
       throw e
     }
   }


### PR DESCRIPTION
Renames the plugin's display name from "Project Manager" to "dotpm" so the community directory, the site at dotpm.pm and the repository all use one name. Follows the move announced in #269.

The manifest id stays `project-manager`. The download count, the directory page, the plugin folder in every vault, the update path and the command ids are all keyed to the id, so nothing changes for existing installs. Users will notice commands listed under "dotpm" in the command palette instead of "Project Manager", and the plugin moves in the installed list.

Changes:

- `manifest.json`: name is "dotpm"
- `src/migration.ts`, `src/store/ProjectStore.ts`: the "Project Manager:" notice prefixes read "dotpm:"
- `README.md`: heading, image alt, command references, TaskNotes section and install step
- `package.json`: description
- `CHANGELOG.md`: entry under Unreleased

Follow-up after merge: bump `manifest.json`, `versions.json` and `package.json` and push the semver tag. The directory reads the name from the released manifest, so no change to obsidian-releases is needed.
