### PR TITLE
make the editor save shortcut configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The shortcut that saves a task and creates a project can be changed between Shift+Enter and Ctrl/Cmd+Enter
+
+### Changed
+
+- The new project dialog creates the project with the save shortcut or its create button
+
+### Fixed
+
+- Undo while typing in a dialog reverted the last task change when a Gantt view was open
+
 ## [2.2.0] - 2026-09-06
 
 ### Added

--- a/src/modals/ProjectCreateModal.ts
+++ b/src/modals/ProjectCreateModal.ts
@@ -1,8 +1,8 @@
-import { App, ButtonComponent, ExtraButtonComponent, Modal, setIcon } from 'obsidian'
+import { App, ButtonComponent, ExtraButtonComponent, Keymap, Modal, setIcon } from 'obsidian'
 import type PMPlugin from '../main'
 import { DEFAULT_PROJECT_COLOR, DEFAULT_PROJECT_ICON } from '../types'
 import { folderOf, projectFilePath, projectFolderOf } from '../store'
-import { safeAsync } from '../utils'
+import { safeAsync, saveShortcutLabel } from '../utils'
 import { renderPersonPicker } from '../ui/PersonPicker'
 import { renderPropRow } from '../ui/FormField'
 import { renderIconControl, renderSelectControl } from '../ui/composites/properties'
@@ -62,20 +62,15 @@ export class ProjectCreateModal extends Modal {
 
     this.renderFooter(contentEl)
 
-    this.modalEl.addEventListener('keydown', this.handleKeyDown)
+    this.scope.register([this.plugin.settings.editorSaveModifier], 'Enter', () => {
+      this.create()
+      return false
+    })
     this.refreshValidity()
   }
 
   onClose(): void {
-    this.modalEl.removeEventListener('keydown', this.handleKeyDown)
     this.contentEl.empty()
-  }
-
-  private readonly handleKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === 'Enter' && e.shiftKey) {
-      e.preventDefault()
-      this.create()
-    }
   }
 
   private renderHeader(parent: HTMLElement): void {
@@ -118,10 +113,7 @@ export class ProjectCreateModal extends Modal {
       this.refreshValidity()
     })
     this.titleInput.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault()
-        this.create()
-      }
+      if (e.key === 'Enter' && !Keymap.isModifier(e, this.plugin.settings.editorSaveModifier)) e.preventDefault()
     })
     window.setTimeout(autosize, 0)
     this.titleInput.focus()
@@ -255,7 +247,7 @@ export class ProjectCreateModal extends Modal {
 
     new ButtonComponent(footer).setButtonText('Cancel').onClick(() => this.close())
     this.submit = new ButtonComponent(footer)
-      .setButtonText('Create project (Shift+Enter)')
+      .setButtonText(`Create project (${saveShortcutLabel(this.plugin.settings.editorSaveModifier)})`)
       .setCta()
       .onClick(() => this.create())
   }

--- a/src/modals/TaskEditor.ts
+++ b/src/modals/TaskEditor.ts
@@ -4,9 +4,11 @@ import {
   Component,
   ExtraButtonComponent,
   Keymap,
+  type KeymapEventHandler,
   Menu,
   MarkdownRenderer,
   Notice,
+  type Scope,
   setIcon,
   setTooltip
 } from 'obsidian'
@@ -14,7 +16,7 @@ import type PMPlugin from '../main'
 import { type Project, type Task, makeTask } from '../types'
 import { flattenTasks } from '../store/TaskTreeOps'
 import { TaskFileNameConflictError } from '../store'
-import { safeAsync, getDefaultStatusId, getDefaultPriorityId, getPriorityConfig } from '../utils'
+import { safeAsync, getDefaultStatusId, getDefaultPriorityId, getPriorityConfig, saveShortcutLabel } from '../utils'
 import { confirmDialog, openTaskByPath } from '../ui/ModalFactory'
 import { renderGlyph } from '../ui/composites/properties'
 import { renderTaskFormFields } from './TaskFormFields'
@@ -27,8 +29,8 @@ export interface TaskEditorHost {
   surface: 'modal' | 'tab'
   /** Dismiss the surface. */
   close: () => void
-  /** Element the Shift+Enter shortcut is bound to. */
-  keyScopeEl: HTMLElement
+  /** Keymap scope the save shortcut is registered on. */
+  scope: Scope
 }
 
 export class TaskEditor {
@@ -42,7 +44,7 @@ export class TaskEditor {
   private persistPromise: Promise<void> | null = null
   private noteSuggest: NoteLinkSuggest | null = null
   private shownExtras = new Set<string>()
-  private saveKeyHandler: ((e: KeyboardEvent) => void) | null = null
+  private saveKeyHandler: KeymapEventHandler | null = null
   private containerEl: HTMLElement | null = null
 
   constructor(
@@ -102,7 +104,7 @@ export class TaskEditor {
       }
     }
     if (this.saveKeyHandler) {
-      this.host.keyScopeEl.removeEventListener('keydown', this.saveKeyHandler)
+      this.host.scope.unregister(this.saveKeyHandler)
       this.saveKeyHandler = null
     }
     this.noteSuggest?.destroy()
@@ -349,7 +351,7 @@ export class TaskEditor {
       autosizeTitle()
     })
     titleInput.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && !e.shiftKey) e.preventDefault()
+      if (e.key === 'Enter' && !Keymap.isModifier(e, this.plugin.settings.editorSaveModifier)) e.preventDefault()
     })
     window.setTimeout(autosizeTitle, 0)
     titleInput.focus()
@@ -602,8 +604,9 @@ export class TaskEditor {
       this.host.close()
     })
 
+    const modifier = this.plugin.settings.editorSaveModifier
     const saveBtn = new ButtonComponent(footer)
-      .setButtonText(this.isNew ? 'Create (Shift+Enter)' : 'Save (Shift+Enter)')
+      .setButtonText(`${this.isNew ? 'Create' : 'Save'} (${saveShortcutLabel(modifier)})`)
       .setCta()
     let saving = false
     const doSave = async () => {
@@ -635,13 +638,10 @@ export class TaskEditor {
       void doSave()
     })
 
-    if (this.saveKeyHandler) this.host.keyScopeEl.removeEventListener('keydown', this.saveKeyHandler)
-    this.saveKeyHandler = (e: KeyboardEvent) => {
-      if (e.key === 'Enter' && e.shiftKey) {
-        e.preventDefault()
-        void doSave()
-      }
-    }
-    this.host.keyScopeEl.addEventListener('keydown', this.saveKeyHandler)
+    if (this.saveKeyHandler) this.host.scope.unregister(this.saveKeyHandler)
+    this.saveKeyHandler = this.host.scope.register([modifier], 'Enter', () => {
+      void doSave()
+      return false
+    })
   }
 }

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -23,7 +23,7 @@ export class TaskModal extends Modal {
       task,
       parentId,
       onSave,
-      { surface: 'modal', close: () => this.close(), keyScopeEl: this.modalEl },
+      { surface: 'modal', close: () => this.close(), scope: this.scope },
       defaults
     )
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ import type { SettingDefinitionItem, SettingDefinitionPage } from 'obsidian'
 import type PMPlugin from './main'
 import { type PMSettings, DEFAULT_SETTINGS, PRIORITY_ICON_SET_LABELS, makeId } from './types'
 import { flattenTasks } from './store/TaskTreeOps'
+import { saveShortcutLabel } from './utils'
 import {
   countTaskNotesPaletteChanges,
   getTaskNotesApi,
@@ -83,6 +84,16 @@ export class PMSettingTab extends PluginSettingTab {
             name: 'Save tasks on close',
             desc: 'Save changes when the task editor is closed.',
             control: { type: 'toggle', key: 'saveTaskOnClose' }
+          },
+          {
+            name: 'Save shortcut',
+            desc: 'Key shortcut to create or save tasks and projects.',
+            aliases: ['hotkey', 'keyboard'],
+            control: {
+              type: 'dropdown',
+              key: 'editorSaveModifier',
+              options: { Shift: saveShortcutLabel('Shift'), Mod: saveShortcutLabel('Mod') }
+            }
           }
         ]
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,6 +222,8 @@ export interface PMSettings {
   showTagColors: boolean
   saveTaskOnClose: boolean
   taskEditorSurface: 'modal' | 'tab'
+  /** Key shortcut to create or save tasks and projects. */
+  editorSaveModifier: 'Shift' | 'Mod'
   /** Where a project link lands: its overview page or its tasks in the default view. */
   projectSurface: 'overview' | 'tasks'
   /** Keyed by scope key, e.g. `project:Projects/Roadmap.md`. */
@@ -275,6 +277,7 @@ export const DEFAULT_SETTINGS: PMSettings = {
   pullForwardOnEarlyFinish: false,
   saveTaskOnClose: true,
   taskEditorSurface: 'modal',
+  editorSaveModifier: 'Shift',
   projectSurface: 'overview',
   projectFilters: {},
   scopeViews: {},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import { Notice, parseLinktext, setIcon } from 'obsidian'
-import type { Task, StatusConfig, PriorityConfig, TaskPriority, PriorityIconSet } from './types'
+import { Notice, parseLinktext, Platform, setIcon } from 'obsidian'
+import type { Task, StatusConfig, PriorityConfig, TaskPriority, PriorityIconSet, PMSettings } from './types'
 import { PRIORITY_ICON_SETS } from './types'
 import type { DueUrgency } from './ui/composites/dueChip'
 import { today, parsePlainDate } from './dates'
@@ -94,6 +94,11 @@ export function stringifyCustomValue(val: unknown): string {
 export function truncateTitle(title: string, maxLen = 20): string {
   if (title.length <= maxLen) return title
   return title.slice(0, maxLen - 1) + '…'
+}
+
+export function saveShortcutLabel(modifier: PMSettings['editorSaveModifier']): string {
+  if (modifier === 'Shift') return 'Shift+Enter'
+  return Platform.isMacOS ? 'Cmd+Enter' : 'Ctrl+Enter'
 }
 
 export function sanitizeFileName(title: string): string {

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -1,4 +1,4 @@
-import { ButtonComponent, ExtraButtonComponent, ItemView, Menu, WorkspaceLeaf } from 'obsidian'
+import { ButtonComponent, ExtraButtonComponent, ItemView, Menu, Scope, WorkspaceLeaf } from 'obsidian'
 import type PMPlugin from '../main'
 import { type Project, type ViewMode, type FilterState, type SavedView, makeDefaultFilter, makeId } from '../types'
 import {
@@ -50,7 +50,7 @@ export class ProjectView extends ItemView {
   private headerEl!: HTMLElement
   private bodyEl!: HTMLElement
   private header: ProjectHeader | null = null
-  private keydownHandler: ((e: KeyboardEvent) => void) | null = null
+  private keyScope: Scope
   private pendingRefresh: Promise<void> | null = null
   private initialized = false
   /** Set once the default view mode is applied, so reloads don't undo a mode switch. */
@@ -67,6 +67,8 @@ export class ProjectView extends ItemView {
     this.plugin = plugin
     this.currentView = plugin.settings.defaultView
     this.navigation = false
+    this.keyScope = new Scope(this.app.scope)
+    this.scope = this.keyScope
   }
 
   getViewType(): string {
@@ -105,10 +107,6 @@ export class ProjectView extends ItemView {
   }
 
   onClose(): Promise<void> {
-    if (this.keydownHandler) {
-      this.containerEl.removeEventListener('keydown', this.keydownHandler)
-      this.keydownHandler = null
-    }
     this.subview?.destroy?.()
     this.subview = null
     return Promise.resolve()
@@ -127,14 +125,6 @@ export class ProjectView extends ItemView {
     this.toolbarEl = root.createDiv('pm-toolbar')
     this.headerEl = root.createDiv('pm-project-header-mount')
     this.bodyEl = root.createDiv('pm-content')
-
-    this.keydownHandler = (e: KeyboardEvent) => {
-      this.subview?.handleKeyDown?.(e)
-    }
-    this.containerEl.addEventListener('keydown', this.keydownHandler)
-    if (!this.containerEl.hasAttribute('tabindex')) {
-      this.containerEl.setAttribute('tabindex', '-1')
-    }
 
     this.register(
       this.plugin.store.onProjectChanged((path) => {
@@ -525,6 +515,7 @@ export class ProjectView extends ItemView {
           this.plugin,
           () => this.refreshProject(),
           this.filter,
+          this.keyScope,
           this.savedTableViewState ?? undefined
         )
         if (savedTableScrollTop !== null) table.setPendingScrollTop(savedTableScrollTop)
@@ -532,7 +523,14 @@ export class ProjectView extends ItemView {
         break
       }
       case 'gantt': {
-        const gantt = new GanttView(this.bodyEl, scope, this.plugin, () => this.refreshProject(), this.filter)
+        const gantt = new GanttView(
+          this.bodyEl,
+          scope,
+          this.plugin,
+          () => this.refreshProject(),
+          this.filter,
+          this.keyScope
+        )
         if (savedGanttScroll) gantt.setPendingScroll(savedGanttScroll)
         if (savedGanttLabelWidth !== null) gantt.setLabelWidth(savedGanttLabelWidth)
         this.subview = gantt

--- a/src/views/SubView.ts
+++ b/src/views/SubView.ts
@@ -3,5 +3,4 @@ export interface SubView {
   /** Re-render in place, keeping scroll and selection. Falls back to render(). */
   refresh?(): void
   destroy?(): void
-  handleKeyDown?(e: KeyboardEvent): void
 }

--- a/src/views/TaskView.ts
+++ b/src/views/TaskView.ts
@@ -1,4 +1,4 @@
-import { ItemView, WorkspaceLeaf } from 'obsidian'
+import { ItemView, Scope, WorkspaceLeaf } from 'obsidian'
 import type PMPlugin from '../main'
 import type { Task } from '../types'
 import { flattenTasks } from '../store'
@@ -22,11 +22,14 @@ export class TaskView extends ItemView {
   private editor: TaskEditor | null = null
   private state: TaskViewState = {}
   private taskTitle = 'Task'
+  private keyScope: Scope
 
   constructor(leaf: WorkspaceLeaf, plugin: PMPlugin) {
     super(leaf)
     this.plugin = plugin
     this.navigation = false
+    this.keyScope = new Scope(this.app.scope)
+    this.scope = this.keyScope
   }
 
   getViewType(): string {
@@ -93,7 +96,7 @@ export class TaskView extends ItemView {
       task,
       parentId ?? null,
       () => {},
-      { surface: 'tab', close: () => this.leaf.detach(), keyScopeEl: this.containerEl },
+      { surface: 'tab', close: () => this.leaf.detach(), scope: this.keyScope },
       defaults
     )
     this.editor.mount(this.contentEl)

--- a/src/views/gantt/GanttView.ts
+++ b/src/views/gantt/GanttView.ts
@@ -1,4 +1,4 @@
-import { ButtonComponent } from 'obsidian'
+import { ButtonComponent, type Scope } from 'obsidian'
 import type PMPlugin from '../../main'
 import type { Task, GanttGranularity, FilterState } from '../../types'
 import { personKeyer, type ProjectScope } from '../../store'
@@ -52,7 +52,8 @@ export class GanttView implements SubView {
     private scope: ProjectScope,
     private plugin: PMPlugin,
     private onRefresh: () => Promise<void>,
-    private filter: FilterState
+    private filter: FilterState,
+    private keyScope: Scope
   ) {
     this.granularity = plugin.settings.ganttGranularity
   }
@@ -192,31 +193,27 @@ export class GanttView implements SubView {
     })
     svgContainer.appendChild(this.svgEl)
 
-    // Gated on this leaf being the active one, so undo/redo isn't hijacked while the
-    // user is editing an unrelated note.
-    const isGanttActive = (): boolean => {
-      const leafEl = this.container.closest('.workspace-leaf')
-      return leafEl?.classList.contains('mod-active') ?? false
-    }
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (!isGanttActive()) return
-      if (e.key === 'Escape' && this.link.active) {
-        cancelLink(this.link)
-      }
+    const undo = () => {
       if (this.drag.isDragging) return
-      const mod = e.ctrlKey || e.metaKey
-      if (!mod) return
-      const key = e.key.toLowerCase()
-      if (key === 'z' && !e.shiftKey) {
-        e.preventDefault()
-        void this.plugin.undoLastAction()
-      } else if ((key === 'z' && e.shiftKey) || key === 'y') {
-        e.preventDefault()
-        void this.plugin.redoLastAction()
-      }
+      void this.plugin.undoLastAction()
+      return false
     }
-    activeDocument.addEventListener('keydown', onKeyDown)
-    this.cleanupFns.push(() => activeDocument.removeEventListener('keydown', onKeyDown))
+    const redo = () => {
+      if (this.drag.isDragging) return
+      void this.plugin.redoLastAction()
+      return false
+    }
+    const keyHandlers = [
+      this.keyScope.register([], 'Escape', () => {
+        if (this.link.active) cancelLink(this.link)
+      }),
+      this.keyScope.register(['Mod'], 'z', undo),
+      this.keyScope.register(['Mod', 'Shift'], 'z', redo),
+      this.keyScope.register(['Mod'], 'y', redo)
+    ]
+    this.cleanupFns.push(() => {
+      for (const handler of keyHandlers) this.keyScope.unregister(handler)
+    })
 
     const ctx = this.makeRendererContext()
     renderTimelineHeader(ctx)

--- a/src/views/table/TableView.ts
+++ b/src/views/table/TableView.ts
@@ -1,4 +1,4 @@
-import { Notice } from 'obsidian'
+import { Notice, type KeymapEventHandler, type Scope } from 'obsidian'
 import { confirmDialog } from '../../ui/ModalFactory'
 import type PMPlugin from '../../main'
 import type { FilterState, Project } from '../../types'
@@ -18,9 +18,12 @@ export interface TableViewState {
   sortDir: SortDir
 }
 
+const TABLE_KEYS = ['Escape', 'ArrowDown', 'ArrowUp', 'j', 'k', 'Enter', 'e', 'Delete', 'Backspace']
+
 export class TableView implements SubView {
   private state: TableState
   private pendingScrollTop: number | null = null
+  private keyHandlers: KeymapEventHandler[]
 
   constructor(
     private container: HTMLElement,
@@ -28,6 +31,7 @@ export class TableView implements SubView {
     private plugin: PMPlugin,
     private onRefresh: () => Promise<void>,
     filter: FilterState,
+    private keyScope: Scope,
     initialState?: TableViewState
   ) {
     this.state = {
@@ -47,6 +51,11 @@ export class TableView implements SubView {
       windowEnd: -1,
       renderWindow: null
     }
+    this.keyHandlers = TABLE_KEYS.map((key) =>
+      keyScope.register([], key, (e) => {
+        handleTableKeyDown(e, this.makeTableContext())
+      })
+    )
   }
 
   getScrollTop(): number {
@@ -85,11 +94,9 @@ export class TableView implements SubView {
     }
   }
 
-  handleKeyDown(e: KeyboardEvent): void {
-    handleTableKeyDown(e, this.makeTableContext())
-  }
-
   destroy(): void {
+    for (const handler of this.keyHandlers) this.keyScope.unregister(handler)
+    this.keyHandlers = []
     this.state.resizeObserver?.disconnect()
     this.state.resizeObserver = null
   }


### PR DESCRIPTION
The task editor and the new project dialog take their save shortcut from a new setting, Shift+Enter or Ctrl/Cmd+Enter, shown on the button in each. Enter in the project name no longer creates the project; it behaves like the task title.

Every keyboard shortcut moved from DOM keydown listeners onto Obsidian scopes, which is what made a rebindable combination possible. That also stops Ctrl+Z reaching the Gantt view's undo while a dialog is open over it, and drops the leaf-active and tabindex workarounds those listeners needed.