### PR TITLE
keep the inline date input open while typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The expand/collapse triangle was hard to click in the table, project list and Gantt views ([#266](https://github.com/dotpm/obsidian-pm/pull/266))
+- A task's due date in the table kept only the first digit typed and closed before the rest could be entered
 
 ## [2.1.0] - 2026-08-27
 

--- a/src/ui/composites/cells/inlineEdit.ts
+++ b/src/ui/composites/cells/inlineEdit.ts
@@ -27,13 +27,23 @@ export function makeInlineEdit(opts: InlineEditOpts): void {
     }
   })
 
+  const cancel = (): void => {
+    if (saved) return
+    saved = true
+    input.replaceWith(display)
+  }
+
+  let typed = false
   input.addEventListener('blur', save)
-  if (inputType !== 'date') {
-    input.addEventListener('keydown', (ev) => {
-      if (ev.key === 'Enter') save()
-      if (ev.key === 'Escape') input.replaceWith(display)
+  input.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Enter') save()
+    else if (ev.key === 'Escape') cancel()
+    else typed = true
+  })
+
+  if (inputType === 'date') {
+    input.addEventListener('change', () => {
+      if (!typed) save()
     })
-  } else {
-    input.addEventListener('change', save)
   }
 }


### PR DESCRIPTION
Editing a task's due date in the table now stays open until you press Enter, click away, or pick from the calendar. Escape cancels.

Fixes #277 