### PR TITLE
repair duplicated ids and add a duplicate project command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The timeline has a year zoom level, showing quarters under each year ([#50](https://github.com/StepanKropachev/obsidian-pm/issues/50), [#77](https://github.com/StepanKropachev/obsidian-pm/issues/77), [#147](https://github.com/StepanKropachev/obsidian-pm/issues/147))
 
+### Fixed
+
+- Edits, dependency checks, and archiving could act on the wrong project when one project was created by copying another's folder
+
 ## [2.1.0] - 2026-08-27
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The timeline has a year zoom level, showing quarters under each year ([#50](https://github.com/StepanKropachev/obsidian-pm/issues/50), [#77](https://github.com/StepanKropachev/obsidian-pm/issues/77), [#147](https://github.com/StepanKropachev/obsidian-pm/issues/147))
+- A project can be duplicated with all its tasks, from the project list's context menu or the duplicate project command
 
 ### Fixed
 

--- a/src/components/IdRepair.test.ts
+++ b/src/components/IdRepair.test.ts
@@ -1,0 +1,183 @@
+import type { App } from 'obsidian'
+import { TFile } from 'obsidian'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { makeFakeApp, type FakeVault } from '../../test/fakeVault'
+import type PMPlugin from '../main'
+import { ProjectStore, VaultIndex } from '../store'
+import type { ProjectRef, TaskRef } from '../store'
+import { DEFAULT_SETTINGS, type PMSettings } from '../types'
+import { IdRepair, planIdRepairs } from './IdRepair'
+
+const expectDefined = <T>(value: T | null | undefined, message = 'expected value to be defined'): T => {
+  if (value == null) throw new Error(message)
+  return value
+}
+
+function taskRef(id: string, projectPath: string): TaskRef {
+  return {
+    id,
+    path: `${projectPath.replace(/\.md$/, '')}_tasks/${id}.md`,
+    projectId: '',
+    projectPath,
+    title: id,
+    status: 'todo',
+    priority: 'medium',
+    start: '',
+    due: '',
+    completed: '',
+    dependencies: [],
+    assignees: [],
+    archived: false
+  }
+}
+
+function projectRef(id: string, path: string): ProjectRef {
+  return {
+    path,
+    id,
+    title: id,
+    icon: '',
+    color: '',
+    teamMembers: [],
+    customFields: [],
+    parentPath: undefined,
+    ownStatusIds: null,
+    completeStatusIds: null,
+    autoArchiveDays: null
+  }
+}
+
+describe('planIdRepairs', () => {
+  it('keeps ids in the project whose note is oldest and reassigns the rest', () => {
+    const collisions = new Map([['t1', [taskRef('t1', 'A.md'), taskRef('t1', 'B.md')]]])
+    const ctimes: Record<string, number> = { 'A.md': 100, 'B.md': 200 }
+
+    const plans = planIdRepairs(collisions, new Map(), (path) => ctimes[path])
+
+    expect(plans).toEqual([{ projectPath: 'B.md', taskIds: ['t1'], newProjectId: false }])
+  })
+
+  it('breaks a creation-time tie by path', () => {
+    const collisions = new Map([['t1', [taskRef('t1', 'B.md'), taskRef('t1', 'A.md')]]])
+
+    const plans = planIdRepairs(collisions, new Map(), () => 100)
+
+    expect(plans).toEqual([{ projectPath: 'B.md', taskIds: ['t1'], newProjectId: false }])
+  })
+
+  it('waits on a group whose note files are not all readable yet', () => {
+    const collisions = new Map([['t1', [taskRef('t1', 'A.md'), taskRef('t1', 'B.md')]]])
+    const ctimes: Record<string, number | null> = { 'A.md': 100, 'B.md': null }
+
+    expect(planIdRepairs(collisions, new Map(), (path) => ctimes[path] ?? null)).toEqual([])
+  })
+
+  it('folds a project id collision into the same plan', () => {
+    const taskCollisions = new Map([['t1', [taskRef('t1', 'A.md'), taskRef('t1', 'B.md')]]])
+    const projectCollisions = new Map([['p1', [projectRef('p1', 'A.md'), projectRef('p1', 'B.md')]]])
+    const ctimes: Record<string, number> = { 'A.md': 100, 'B.md': 200 }
+
+    const plans = planIdRepairs(taskCollisions, projectCollisions, (path) => ctimes[path])
+
+    expect(plans).toEqual([{ projectPath: 'B.md', taskIds: ['t1'], newProjectId: true }])
+  })
+
+  it('plans a project id repair even when no task ids collide', () => {
+    const projectCollisions = new Map([['p1', [projectRef('p1', 'A.md'), projectRef('p1', 'B.md')]]])
+    const ctimes: Record<string, number> = { 'A.md': 100, 'B.md': 200 }
+
+    const plans = planIdRepairs(new Map(), projectCollisions, (path) => ctimes[path])
+
+    expect(plans).toEqual([{ projectPath: 'B.md', taskIds: [], newProjectId: true }])
+  })
+})
+
+describe('IdRepair sweep', () => {
+  let app: App
+  let vault: FakeVault
+  let index: VaultIndex
+  let store: ProjectStore
+  let notices: string[]
+  let repair: IdRepair
+
+  beforeEach(() => {
+    const fake = makeFakeApp({ liveMetadataCache: true })
+    vault = fake.vault
+    app = fake.app as unknown as App
+    const settings: PMSettings = structuredClone(DEFAULT_SETTINGS)
+    index = new VaultIndex(app, () => settings)
+    store = new ProjectStore(app, () => settings, index)
+    notices = []
+    const plugin = {
+      app,
+      index,
+      store,
+      showNotice: (msg: string) => notices.push(msg)
+    } as unknown as PMPlugin
+    repair = new IdRepair(plugin)
+  })
+
+  function projectNote(taskIds: string[]): string {
+    const ids = taskIds.map((id) => `"${id}"`).join(', ')
+    return `---\npm-project: true\nid: pjt1\ntitle: Template\ntaskIds: [${ids}]\n---\n\n# Template\n`
+  }
+
+  function taskNote(id: string, title: string, deps: string[]): string {
+    const list = deps.map((dep) => `"${dep}"`).join(', ')
+    return `---\npm-task: true\nid: ${id}\nprojectId: pjt1\ntitle: ${title}\nstatus: todo\ndependencies: [${list}]\n---\n`
+  }
+
+  async function createCopiedPair(): Promise<void> {
+    for (const folder of ['Template', 'Copy']) {
+      await vault.create(`Projects/${folder}/${folder}.md`, projectNote(['t1', 't2']))
+      await vault.create(`Projects/${folder}/_tasks/one.md`, taskNote('t1', 'One', []))
+      await vault.create(`Projects/${folder}/_tasks/two.md`, taskNote('t2', 'Two', ['t1']))
+    }
+    setCtime('Projects/Template/Template.md', 100)
+    setCtime('Projects/Copy/Copy.md', 200)
+  }
+
+  function setCtime(path: string, ctime: number): void {
+    const file = app.vault.getAbstractFileByPath(path)
+    if (!(file instanceof TFile)) throw new Error(`no file at ${path}`)
+    file.stat.ctime = ctime
+  }
+
+  it('gives the newer copy fresh ids and leaves the original alone', async () => {
+    await createCopiedPair()
+    index.build()
+    vault.resetCounts()
+
+    await repair.check()
+
+    expect(notices).toEqual(['Repaired duplicated ids in "Template" (copied project).'])
+    for (const path of vault.modifyCount.keys()) {
+      expect(path.startsWith('Projects/Copy/')).toBe(true)
+    }
+
+    const copy = expectDefined(await store.loadProjectByPath('Projects/Copy/Copy.md'))
+    expect(copy.id).not.toBe('pjt1')
+    const one = expectDefined(copy.tasks.find((t) => t.title === 'One'))
+    const two = expectDefined(copy.tasks.find((t) => t.title === 'Two'))
+    expect(one.id).not.toBe('t1')
+    expect(two.id).not.toBe('t2')
+    expect(two.dependencies).toEqual([one.id])
+
+    const template = expectDefined(await store.loadProjectByPath('Projects/Template/Template.md'))
+    expect(template.id).toBe('pjt1')
+    expect(template.tasks.map((t) => t.id).sort()).toEqual(['t1', 't2'])
+  })
+
+  it('finds nothing to do on a second pass', async () => {
+    await createCopiedPair()
+    index.build()
+
+    await repair.check()
+    index.build()
+    vault.resetCounts()
+    await repair.check()
+
+    expect(notices).toHaveLength(1)
+    expect(vault.modifyCount.size).toBe(0)
+  })
+})

--- a/src/components/IdRepair.ts
+++ b/src/components/IdRepair.ts
@@ -1,0 +1,127 @@
+import { TFile } from 'obsidian'
+import type PMPlugin from '../main'
+import type { ProjectRef, TaskRef } from '../store'
+import { safeAsync } from '../utils'
+
+const DEBOUNCE_MS = 5000
+
+export interface IdRepairPlan {
+  projectPath: string
+  taskIds: string[]
+  newProjectId: boolean
+}
+
+/**
+ * Which projects give up which duplicated ids. The project whose note file is oldest
+ * keeps its ids, so an existing dependency from elsewhere in the vault keeps pointing at
+ * the task it was created against; ties go to the lexically smaller path. A group whose
+ * note files can't all be found yet is left for a later pass, since a folder being copied
+ * in shows up file by file.
+ */
+export function planIdRepairs(
+  taskCollisions: Map<string, TaskRef[]>,
+  projectCollisions: Map<string, ProjectRef[]>,
+  noteCtime: (projectPath: string) => number | null
+): IdRepairPlan[] {
+  const keeperOf = (paths: string[]): string | null => {
+    let keeper: string | null = null
+    let keeperTime = Infinity
+    for (const path of new Set(paths)) {
+      const time = noteCtime(path)
+      if (time === null) return null
+      if (time < keeperTime || (time === keeperTime && keeper !== null && path < keeper)) {
+        keeper = path
+        keeperTime = time
+      }
+    }
+    return keeper
+  }
+
+  const taskIdsByProject = new Map<string, Set<string>>()
+  for (const [id, refs] of taskCollisions) {
+    const paths = refs.map((ref) => ref.projectPath).filter((path): path is string => path !== null)
+    const keeper = keeperOf(paths)
+    if (!keeper) continue
+    for (const path of paths) {
+      if (path === keeper) continue
+      const bucket = taskIdsByProject.get(path)
+      if (bucket) bucket.add(id)
+      else taskIdsByProject.set(path, new Set([id]))
+    }
+  }
+
+  const newProjectIds = new Set<string>()
+  for (const [, refs] of projectCollisions) {
+    const keeper = keeperOf(refs.map((ref) => ref.path))
+    if (!keeper) continue
+    for (const ref of refs) {
+      if (ref.path !== keeper) newProjectIds.add(ref.path)
+    }
+  }
+
+  const plans = new Map<string, IdRepairPlan>()
+  for (const [projectPath, ids] of taskIdsByProject) {
+    plans.set(projectPath, { projectPath, taskIds: [...ids], newProjectId: newProjectIds.has(projectPath) })
+  }
+  for (const projectPath of newProjectIds) {
+    if (!plans.has(projectPath)) plans.set(projectPath, { projectPath, taskIds: [], newProjectId: true })
+  }
+  return [...plans.values()]
+}
+
+/**
+ * Copying a project's folder on disk duplicates the project id and every task id in it,
+ * and everything resolved vault-wide by id then answers for the wrong copy: edits in a
+ * multi-project view, dependency lookups, cycle checks, archiving. This sweep watches the
+ * index, gives the newer copy fresh ids, and leaves the original as it was.
+ */
+export class IdRepair {
+  private timer: number | null = null
+  private running = false
+
+  constructor(private plugin: PMPlugin) {}
+
+  /** The first pass runs from the startup sweep; this catches copies made while the app is open. */
+  start(): void {
+    this.plugin.register(this.plugin.index.onChange(() => this.schedule()))
+    this.plugin.register(() => {
+      if (this.timer !== null) window.clearTimeout(this.timer)
+    })
+  }
+
+  private schedule(): void {
+    if (this.timer !== null) window.clearTimeout(this.timer)
+    this.timer = window.setTimeout(
+      safeAsync(() => {
+        this.timer = null
+        return this.check()
+      }),
+      DEBOUNCE_MS
+    )
+  }
+
+  async check(): Promise<void> {
+    if (this.running || !this.plugin.index.ready) return
+    this.running = true
+    try {
+      const plans = planIdRepairs(
+        this.plugin.index.findTaskIdCollisions(),
+        this.plugin.index.findProjectIdCollisions(),
+        (path) => this.noteCtime(path)
+      )
+      for (const plan of plans) {
+        const project = await this.plugin.store.loadProjectByPath(plan.projectPath)
+        if (!project) continue
+        await this.plugin.store.reassignIds(project, plan.taskIds, plan.newProjectId)
+        this.plugin.showNotice(`Repaired duplicated ids in "${project.title}" (copied project).`)
+      }
+    } finally {
+      this.running = false
+    }
+  }
+
+  private noteCtime(path: string): number | null {
+    const file = this.plugin.app.vault.getAbstractFileByPath(path)
+    return file instanceof TFile ? file.stat.ctime : null
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import {
 } from './ui/ModalFactory'
 import { Notifier } from './components/Notifier'
 import { AutoArchiver } from './components/AutoArchiver'
+import { IdRepair } from './components/IdRepair'
 import { migrateProjects, migrateProjectLayout } from './migration'
 import { dedupePeople, displayName, safeAsync } from './utils'
 
@@ -31,6 +32,7 @@ export default class PMPlugin extends Plugin {
   index!: VaultIndex
   notifier!: Notifier
   autoArchiver!: AutoArchiver
+  idRepair!: IdRepair
   router!: PMViewRouter
   /** Paths deliberately sent to the markdown editor, which the swap then leaves alone. */
   private markdownEscapes = new Set<string>()
@@ -72,6 +74,7 @@ export default class PMPlugin extends Plugin {
     this.store.registerVaultSync(this)
     this.notifier = new Notifier(this)
     this.autoArchiver = new AutoArchiver(this)
+    this.idRepair = new IdRepair(this)
     this.router = new PMViewRouter(this)
 
     this.registerView(PM_PROJECT_VIEW_TYPE, (leaf) => new ProjectView(leaf, this))
@@ -252,6 +255,7 @@ export default class PMPlugin extends Plugin {
     this.addSettingTab(new PMSettingTab(this.app, this))
     this.notifier.start()
     this.autoArchiver.start()
+    this.idRepair.start()
   }
 
   onunload(): void {
@@ -366,6 +370,7 @@ export default class PMPlugin extends Plugin {
   private async startupSweep(): Promise<void> {
     await migrateProjects(this)
     await migrateProjectLayout(this)
+    await this.idRepair.check()
     await this.cleanupStaleProjectFilters()
     this.notifier.check()
     await this.autoArchiver.check()

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,8 @@ import {
   openProjectPicker,
   openTaskPicker,
   openImportModal,
-  confirmDialog
+  confirmDialog,
+  promptText
 } from './ui/ModalFactory'
 import { Notifier } from './components/Notifier'
 import { AutoArchiver } from './components/AutoArchiver'
@@ -125,6 +126,17 @@ export default class PMPlugin extends Plugin {
       name: 'Create new subtask',
       callback: () => {
         this.pickProjectThenCreateTask('pick-parent')
+      }
+    })
+
+    this.addCommand({
+      id: 'duplicate-project',
+      name: 'Duplicate project',
+      callback: () => {
+        this.pickProject(
+          safeAsync((project) => this.duplicateProjectFlow(project)),
+          false
+        )
       }
     })
 
@@ -345,6 +357,20 @@ export default class PMPlugin extends Plugin {
     if (separator === -1) return true
     const path = key.slice(separator + 1)
     return path === '' || this.app.vault.getAbstractFileByPath(path) !== null
+  }
+
+  /** Prompts for a title, copies the project with fresh task ids, and opens the copy. */
+  async duplicateProjectFlow(source: Project): Promise<void> {
+    const title = await promptText(this.app, `Duplicate "${source.title}" as`, 'Project name', `${source.title} copy`)
+    if (!title) return
+    let copy: Project
+    try {
+      copy = await this.store.duplicateProject(source, title)
+    } catch (e) {
+      this.showNotice(e instanceof Error ? e.message : String(e))
+      return
+    }
+    await this.router.openProjectOverview(copy.filePath)
   }
 
   /** A project with no window of its own archives everything it has finished. */

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -1483,3 +1483,60 @@ describe('ProjectStore project folders', () => {
     expect(app.vault.getAbstractFileByPath('Work/Alpha_tasks/card.md')).toBeInstanceOf(TFile)
   })
 })
+
+describe('ProjectStore.reassignIds', () => {
+  it('gives listed tasks fresh ids and remaps internal dependencies, in memory and on disk', async () => {
+    const { store, app } = newStore()
+    const project = await store.createProject('Roadmap', 'Projects')
+    const alpha = await addNamed(store, project, 'Alpha')
+    const beta = await addNamed(store, project, 'Beta')
+    await store.updateTask(project, beta.id, { dependencies: [alpha.id] })
+    const oldAlphaId = alpha.id
+    const oldBetaId = beta.id
+
+    await store.reassignIds(project, [oldAlphaId, oldBetaId], false)
+
+    expect(findTask(project.tasks, oldAlphaId)).toBeNull()
+    expect(findTask(project.tasks, oldBetaId)).toBeNull()
+    const freshAlpha = expectDefined(project.tasks.find((t) => t.title === 'Alpha'))
+    const freshBeta = expectDefined(project.tasks.find((t) => t.title === 'Beta'))
+    expect(freshBeta.dependencies).toEqual([freshAlpha.id])
+    expect(expectDefined(project.taskIndex.get(freshAlpha.id)).task).toBe(freshAlpha)
+
+    const alphaContent = await app.vault.cachedRead(fileAt(app, expectDefined(freshAlpha.filePath)))
+    expect(alphaContent).toContain(freshAlpha.id)
+    expect(alphaContent).not.toContain(oldAlphaId)
+    const projectContent = await app.vault.cachedRead(fileAt(app, project.filePath))
+    expect(projectContent).toContain(freshAlpha.id)
+    expect(projectContent).not.toContain(oldAlphaId)
+  })
+
+  it('keeps a dependency on an id the project does not own', async () => {
+    const { store, vault } = newStore()
+    const project = await store.createProject('Roadmap', 'Projects')
+    const alpha = await addNamed(store, project, 'Alpha')
+    await store.updateTask(project, alpha.id, { dependencies: ['elsewhere1'] })
+
+    vault.resetCounts()
+    await store.reassignIds(project, ['elsewhere1'], false)
+
+    expect(expectDefined(findTask(project.tasks, alpha.id)).dependencies).toEqual(['elsewhere1'])
+    expect(vault.modifyCount.size).toBe(0)
+  })
+
+  it('writes a fresh project id into the project note and every task note', async () => {
+    const { store, app } = newStore()
+    const project = await store.createProject('Roadmap', 'Projects')
+    const alpha = await addNamed(store, project, 'Alpha')
+    const oldProjectId = project.id
+
+    await store.reassignIds(project, [], true)
+
+    expect(project.id).not.toBe(oldProjectId)
+    const projectContent = await app.vault.cachedRead(fileAt(app, project.filePath))
+    expect(projectContent).toContain(project.id)
+    const alphaContent = await app.vault.cachedRead(fileAt(app, expectDefined(alpha.filePath)))
+    expect(alphaContent).toContain(project.id)
+    expect(alphaContent).not.toContain(oldProjectId)
+  })
+})

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -1540,3 +1540,51 @@ describe('ProjectStore.reassignIds', () => {
     expect(alphaContent).not.toContain(oldProjectId)
   })
 })
+
+describe('ProjectStore.duplicateProject', () => {
+  it('clones every task with fresh ids and remaps dependencies between roots', async () => {
+    const { store, app } = newStore()
+    const source = await store.createProject('Roadmap', 'Projects')
+    const alpha = await addNamed(store, source, 'Alpha')
+    const beta = await addNamed(store, source, 'Beta')
+    await store.updateTask(source, beta.id, { dependencies: [alpha.id, 'elsewhere1'] })
+
+    const copy = await store.duplicateProject(source, 'Roadmap copy')
+
+    expect(copy.filePath).toBe('Projects/Roadmap copy/Roadmap copy.md')
+    expect(copy.id).not.toBe(source.id)
+    const copyAlpha = expectDefined(copy.tasks.find((t) => t.title === 'Alpha'))
+    const copyBeta = expectDefined(copy.tasks.find((t) => t.title === 'Beta'))
+    expect(copyAlpha.id).not.toBe(alpha.id)
+    expect(copyBeta.dependencies).toEqual([copyAlpha.id, 'elsewhere1'])
+    expect(fileAt(app, 'Projects/Roadmap copy/_tasks/alpha.md')).toBeInstanceOf(TFile)
+
+    expect(source.tasks.map((t) => t.id)).toEqual([alpha.id, beta.id])
+    expect(expectDefined(findTask(source.tasks, beta.id)).dependencies).toEqual([alpha.id, 'elsewhere1'])
+  })
+
+  it('carries the project settings, people, and descriptions over', async () => {
+    const { store, app } = newStore()
+    const source = await store.createProject('Roadmap', 'Projects')
+    source.teamMembers = ['Jane']
+    source.config = { defaultView: 'kanban' }
+    await store.updateProject(source, { description: 'The plan.' })
+    const alpha = await addNamed(store, source, 'Alpha')
+    await store.updateTask(source, alpha.id, { description: 'Alpha body.' })
+
+    const copy = await store.duplicateProject(source, 'Roadmap copy')
+
+    expect(copy.teamMembers).toEqual(['Jane'])
+    expect(copy.config).toEqual({ defaultView: 'kanban' })
+    expect(copy.description).toBe('The plan.')
+    const copyAlphaContent = await app.vault.cachedRead(fileAt(app, 'Projects/Roadmap copy/_tasks/alpha.md'))
+    expect(copyAlphaContent).toContain('Alpha body.')
+  })
+
+  it('refuses a title already taken beside the source', async () => {
+    const { store } = newStore()
+    const source = await store.createProject('Roadmap', 'Projects')
+
+    await expect(store.duplicateProject(source, 'Roadmap')).rejects.toThrow('already exists')
+  })
+})

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -18,6 +18,7 @@ import {
 } from './TaskIndex'
 import {
   addTaskToTree,
+  cloneTaskForest,
   cloneTaskSubtree,
   deleteTaskFromTree,
   flattenTasks,
@@ -935,6 +936,39 @@ export class ProjectStore implements TaskSource {
     if (parentId) this.markDirty(project, [parentId], 'full')
     await this.saveProject(project)
     return copy
+  }
+
+  /**
+   * A full copy of a project under a new title, created beside the source: every task
+   * cloned with a fresh id, dependencies inside the project remapped to the clones, and
+   * the description, palette, saved views, and settings carried over. A dependency on
+   * another project's task still targets that task.
+   */
+  async duplicateProject(source: Project, title: string): Promise<Project> {
+    const dir = folderOf(projectFolderOf(this.app, source.filePath) ?? source.filePath)
+    const filePath = projectFilePath(title, dir)
+    if (this.app.vault.getAbstractFileByPath(filePath) || this.app.vault.getAbstractFileByPath(folderOf(filePath))) {
+      throw new Error(`A project named "${title}" already exists here.`)
+    }
+
+    await this.loadProjectBody(source)
+    for (const { task } of flattenTasks(source.tasks)) await this.loadTaskBody(task)
+
+    const project = makeProject(title, filePath)
+    project.description = source.description
+    project.color = source.color
+    project.icon = source.icon
+    project.customFields = structuredClone(source.customFields)
+    project.teamMembers = [...source.teamMembers]
+    project.savedViews = structuredClone(source.savedViews)
+    project.parentPath = source.parentPath
+    if (source.config) project.config = structuredClone(source.config)
+    project.tasks = cloneTaskForest(source.tasks)
+    rebuildTaskIndex(project)
+    this.hydratedBodies.add(project)
+    for (const { task } of flattenTasks(project.tasks)) this.hydratedBodies.add(task)
+    await this.saveProject(project)
+    return project
   }
 
   async reassignIds(project: Project, taskIds: string[], newProjectId: boolean): Promise<void> {

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -1,7 +1,7 @@
 import type { Plugin, TAbstractFile } from 'obsidian'
 import { App, Notice, TFile, TFolder, normalizePath } from 'obsidian'
 import type { PMSettings, Project, ProjectPatch, ResolvedProjectConfig, StatusConfig, Task } from '../types'
-import { DEFAULT_SETTINGS, makeProject, makeTask } from '../types'
+import { DEFAULT_SETTINGS, makeId, makeProject, makeTask } from '../types'
 import { today } from '../dates'
 import { isTerminalStatus, sanitizeFileName } from '../utils'
 import { archiveTask as doArchiveTask, unarchiveTask as doUnarchiveTask } from './ArchiveOps'
@@ -935,6 +935,27 @@ export class ProjectStore implements TaskSource {
     if (parentId) this.markDirty(project, [parentId], 'full')
     await this.saveProject(project)
     return copy
+  }
+
+  async reassignIds(project: Project, taskIds: string[], newProjectId: boolean): Promise<void> {
+    const mapping = new Map<string, string>()
+    for (const id of taskIds) {
+      // Only ids the project owns: an id it doesn't could be an external dependency,
+      // and remapping that would point it at a task that doesn't exist.
+      if (project.taskIndex.has(id)) mapping.set(id, makeId())
+    }
+    if (mapping.size === 0 && !newProjectId) return
+    for (const { task } of flattenTasks(project.tasks)) {
+      const fresh = mapping.get(task.id)
+      if (fresh) task.id = fresh
+      if (task.dependencies.some((dep) => mapping.has(dep))) {
+        task.dependencies = task.dependencies.map((dep) => mapping.get(dep) ?? dep)
+      }
+    }
+    if (newProjectId) project.id = makeId()
+    rebuildTaskIndex(project)
+    this.markAllDirty(project, 'fm')
+    await this.saveProject(project)
   }
 
   private assignCopyName(task: Task, folder: string, usedTitles: Set<string>, claimed: Set<string>): void {

--- a/src/store/TaskSource.ts
+++ b/src/store/TaskSource.ts
@@ -59,6 +59,8 @@ export interface TaskSource {
    * copied on disk, which duplicates every id in it.
    */
   reassignIds(project: Project, taskIds: string[], newProjectId: boolean): Promise<void>
+  /** A full copy of a project under a new title, every task cloned with a fresh id. */
+  duplicateProject(source: Project, title: string): Promise<Project>
   importNoteAsTask(project: Project, file: TFile, opts: ImportNoteOptions): Promise<'imported' | 'skipped'>
   importTaskForest(
     project: Project,

--- a/src/store/TaskSource.ts
+++ b/src/store/TaskSource.ts
@@ -53,6 +53,12 @@ export interface TaskSource {
 
   insertTask(project: Project, task: Task, parentId?: string | null): Promise<void>
   duplicateTask(project: Project, sourceId: string, includeSubtasks: boolean): Promise<Task | null>
+  /**
+   * Gives the listed tasks fresh ids, remapping every reference the project holds to
+   * them, and optionally the project's own id. Repairs a project whose folder was
+   * copied on disk, which duplicates every id in it.
+   */
+  reassignIds(project: Project, taskIds: string[], newProjectId: boolean): Promise<void>
   importNoteAsTask(project: Project, file: TFile, opts: ImportNoteOptions): Promise<'imported' | 'skipped'>
   importTaskForest(
     project: Project,

--- a/src/store/TaskTreeOps.ts
+++ b/src/store/TaskTreeOps.ts
@@ -79,6 +79,18 @@ export function cloneTaskSubtree(source: Task, includeSubtasks: boolean): Task {
   return clone
 }
 
+/**
+ * Deep-clone a whole task forest with fresh ids, sharing one id map so a dependency
+ * between any two tasks in it is remapped, whichever roots they sit under. Dependencies
+ * pointing outside the forest still target the originals.
+ */
+export function cloneTaskForest(roots: Task[]): Task[] {
+  const idMap = new Map<string, string>()
+  const clones = roots.map((root) => cloneNode(root, true, idMap))
+  for (const clone of clones) remapDeps(clone, idMap)
+  return clones
+}
+
 function cloneNode(source: Task, includeSubtasks: boolean, idMap: Map<string, string>): Task {
   const now = new Date().toISOString()
   const newId = makeId()

--- a/src/store/VaultIndex.test.ts
+++ b/src/store/VaultIndex.test.ts
@@ -410,3 +410,51 @@ describe('VaultIndex people queries', () => {
     expect(index.allAssignees()).toHaveLength(3)
   })
 })
+
+describe('VaultIndex id collisions', () => {
+  let vault: FakeVault
+  let index: VaultIndex
+
+  beforeEach(() => {
+    const fake = makeFakeApp({ liveMetadataCache: true })
+    vault = fake.vault
+    index = new VaultIndex(fake.app as unknown as App, () => ({ ...DEFAULT_SETTINGS }))
+  })
+
+  it('reports task and project ids that two projects claim', async () => {
+    await vault.create('Projects/Template/Template.md', projectNote('p1', 'Template'))
+    await vault.create('Projects/Template/_tasks/one.md', taskNote('t1', 'One', 'p1'))
+    await vault.create('Projects/Copy/Copy.md', projectNote('p1', 'Template'))
+    await vault.create('Projects/Copy/_tasks/one.md', taskNote('t1', 'One', 'p1'))
+    index.build()
+
+    const tasks = index.findTaskIdCollisions()
+    expect([...tasks.keys()]).toEqual(['t1'])
+    expect(
+      expectDefined(tasks.get('t1'))
+        .map((ref) => ref.path)
+        .sort()
+    ).toEqual(['Projects/Copy/_tasks/one.md', 'Projects/Template/_tasks/one.md'])
+    expect([...index.findProjectIdCollisions().keys()]).toEqual(['p1'])
+  })
+
+  it('does not report an id repeated inside one project', async () => {
+    await vault.create('Projects/Roadmap/Roadmap.md', projectNote('p1', 'Roadmap'))
+    await vault.create('Projects/Roadmap/_tasks/one.md', taskNote('t1', 'One', 'p1'))
+    await vault.create('Projects/Roadmap/_tasks/Archive/one.md', taskNote('t1', 'One', 'p1'))
+    index.build()
+
+    expect(index.findTaskIdCollisions().size).toBe(0)
+  })
+
+  it('reports nothing when every id is unique', async () => {
+    await vault.create('Projects/A/A.md', projectNote('p1', 'A'))
+    await vault.create('Projects/A/_tasks/one.md', taskNote('t1', 'One', 'p1'))
+    await vault.create('Projects/B/B.md', projectNote('p2', 'B'))
+    await vault.create('Projects/B/_tasks/two.md', taskNote('t2', 'Two', 'p2'))
+    index.build()
+
+    expect(index.findTaskIdCollisions().size).toBe(0)
+    expect(index.findProjectIdCollisions().size).toBe(0)
+  })
+})

--- a/src/store/VaultIndex.ts
+++ b/src/store/VaultIndex.ts
@@ -363,6 +363,42 @@ export class VaultIndex {
     return map
   }
 
+  /**
+   * Task ids that notes in more than one project claim, id to every ref holding it.
+   * This is what a project folder copied on disk looks like: the copy keeps every id
+   * of the original. A repeated id inside one project doesn't count; an archived task
+   * and its replacement can share one legitimately.
+   */
+  findTaskIdCollisions(): Map<string, TaskRef[]> {
+    const byId = new Map<string, TaskRef[]>()
+    for (const ref of this.tasks.values()) {
+      if (!ref.projectPath) continue
+      const list = byId.get(ref.id)
+      if (list) list.push(ref)
+      else byId.set(ref.id, [ref])
+    }
+    const collisions = new Map<string, TaskRef[]>()
+    for (const [id, refs] of byId) {
+      if (new Set(refs.map((ref) => ref.projectPath)).size > 1) collisions.set(id, refs)
+    }
+    return collisions
+  }
+
+  /** Project ids more than one project note claims. */
+  findProjectIdCollisions(): Map<string, ProjectRef[]> {
+    const byId = new Map<string, ProjectRef[]>()
+    for (const ref of this.projects.values()) {
+      const list = byId.get(ref.id)
+      if (list) list.push(ref)
+      else byId.set(ref.id, [ref])
+    }
+    const collisions = new Map<string, ProjectRef[]>()
+    for (const [id, refs] of byId) {
+      if (refs.length > 1) collisions.set(id, refs)
+    }
+    return collisions
+  }
+
   /** The project owning a task note, by location first and by its `projectId` when it moved. */
   projectPathForTask(taskPath: string): string | null {
     return this.tasks.get(normalizePath(taskPath))?.projectPath ?? this.resolveOwner(normalizePath(taskPath), '')

--- a/src/ui/ModalFactory.ts
+++ b/src/ui/ModalFactory.ts
@@ -24,9 +24,9 @@ export function confirmDuplicateSubtasks(app: App, taskTitle: string): Promise<'
 }
 
 /** Returns the trimmed string, or null if cancelled or empty. */
-export function promptText(app: App, label: string, placeholder = ''): Promise<string | null> {
+export function promptText(app: App, label: string, placeholder = '', initial = ''): Promise<string | null> {
   return new Promise((resolve) => {
-    const modal = new TextPromptModal(app, label, placeholder, resolve)
+    const modal = new TextPromptModal(app, label, placeholder, initial, resolve)
     modal.open()
   })
 }
@@ -38,6 +38,7 @@ class TextPromptModal extends Modal {
     app: App,
     private label: string,
     private placeholder: string,
+    private initial: string,
     private resolve: (value: string | null) => void
   ) {
     super(app)
@@ -63,6 +64,7 @@ class TextPromptModal extends Modal {
       placeholder: this.placeholder,
       cls: 'pm-prompt-input'
     })
+    input.value = this.initial
 
     const btnRow = contentEl.createDiv('pm-modal-btn-row')
 
@@ -91,7 +93,10 @@ class TextPromptModal extends Modal {
       }
     })
 
-    window.setTimeout(() => input.focus(), 10)
+    window.setTimeout(() => {
+      input.focus()
+      if (this.initial) input.select()
+    }, 10)
   }
 
   onClose(): void {

--- a/src/views/ProjectListRenderer.ts
+++ b/src/views/ProjectListRenderer.ts
@@ -134,6 +134,18 @@ function openProjectContextMenu(ctx: ProjectListContext, ref: ProjectRef, e: Mou
   }
   menu.addItem((item) =>
     item
+      .setTitle('Duplicate project')
+      .setIcon('copy')
+      .onClick(
+        safeAsync(async () => {
+          const project = await ctx.plugin.store.loadProjectByPath(ref.path)
+          if (!project) return
+          await ctx.plugin.duplicateProjectFlow(project)
+        })
+      )
+  )
+  menu.addItem((item) =>
+    item
       .setTitle('Edit project')
       .setIcon('settings')
       .onClick(safeAsync(() => ctx.plugin.router.openProjectEdit(ref.path)))


### PR DESCRIPTION
Copying a project's folder on disk to reuse it as a starter duplicated the project id and every task id. Anything resolved vault-wide by id then acted on the wrong copy: a status change in a multi-project view wrote into the original project's files, cycle checks refused valid dependencies, and auto-archive held back tasks the copy appeared to depend on. A background sweep now detects duplicated ids and gives the newer copy fresh ones, keeping the original's ids so existing cross-project dependencies stay intact.

There is also a duplicate project command and project-list menu item that copies a project with fresh ids from the start.