### PR TITLE
serve projects and tasks to local apps over http and mcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Other apps on the same computer can read and edit tasks over a local HTTP and MCP server when it is turned on in settings
+
 ## [2.3.1] - 2026-09-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ For teams:
 
 There is no real-time multi-user editing. Two people editing the same task at once produces a sync conflict, same as any Markdown note.
 
+## Local API and MCP
+
+Other programs on the same computer can read and edit your tasks: a coding agent through the Model Context Protocol, a script over plain HTTP. Turn it on in **Settings > Local API**. It is off by default and only exists on desktop.
+
+When it is on, dotpm listens on `127.0.0.1` on the port shown in settings. Each vault starts with its own port, derived from the vault name so two open vaults never want the same one, and you can change it. Nothing outside this computer can connect, and every request needs the token shown next to the port. Point an MCP client at `http://127.0.0.1:<port>/mcp` with `Authorization: Bearer <token>`; Claude Code, for example:
+
+```sh
+claude mcp add --transport http dotpm http://127.0.0.1:<port>/mcp --header "Authorization: Bearer <token>"
+```
+
+Everything a client changes goes through the same code the views use, so it shows up in Obsidian at once. The endpoints, the MCP tools and the change feed are documented in [docs/api.md](docs/api.md).
+
 ## Using with TaskNotes
 
 dotpm works alongside the [TaskNotes](https://github.com/callumalpass/tasknotes) plugin (4.10 or newer).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,75 @@
+# Local API and MCP
+
+dotpm can serve the projects and tasks in the current vault to other programs on the same computer. Turn it on in Settings under "Local API". It is off by default, desktop only, listens on `127.0.0.1` only, and every request needs the bearer token shown in settings.
+
+Two clients speak to the same server:
+
+- Plain HTTP with JSON bodies, at `http://127.0.0.1:<port>/v1/...`.
+- The Model Context Protocol (MCP) over Streamable HTTP, at `http://127.0.0.1:<port>/mcp`, for coding agents and chat clients.
+
+The port is shown in settings. Each vault starts with its own, derived from the vault name so two open vaults never want the same one, and it can be changed there. Both surfaces read and write the same markdown notes the views use, through the same code, so a change made by a client shows up in Obsidian at once and vice versa.
+
+## Connecting an MCP client
+
+Claude Code:
+
+```sh
+claude mcp add --transport http dotpm http://127.0.0.1:<port>/mcp --header "Authorization: Bearer <token>"
+```
+
+Cursor, Claude Desktop and other clients that take a JSON config:
+
+```json
+{
+  "mcpServers": {
+    "dotpm": {
+      "url": "http://127.0.0.1:<port>/mcp",
+      "headers": { "Authorization": "Bearer <token>" }
+    }
+  }
+}
+```
+
+The server is stateless: every request stands alone, there is no session to keep, and it does not push notifications. Clients that insist on a Server-Sent Events stream get `405` from `GET /mcp` and fall back to plain requests.
+
+Tools: `list_projects`, `get_project`, `list_tasks`, `get_task`, `search_tasks`, `create_task`, `update_task`, `move_task`, `archive_task`, `delete_task`, `list_changes`. Resources: `dotpm://projects/{id}` (the project with its tasks) and `dotpm://tasks/{id}`.
+
+Read a project before writing tasks into it: its `statuses` and `priorities` list the ids a task may carry, and a write with any other value is refused.
+
+## HTTP endpoints
+
+Send `Authorization: Bearer <token>` with every request except `GET /v1/health`.
+
+| Method and path | What it does |
+| --- | --- |
+| `GET /v1/health` | `{ ok, name, version }`, no token needed |
+| `GET /v1/projects` | Every project: id, path, title, icon, color, parentId, taskCount, doneCount |
+| `GET /v1/projects/{id}` | One project with description, team, custom fields, statuses and priorities |
+| `GET /v1/projects/{id}/tasks` | Its tasks in tree order; add `?includeArchived=true` for archived ones |
+| `POST /v1/projects/{id}/tasks` | Create a task; body is the task fields below plus an optional `parentId` |
+| `GET /v1/tasks/{id}` | One task |
+| `PATCH /v1/tasks/{id}` | Change the fields in the body; `If-Match: <updatedAt>` refuses the write with `412` if the task changed since |
+| `POST /v1/tasks/{id}/move` | Body: `parentId` (null for top level), `projectId`, and `before` or `after` naming a sibling |
+| `POST /v1/tasks/{id}/archive` | Body `{ "archived": true }` (the default) or `false` |
+| `DELETE /v1/tasks/{id}` | Delete the task and its subtasks |
+| `GET /v1/search` | `q` (title text), `projectId`, `status`, `assignee`, `includeArchived`, `limit` (default 50) |
+| `GET /v1/changes?since=<cursor>` | What changed after a cursor, see below |
+
+Task fields a client may write: `title`, `description`, `type` (`task`, `milestone`, `subtask`), `status`, `priority`, `start`, `due` (`YYYY-MM-DD` or empty), `progress` (0 to 100), `assignees`, `tags`, `dependencies` (task ids), `recurrence` (`{ interval, every, endDate? }` or null), `timeEstimate` (hours or null), `customFields` (an object keyed by field id).
+
+Every task carries `id`, `projectId`, `parentId`, `position` (its index among its siblings), `path`, `archived`, `completed`, `timeLogs`, `createdAt` and `updatedAt` on top of the fields above. Ids are stable for the life of a task; paths change when a task is renamed or archived.
+
+Errors come back as `{ "error": { "code", "message" } }` with `400` (`invalid`), `401` (`unauthorized`), `404` (`not_found`) or `412` (`conflict`).
+
+## Changes
+
+`GET /v1/changes` without `since` returns the current cursor and nothing else. Poll with that cursor to get everything that changed after it, oldest first, each entry as `{ seq, at, kind: "project" | "task", op: "upsert" | "delete", id, projectId }`. Keep the returned `cursor` for the next poll. A response with `reset: true` means the cursor is older than what the server kept (about the last thousand changes); list what you need again instead of applying changes.
+
+The feed covers projects that have been loaded during this Obsidian session: any project a client has read through the API, and any project open in a view. Changes to a project nobody has opened yet are not tracked until it is.
+
+## Limits
+
+- Desktop only. The mobile app has no server to run.
+- Only this computer can connect. There is no way to bind another interface.
+- Every client shares the one token. Regenerate it in settings to cut every client off at once.
+- Task bodies (`description`) are loaded when a task is read, so the first read of a large project is slower than the rest.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ import obsidianmd from 'eslint-plugin-obsidianmd'
 export default defineConfig([
   ...obsidianmd.configs.recommended,
   {
-    ignores: ['**/*.test.ts', 'packages/ui/src/dom-shim.ts', 'packages/ui/src/dom-platform.ts']
+    ignores: ['**/*.test.ts', 'packages/*/test/**', 'packages/ui/src/dom-shim.ts', 'packages/ui/src/dom-platform.ts']
   },
   {
     files: ['src/**/*.ts', 'packages/*/src/**/*.ts'],

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@2bad/axiom": "2.1.0",
     "@2bad/tsconfig": "4.0.0",
+    "@dotpm/api": "workspace:*",
     "@dotpm/core": "workspace:*",
     "@dotpm/ui": "workspace:*",
     "@types/node": "26.4.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@dotpm/api",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@dotpm/core": "workspace:*"
+  }
+}

--- a/packages/api/src/contract.ts
+++ b/packages/api/src/contract.ts
@@ -1,0 +1,148 @@
+import type { CustomFieldDef, PriorityConfig, Recurrence, StatusConfig, TaskType, TimeLog } from '@dotpm/core'
+
+/** What a listing shows for a project, cheap enough to serve without loading it. */
+export interface ProjectSummary {
+  id: string
+  path: string
+  title: string
+  icon: string
+  color: string
+  parentId: string | null
+  taskCount: number
+  doneCount: number
+}
+
+export interface ProjectResource extends ProjectSummary {
+  description: string
+  teamMembers: string[]
+  customFields: CustomFieldDef[]
+  statuses: StatusConfig[]
+  priorities: PriorityConfig[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface TaskResource {
+  id: string
+  projectId: string
+  parentId: string | null
+  /** Index among its siblings. */
+  position: number
+  path: string
+  title: string
+  description: string
+  type: TaskType
+  status: string
+  priority: string
+  start: string
+  due: string
+  completed: string
+  progress: number
+  assignees: string[]
+  tags: string[]
+  dependencies: string[]
+  recurrence: Recurrence | null
+  timeEstimate: number | null
+  timeLogs: TimeLog[]
+  customFields: Record<string, unknown>
+  archived: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+/** The fields a client may write. Everything else is derived or owned by the host. */
+export interface TaskWrite {
+  title?: string
+  description?: string
+  type?: TaskType
+  status?: string
+  priority?: string
+  start?: string
+  due?: string
+  progress?: number
+  assignees?: string[]
+  tags?: string[]
+  dependencies?: string[]
+  recurrence?: Recurrence | null
+  timeEstimate?: number | null
+  customFields?: Record<string, unknown>
+}
+
+export interface TaskCreate extends TaskWrite {
+  title: string
+  parentId?: string | null
+}
+
+export interface TaskMove {
+  parentId?: string | null
+  projectId?: string
+  before?: string
+  after?: string
+}
+
+export interface TaskSearch {
+  query?: string
+  projectId?: string
+  status?: string
+  assignee?: string
+  includeArchived?: boolean
+  limit?: number
+}
+
+export interface Change {
+  seq: number
+  at: string
+  kind: 'project' | 'task'
+  op: 'upsert' | 'delete'
+  id: string
+  projectId: string
+}
+
+export interface ChangePage {
+  cursor: number
+  changes: Change[]
+  /** The cursor asked for is older than what is kept; refetch instead of applying. */
+  reset: boolean
+}
+
+export type ApiErrorCode = 'invalid' | 'unauthorized' | 'not_found' | 'conflict' | 'unavailable'
+
+export class ApiRequestError extends Error {
+  constructor(
+    readonly code: ApiErrorCode,
+    message: string
+  ) {
+    super(message)
+    this.name = 'ApiRequestError'
+  }
+}
+
+export const ERROR_STATUS: Record<ApiErrorCode, number> = {
+  invalid: 400,
+  unauthorized: 401,
+  not_found: 404,
+  conflict: 412,
+  unavailable: 503
+}
+
+/**
+ * The contract every host implements: the plugin over the vault today, a server later.
+ * Ids are the only identity; paths are attributes. Writes take the raw client input
+ * (`TaskCreate`, `TaskWrite`, `TaskMove` shaped) and validate it against the project,
+ * since only the host knows a project's statuses. Every client mistake rejects with an
+ * `ApiRequestError`.
+ */
+export interface DomainApi {
+  listProjects(): Promise<ProjectSummary[]>
+  getProject(projectId: string): Promise<ProjectResource>
+  listTasks(projectId: string, includeArchived?: boolean): Promise<TaskResource[]>
+  getTask(taskId: string): Promise<TaskResource>
+  searchTasks(search: TaskSearch): Promise<TaskResource[]>
+  createTask(projectId: string, input: unknown): Promise<TaskResource>
+  /** `expectedUpdatedAt` makes the write conditional: a mismatch rejects with `conflict`. */
+  updateTask(taskId: string, input: unknown, expectedUpdatedAt?: string): Promise<TaskResource>
+  moveTask(taskId: string, input: unknown): Promise<TaskResource>
+  archiveTask(taskId: string, archived: boolean): Promise<TaskResource>
+  deleteTask(taskId: string): Promise<void>
+  changes(since: number | null): Promise<ChangePage>
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,0 +1,4 @@
+export * from './contract'
+export * from './resources'
+export * from './router'
+export * from './mcp'

--- a/packages/api/src/mcp.test.ts
+++ b/packages/api/src/mcp.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { FakeApi } from '../test/fakeApi'
+import { handleMcp, MCP_PROTOCOL_VERSION, type JsonRpcResponse } from './mcp'
+
+const INFO = { name: 'dotpm', version: '9.9.9' }
+
+function rpc(method: string, params?: unknown, id: number | string = 1): unknown {
+  return { jsonrpc: '2.0', id, method, params }
+}
+
+function parsed(reply: JsonRpcResponse | JsonRpcResponse[] | null): unknown {
+  const one = reply as JsonRpcResponse
+  const content = (one.result as { content: Array<{ text: string }> }).content
+  return JSON.parse(content[0].text)
+}
+
+describe('handleMcp', () => {
+  let api: FakeApi
+
+  beforeEach(() => {
+    api = new FakeApi()
+  })
+
+  it('initializes with a supported protocol version and falls back to the newest', async () => {
+    const old = (await handleMcp(rpc('initialize', { protocolVersion: '2024-11-05' }), api, INFO)) as JsonRpcResponse
+    expect(old.result).toMatchObject({ protocolVersion: '2024-11-05', capabilities: { tools: {} } })
+    const unknown = (await handleMcp(
+      rpc('initialize', { protocolVersion: '1999-01-01' }),
+      api,
+      INFO
+    )) as JsonRpcResponse
+    expect(unknown.result).toMatchObject({ protocolVersion: MCP_PROTOCOL_VERSION })
+  })
+
+  it('lists tools with schemas and reports unknown methods', async () => {
+    const tools = (await handleMcp(rpc('tools/list'), api, INFO)) as JsonRpcResponse
+    const names = (tools.result as { tools: Array<{ name: string; inputSchema: object }> }).tools.map((t) => t.name)
+    expect(names).toEqual([
+      'list_projects',
+      'get_project',
+      'list_tasks',
+      'get_task',
+      'search_tasks',
+      'create_task',
+      'update_task',
+      'move_task',
+      'archive_task',
+      'delete_task',
+      'list_changes'
+    ])
+    const missing = (await handleMcp(rpc('nope/method'), api, INFO)) as JsonRpcResponse
+    expect(missing.error?.code).toBe(-32601)
+  })
+
+  it('calls tools and returns JSON text content', async () => {
+    const reply = await handleMcp(rpc('tools/call', { name: 'list_projects', arguments: {} }), api, INFO)
+    expect(parsed(reply)).toEqual([expect.objectContaining({ id: 'p1', title: 'Demo' })])
+
+    const created = await handleMcp(
+      rpc('tools/call', { name: 'create_task', arguments: { projectId: 'p1', title: 'Via MCP', tags: ['agent'] } }),
+      api,
+      INFO
+    )
+    expect(parsed(created)).toMatchObject({ id: 't3', title: 'Via MCP', tags: ['agent'] })
+    expect(api.calls).toContain('createTask p1')
+
+    await handleMcp(
+      rpc('tools/call', {
+        name: 'update_task',
+        arguments: { taskId: 't3', status: 'done', expectedUpdatedAt: 'stale' }
+      }),
+      api,
+      INFO
+    )
+    expect(api.calls.at(-1)).toBe('updateTask t3 if stale')
+  })
+
+  it('reports a client mistake as a tool error instead of a protocol error', async () => {
+    const reply = (await handleMcp(
+      rpc('tools/call', { name: 'get_task', arguments: { taskId: 'zzz' } }),
+      api,
+      INFO
+    )) as JsonRpcResponse
+    expect(reply.error).toBeUndefined()
+    expect(reply.result).toMatchObject({ isError: true })
+    expect(parsed(reply)).toEqual({ error: 'not_found', message: 'task zzz not found' })
+  })
+
+  it('exposes projects as resources and reads tasks by uri', async () => {
+    const list = (await handleMcp(rpc('resources/list'), api, INFO)) as JsonRpcResponse
+    expect(list.result).toEqual({
+      resources: [expect.objectContaining({ uri: 'dotpm://projects/p1', name: 'Demo', mimeType: 'application/json' })]
+    })
+    const read = (await handleMcp(rpc('resources/read', { uri: 'dotpm://tasks/t1' }), api, INFO)) as JsonRpcResponse
+    const contents = (read.result as { contents: Array<{ uri: string; text: string }> }).contents
+    expect(contents[0].uri).toBe('dotpm://tasks/t1')
+    expect(JSON.parse(contents[0].text)).toMatchObject({ id: 't1', title: 'First' })
+    const project = (await handleMcp(
+      rpc('resources/read', { uri: 'dotpm://projects/p1' }),
+      api,
+      INFO
+    )) as JsonRpcResponse
+    expect(JSON.parse((project.result as { contents: Array<{ text: string }> }).contents[0].text)).toMatchObject({
+      id: 'p1',
+      tasks: [expect.objectContaining({ id: 't1' }), expect.objectContaining({ id: 't2' })]
+    })
+  })
+
+  it('handles batches and stays quiet for notifications', async () => {
+    expect(await handleMcp({ jsonrpc: '2.0', method: 'notifications/initialized' }, api, INFO)).toBeNull()
+    const batch = (await handleMcp(
+      [rpc('ping', undefined, 'a'), { jsonrpc: '2.0', method: 'notifications/initialized' }],
+      api,
+      INFO
+    )) as JsonRpcResponse[]
+    expect(batch).toEqual([{ jsonrpc: '2.0', id: 'a', result: {} }])
+    const bad = (await handleMcp({ hello: 'world' }, api, INFO)) as JsonRpcResponse
+    expect(bad.error?.code).toBe(-32600)
+  })
+})

--- a/packages/api/src/mcp.ts
+++ b/packages/api/src/mcp.ts
@@ -1,0 +1,368 @@
+import { ApiRequestError, type DomainApi } from './contract'
+import { parseTaskSearch } from './resources'
+
+export interface ServerInfo {
+  name: string
+  version: string
+}
+
+export interface JsonRpcRequest {
+  jsonrpc: '2.0'
+  id?: number | string | null
+  method: string
+  params?: unknown
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: '2.0'
+  id: number | string | null
+  result?: unknown
+  error?: { code: number; message: string; data?: unknown }
+}
+
+export const MCP_PROTOCOL_VERSION = '2025-06-18'
+const SUPPORTED_PROTOCOL_VERSIONS = new Set(['2025-06-18', '2025-03-26', '2024-11-05'])
+
+const PARSE_ERROR = -32700
+const INVALID_REQUEST = -32600
+const METHOD_NOT_FOUND = -32601
+const INVALID_PARAMS = -32602
+
+type JsonSchema = Record<string, unknown>
+
+const TASK_FIELDS: Record<string, JsonSchema> = {
+  title: { type: 'string' },
+  description: { type: 'string', description: 'Markdown body of the task note' },
+  type: { type: 'string', enum: ['task', 'milestone', 'subtask'] },
+  status: { type: 'string', description: "One of the project's status ids (see get_project)" },
+  priority: { type: 'string', description: "One of the project's priority ids (see get_project)" },
+  start: { type: 'string', description: 'YYYY-MM-DD, or empty to clear' },
+  due: { type: 'string', description: 'YYYY-MM-DD, or empty to clear' },
+  progress: { type: 'integer', minimum: 0, maximum: 100 },
+  assignees: { type: 'array', items: { type: 'string' } },
+  tags: { type: 'array', items: { type: 'string' } },
+  dependencies: { type: 'array', items: { type: 'string' }, description: 'Ids of tasks this one waits for' },
+  recurrence: {
+    type: ['object', 'null'],
+    properties: {
+      interval: { type: 'string', enum: ['daily', 'weekly', 'monthly', 'yearly'] },
+      every: { type: 'integer', minimum: 1 },
+      endDate: { type: 'string' }
+    },
+    required: ['interval', 'every']
+  },
+  timeEstimate: { type: ['number', 'null'], description: 'Hours' },
+  customFields: { type: 'object', additionalProperties: true }
+}
+
+interface ToolDefinition {
+  name: string
+  description: string
+  inputSchema: JsonSchema
+}
+
+const TOOLS: ToolDefinition[] = [
+  {
+    name: 'list_projects',
+    description: 'Every project in the vault with its id, title, parent and task counts.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false }
+  },
+  {
+    name: 'get_project',
+    description: 'One project with its description, team, custom fields and the status and priority ids its tasks use.',
+    inputSchema: {
+      type: 'object',
+      properties: { projectId: { type: 'string' } },
+      required: ['projectId'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'list_tasks',
+    description: 'All tasks of a project in tree order. Each carries parentId and position.',
+    inputSchema: {
+      type: 'object',
+      properties: { projectId: { type: 'string' }, includeArchived: { type: 'boolean' } },
+      required: ['projectId'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'get_task',
+    description: 'One task by id, including its description.',
+    inputSchema: {
+      type: 'object',
+      properties: { taskId: { type: 'string' } },
+      required: ['taskId'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'search_tasks',
+    description: 'Find tasks across every project by title text, project, status or assignee.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Case-insensitive match on the title' },
+        projectId: { type: 'string' },
+        status: { type: 'string' },
+        assignee: { type: 'string' },
+        includeArchived: { type: 'boolean' },
+        limit: { type: 'integer', minimum: 1, maximum: 500 }
+      },
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'create_task',
+    description: 'Create a task in a project, at the top level or under parentId.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectId: { type: 'string' },
+        parentId: { type: ['string', 'null'] },
+        ...TASK_FIELDS
+      },
+      required: ['projectId', 'title'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'update_task',
+    description:
+      'Change fields of a task. Only the fields passed change. Pass expectedUpdatedAt from a previous read to refuse the write when the task changed since.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        taskId: { type: 'string' },
+        expectedUpdatedAt: { type: 'string' },
+        ...TASK_FIELDS
+      },
+      required: ['taskId'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'move_task',
+    description:
+      'Re-parent a task (parentId, null for top level), move it to another project (projectId), or reorder it among its siblings (before or after a sibling id).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        taskId: { type: 'string' },
+        parentId: { type: ['string', 'null'] },
+        projectId: { type: 'string' },
+        before: { type: 'string' },
+        after: { type: 'string' }
+      },
+      required: ['taskId'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'archive_task',
+    description: 'Archive a task and its subtasks, or bring them back with archived: false.',
+    inputSchema: {
+      type: 'object',
+      properties: { taskId: { type: 'string' }, archived: { type: 'boolean', default: true } },
+      required: ['taskId'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'delete_task',
+    description: 'Delete a task and its subtasks. Cannot be undone.',
+    inputSchema: {
+      type: 'object',
+      properties: { taskId: { type: 'string' } },
+      required: ['taskId'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'list_changes',
+    description:
+      'Projects and tasks changed since a cursor, oldest first. Omit since for the current cursor only. A reset of true means the cursor was too old: refetch.',
+    inputSchema: {
+      type: 'object',
+      properties: { since: { type: 'integer' } },
+      additionalProperties: false
+    }
+  }
+]
+
+const PROJECT_URI = /^dotpm:\/\/projects\/([^/]+)$/
+const TASK_URI = /^dotpm:\/\/tasks\/([^/]+)$/
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function requireString(params: Record<string, unknown>, key: string): string {
+  const value = params[key]
+  if (typeof value !== 'string' || !value) throw new ApiRequestError('invalid', `${key} is required`)
+  return value
+}
+
+function withoutKeys(params: Record<string, unknown>, keys: string[]): Record<string, unknown> {
+  const rest: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(params)) if (!keys.includes(key)) rest[key] = value
+  return rest
+}
+
+async function callTool(name: string, params: Record<string, unknown>, api: DomainApi): Promise<unknown> {
+  switch (name) {
+    case 'list_projects':
+      return api.listProjects()
+    case 'get_project':
+      return api.getProject(requireString(params, 'projectId'))
+    case 'list_tasks':
+      return api.listTasks(requireString(params, 'projectId'), params['includeArchived'] === true)
+    case 'get_task':
+      return api.getTask(requireString(params, 'taskId'))
+    case 'search_tasks':
+      return api.searchTasks(parseTaskSearch(params))
+    case 'create_task':
+      return api.createTask(requireString(params, 'projectId'), withoutKeys(params, ['projectId']))
+    case 'update_task': {
+      const expected = params['expectedUpdatedAt']
+      return api.updateTask(
+        requireString(params, 'taskId'),
+        withoutKeys(params, ['taskId', 'expectedUpdatedAt']),
+        typeof expected === 'string' ? expected : undefined
+      )
+    }
+    case 'move_task':
+      return api.moveTask(requireString(params, 'taskId'), withoutKeys(params, ['taskId']))
+    case 'archive_task':
+      return api.archiveTask(requireString(params, 'taskId'), params['archived'] !== false)
+    case 'delete_task':
+      await api.deleteTask(requireString(params, 'taskId'))
+      return { deleted: true }
+    case 'list_changes': {
+      const since = params['since']
+      return api.changes(typeof since === 'number' ? since : null)
+    }
+    default:
+      throw new ApiRequestError('not_found', `unknown tool ${name}`)
+  }
+}
+
+function text(value: unknown): { content: Array<{ type: 'text'; text: string }>; isError?: boolean } {
+  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] }
+}
+
+async function readResource(uri: string, api: DomainApi): Promise<unknown> {
+  const project = PROJECT_URI.exec(uri)
+  if (project) {
+    const [resource, tasks] = await Promise.all([api.getProject(project[1]), api.listTasks(project[1])])
+    return { ...resource, tasks }
+  }
+  const task = TASK_URI.exec(uri)
+  if (task) return api.getTask(task[1])
+  throw new ApiRequestError('not_found', `unknown resource ${uri}`)
+}
+
+async function dispatch(method: string, params: unknown, api: DomainApi, info: ServerInfo): Promise<unknown> {
+  const p = isRecord(params) ? params : {}
+  switch (method) {
+    case 'initialize': {
+      const requested = p['protocolVersion']
+      const protocolVersion =
+        typeof requested === 'string' && SUPPORTED_PROTOCOL_VERSIONS.has(requested) ? requested : MCP_PROTOCOL_VERSION
+      return {
+        protocolVersion,
+        capabilities: { tools: { listChanged: false }, resources: { subscribe: false, listChanged: false } },
+        serverInfo: info,
+        instructions:
+          'Projects hold tasks in a tree. Read a project first to learn its status and priority ids before writing tasks.'
+      }
+    }
+    case 'ping':
+      return {}
+    case 'tools/list':
+      return { tools: TOOLS }
+    case 'tools/call': {
+      const name = p['name']
+      if (typeof name !== 'string') throw new ApiRequestError('invalid', 'tool name is required')
+      const args = isRecord(p['arguments']) ? p['arguments'] : {}
+      try {
+        return text(await callTool(name, args, api))
+      } catch (err: unknown) {
+        if (err instanceof ApiRequestError) return { ...text({ error: err.code, message: err.message }), isError: true }
+        throw err
+      }
+    }
+    case 'resources/list': {
+      const projects = await api.listProjects()
+      return {
+        resources: projects.map((project) => ({
+          uri: `dotpm://projects/${project.id}`,
+          name: project.title,
+          description: `${project.taskCount} tasks, ${project.doneCount} done`,
+          mimeType: 'application/json'
+        }))
+      }
+    }
+    case 'resources/templates/list':
+      return {
+        resourceTemplates: [
+          { uriTemplate: 'dotpm://tasks/{taskId}', name: 'Task', mimeType: 'application/json' },
+          { uriTemplate: 'dotpm://projects/{projectId}', name: 'Project with tasks', mimeType: 'application/json' }
+        ]
+      }
+    case 'resources/read': {
+      const uri = p['uri']
+      if (typeof uri !== 'string') throw new ApiRequestError('invalid', 'uri is required')
+      const body = await readResource(uri, api)
+      return { contents: [{ uri, mimeType: 'application/json', text: JSON.stringify(body, null, 2) }] }
+    }
+    default:
+      return undefined
+  }
+}
+
+function errorResponse(id: number | string | null, code: number, message: string): JsonRpcResponse {
+  return { jsonrpc: '2.0', id, error: { code, message } }
+}
+
+async function handleOne(message: unknown, api: DomainApi, info: ServerInfo): Promise<JsonRpcResponse | null> {
+  if (!isRecord(message) || message['jsonrpc'] !== '2.0' || typeof message['method'] !== 'string') {
+    return errorResponse(null, INVALID_REQUEST, 'expected a JSON-RPC 2.0 request')
+  }
+  const request = message as unknown as JsonRpcRequest
+  const id = request.id ?? null
+  const isNotification = request.id === undefined
+  try {
+    const result = await dispatch(request.method, request.params, api, info)
+    if (isNotification) return null
+    if (result === undefined) return errorResponse(id, METHOD_NOT_FOUND, `unknown method ${request.method}`)
+    return { jsonrpc: '2.0', id, result }
+  } catch (err: unknown) {
+    if (isNotification) return null
+    if (err instanceof ApiRequestError) {
+      return errorResponse(id, err.code === 'invalid' ? INVALID_PARAMS : -32000, err.message)
+    }
+    console.error('[PM] mcp request failed', err)
+    return errorResponse(id, -32603, 'request failed; see the developer console')
+  }
+}
+
+/**
+ * MCP over Streamable HTTP in its stateless form: one POST carries one message (or a
+ * batch), the reply is plain JSON, and notifications get no body. Returns null when
+ * there is nothing to send back.
+ */
+export async function handleMcp(
+  body: unknown,
+  api: DomainApi,
+  info: ServerInfo
+): Promise<JsonRpcResponse | JsonRpcResponse[] | null> {
+  if (body === undefined || body === null) return errorResponse(null, PARSE_ERROR, 'empty body')
+  if (Array.isArray(body)) {
+    const replies = await Promise.all(body.map((message) => handleOne(message, api, info)))
+    const sent = replies.filter((reply): reply is JsonRpcResponse => reply !== null)
+    return sent.length ? sent : null
+  }
+  return handleOne(body, api, info)
+}

--- a/packages/api/src/resources.test.ts
+++ b/packages/api/src/resources.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_PRIORITIES, DEFAULT_STATUSES, makeProject, makeTask, type ResolvedProjectConfig } from '@dotpm/core'
+import { ApiRequestError } from './contract'
+import { parseTaskCreate, parseTaskMove, parseTaskSearch, parseTaskWrite, taskPatch, taskResources } from './resources'
+
+const CONFIG: ResolvedProjectConfig = {
+  statuses: DEFAULT_STATUSES,
+  priorities: DEFAULT_PRIORITIES,
+  priorityIcons: 'chevrons',
+  customFields: [],
+  defaultView: 'table',
+  autoSchedule: false,
+  pullForwardOnEarlyFinish: false,
+  autoArchiveDays: 0,
+  showSubtreeConnections: true,
+  lineBorders: 'none',
+  kanbanShowSubtasks: false,
+  kanbanShowDescriptionPreview: false
+}
+
+function rejects(fn: () => unknown, message: string): void {
+  expect(fn).toThrow(ApiRequestError)
+  expect(fn).toThrow(message)
+}
+
+describe('parseTaskWrite', () => {
+  it('keeps only known fields and accepts valid values', () => {
+    const write = parseTaskWrite(
+      {
+        title: 'A',
+        status: 'done',
+        priority: 'high',
+        start: '2030-01-01',
+        due: '',
+        progress: 40,
+        tags: ['x'],
+        recurrence: { interval: 'weekly', every: 2 },
+        timeEstimate: null,
+        customFields: { sprint: 3 },
+        filePath: 'ignored',
+        updatedAt: 'ignored'
+      },
+      CONFIG
+    )
+    expect(write).toEqual({
+      title: 'A',
+      status: 'done',
+      priority: 'high',
+      start: '2030-01-01',
+      due: '',
+      progress: 40,
+      tags: ['x'],
+      recurrence: { interval: 'weekly', every: 2 },
+      timeEstimate: null,
+      customFields: { sprint: 3 }
+    })
+  })
+
+  it('rejects values the project cannot hold', () => {
+    expect.hasAssertions()
+    rejects(() => parseTaskWrite('nope', CONFIG), 'expected an object')
+    rejects(() => parseTaskWrite({ status: 'nope' }, CONFIG), 'status must be one of')
+    rejects(() => parseTaskWrite({ priority: 7 }, CONFIG), 'priority must be a string')
+    rejects(() => parseTaskWrite({ due: '2030-13-45' }, CONFIG), 'due must be YYYY-MM-DD or empty')
+    rejects(() => parseTaskWrite({ due: 'tomorrow' }, CONFIG), 'due must be YYYY-MM-DD or empty')
+    rejects(() => parseTaskWrite({ progress: 101 }, CONFIG), 'progress must be an integer from 0 to 100')
+    rejects(() => parseTaskWrite({ assignees: 'me' }, CONFIG), 'assignees must be a list of strings')
+    rejects(() => parseTaskWrite({ recurrence: { interval: 'hourly', every: 1 } }, CONFIG), 'recurrence.interval')
+    rejects(() => parseTaskWrite({ type: 'epic' }, CONFIG), 'type must be one of')
+  })
+
+  it('turns a write into the store patch, clearing with undefined', () => {
+    expect(taskPatch({ recurrence: null, timeEstimate: null, title: 'T' })).toEqual({
+      recurrence: undefined,
+      timeEstimate: undefined,
+      title: 'T'
+    })
+  })
+})
+
+describe('parseTaskCreate', () => {
+  it('requires a title and defaults the parent to the top level', () => {
+    rejects(() => parseTaskCreate({ status: 'todo' }, CONFIG), 'title is required')
+    expect(parseTaskCreate({ title: 'New' }, CONFIG)).toEqual({ title: 'New', parentId: null })
+    expect(parseTaskCreate({ title: 'New', parentId: 'p' }, CONFIG).parentId).toBe('p')
+    rejects(() => parseTaskCreate({ title: 'New', parentId: 4 }, CONFIG), 'parentId must be a string or null')
+  })
+})
+
+describe('parseTaskMove', () => {
+  it('needs a destination and refuses before with after', () => {
+    rejects(() => parseTaskMove({}), 'nothing to move')
+    rejects(() => parseTaskMove({ before: 'a', after: 'b' }), 'pass before or after, not both')
+    expect(parseTaskMove({ parentId: null })).toEqual({ parentId: null })
+    expect(parseTaskMove({ projectId: 'p2', after: 't9' })).toEqual({ projectId: 'p2', after: 't9' })
+  })
+})
+
+describe('parseTaskSearch', () => {
+  it('reads query-string shaped input', () => {
+    expect(parseTaskSearch({ query: 'x', includeArchived: 'true', limit: '10', status: '' })).toEqual({
+      query: 'x',
+      includeArchived: true,
+      limit: 10
+    })
+    rejects(() => parseTaskSearch({ limit: 0 }), 'limit must be an integer from 1 to 500')
+  })
+})
+
+describe('taskResources', () => {
+  it('walks the tree with parent ids and sibling positions, skipping archived unless asked', () => {
+    const project = makeProject('P', 'Projects/P/P.md')
+    const child = makeTask({ id: 'c', title: 'Child' })
+    const archived = makeTask({ id: 'z', title: 'Old', archived: true })
+    project.tasks = [makeTask({ id: 'a', title: 'A', subtasks: [child] }), archived, makeTask({ id: 'b', title: 'B' })]
+    const rows = taskResources(project, 'pid', false)
+    expect(rows.map((r) => [r.id, r.parentId, r.position])).toEqual([
+      ['a', null, 0],
+      ['c', 'a', 0],
+      ['b', null, 2]
+    ])
+    expect(taskResources(project, 'pid', true).map((r) => r.id)).toEqual(['a', 'c', 'z', 'b'])
+    expect(rows[0].projectId).toBe('pid')
+    expect(rows[0].archived).toBe(false)
+  })
+})

--- a/packages/api/src/resources.ts
+++ b/packages/api/src/resources.ts
@@ -1,0 +1,254 @@
+import type { Project, Recurrence, ResolvedProjectConfig, Task, TaskType } from '@dotpm/core'
+import { parsePlainDate } from '@dotpm/core'
+import {
+  ApiRequestError,
+  type ProjectResource,
+  type ProjectSummary,
+  type TaskCreate,
+  type TaskMove,
+  type TaskResource,
+  type TaskSearch,
+  type TaskWrite
+} from './contract'
+
+const TASK_TYPES: TaskType[] = ['task', 'milestone', 'subtask']
+const RECURRENCE_INTERVALS: Recurrence['interval'][] = ['daily', 'weekly', 'monthly', 'yearly']
+
+export function invalid(message: string): never {
+  throw new ApiRequestError('invalid', message)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function toTaskResource(task: Task, projectId: string, parentId: string | null, position: number): TaskResource {
+  return {
+    id: task.id,
+    projectId,
+    parentId,
+    position,
+    path: task.filePath ?? '',
+    title: task.title,
+    description: task.description,
+    type: task.type,
+    status: task.status,
+    priority: task.priority,
+    start: task.start,
+    due: task.due,
+    completed: task.completed,
+    progress: task.progress,
+    assignees: [...task.assignees],
+    tags: [...task.tags],
+    dependencies: [...task.dependencies],
+    recurrence: task.recurrence ? { ...task.recurrence } : null,
+    timeEstimate: task.timeEstimate ?? null,
+    timeLogs: (task.timeLogs ?? []).map((log) => ({ ...log })),
+    customFields: { ...task.customFields },
+    archived: task.archived === true,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt
+  }
+}
+
+/** Every task of a project in tree order, positions counted among siblings. */
+export function taskResources(project: Project, projectId: string, includeArchived: boolean): TaskResource[] {
+  const out: TaskResource[] = []
+  const walk = (tasks: Task[], parentId: string | null): void => {
+    tasks.forEach((task, position) => {
+      if (task.archived && !includeArchived) return
+      out.push(toTaskResource(task, projectId, parentId, position))
+      walk(task.subtasks, task.id)
+    })
+  }
+  walk(project.tasks, null)
+  return out
+}
+
+export function toProjectResource(
+  project: Project,
+  config: ResolvedProjectConfig,
+  summary: ProjectSummary
+): ProjectResource {
+  return {
+    ...summary,
+    description: project.description,
+    teamMembers: [...project.teamMembers],
+    customFields: config.customFields.map((field) => ({ ...field })),
+    statuses: config.statuses.map((status) => ({ ...status })),
+    priorities: config.priorities.map((priority) => ({ ...priority })),
+    createdAt: project.createdAt,
+    updatedAt: project.updatedAt
+  }
+}
+
+function readString(input: Record<string, unknown>, key: string): string | undefined {
+  const value = input[key]
+  if (value === undefined) return undefined
+  if (typeof value !== 'string') invalid(`${key} must be a string`)
+  return value
+}
+
+function readDate(input: Record<string, unknown>, key: string): string | undefined {
+  const value = readString(input, key)
+  if (value === undefined || value === '') return value
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value) || !parsePlainDate(value)) invalid(`${key} must be YYYY-MM-DD or empty`)
+  return value
+}
+
+function readStringList(input: Record<string, unknown>, key: string): string[] | undefined {
+  const value = input[key]
+  if (value === undefined) return undefined
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    invalid(`${key} must be a list of strings`)
+  }
+  return value as string[]
+}
+
+function readRecurrence(input: Record<string, unknown>): Recurrence | null | undefined {
+  const value = input['recurrence']
+  if (value === undefined) return undefined
+  if (value === null) return null
+  if (!isRecord(value)) invalid('recurrence must be an object or null')
+  const interval = value['interval']
+  const every = value['every']
+  if (!RECURRENCE_INTERVALS.includes(interval as Recurrence['interval'])) {
+    invalid(`recurrence.interval must be one of ${RECURRENCE_INTERVALS.join(', ')}`)
+  }
+  if (typeof every !== 'number' || !Number.isInteger(every) || every < 1) {
+    invalid('recurrence.every must be a positive integer')
+  }
+  const endDate = readDate(value, 'endDate')
+  return { interval: interval as Recurrence['interval'], every, ...(endDate ? { endDate } : {}) }
+}
+
+export function parseTaskWrite(input: unknown, config: ResolvedProjectConfig): TaskWrite {
+  if (!isRecord(input)) invalid('expected an object')
+  const write: TaskWrite = {}
+  const title = readString(input, 'title')
+  if (title !== undefined) {
+    if (!title.trim()) invalid('title must not be empty')
+    write.title = title
+  }
+  const description = readString(input, 'description')
+  if (description !== undefined) write.description = description
+  const type = readString(input, 'type')
+  if (type !== undefined) {
+    if (!TASK_TYPES.includes(type as TaskType)) invalid(`type must be one of ${TASK_TYPES.join(', ')}`)
+    write.type = type as TaskType
+  }
+  const status = readString(input, 'status')
+  if (status !== undefined) {
+    if (!config.statuses.some((s) => s.id === status)) {
+      invalid(`status must be one of ${config.statuses.map((s) => s.id).join(', ')}`)
+    }
+    write.status = status
+  }
+  const priority = readString(input, 'priority')
+  if (priority !== undefined) {
+    if (!config.priorities.some((p) => p.id === priority)) {
+      invalid(`priority must be one of ${config.priorities.map((p) => p.id).join(', ')}`)
+    }
+    write.priority = priority
+  }
+  const start = readDate(input, 'start')
+  if (start !== undefined) write.start = start
+  const due = readDate(input, 'due')
+  if (due !== undefined) write.due = due
+  const progress = input['progress']
+  if (progress !== undefined) {
+    if (typeof progress !== 'number' || !Number.isInteger(progress) || progress < 0 || progress > 100) {
+      invalid('progress must be an integer from 0 to 100')
+    }
+    write.progress = progress
+  }
+  for (const key of ['assignees', 'tags', 'dependencies'] as const) {
+    const list = readStringList(input, key)
+    if (list !== undefined) write[key] = list
+  }
+  const recurrence = readRecurrence(input)
+  if (recurrence !== undefined) write.recurrence = recurrence
+  const timeEstimate = input['timeEstimate']
+  if (timeEstimate !== undefined) {
+    if (timeEstimate !== null && (typeof timeEstimate !== 'number' || timeEstimate < 0)) {
+      invalid('timeEstimate must be a non-negative number or null')
+    }
+    write.timeEstimate = timeEstimate
+  }
+  const customFields = input['customFields']
+  if (customFields !== undefined) {
+    if (!isRecord(customFields)) invalid('customFields must be an object')
+    write.customFields = customFields
+  }
+  return write
+}
+
+export function parseTaskCreate(input: unknown, config: ResolvedProjectConfig): TaskCreate {
+  const write = parseTaskWrite(input, config)
+  if (write.title === undefined) invalid('title is required')
+  const record = input as Record<string, unknown>
+  const parentId = record['parentId']
+  if (parentId !== undefined && parentId !== null && typeof parentId !== 'string') {
+    invalid('parentId must be a string or null')
+  }
+  return { ...write, title: write.title, parentId: parentId ?? null }
+}
+
+export function parseTaskMove(input: unknown): TaskMove {
+  if (!isRecord(input)) invalid('expected an object')
+  const move: TaskMove = {}
+  const parentId = input['parentId']
+  if (parentId !== undefined) {
+    if (parentId !== null && typeof parentId !== 'string') invalid('parentId must be a string or null')
+    move.parentId = parentId
+  }
+  for (const key of ['projectId', 'before', 'after'] as const) {
+    const value = readString(input, key)
+    if (value !== undefined) move[key] = value
+  }
+  if (move.before !== undefined && move.after !== undefined) invalid('pass before or after, not both')
+  if (move.parentId === undefined && move.projectId === undefined && !move.before && !move.after) {
+    invalid('nothing to move: pass parentId, projectId, before or after')
+  }
+  return move
+}
+
+export function parseTaskSearch(input: unknown): TaskSearch {
+  if (!isRecord(input)) invalid('expected an object')
+  const search: TaskSearch = {}
+  for (const key of ['query', 'projectId', 'status', 'assignee'] as const) {
+    const value = readString(input, key)
+    if (value !== undefined && value !== '') search[key] = value
+  }
+  const includeArchived = input['includeArchived']
+  if (includeArchived !== undefined) search.includeArchived = includeArchived === true || includeArchived === 'true'
+  const limit = input['limit']
+  if (limit !== undefined) {
+    const n = typeof limit === 'string' ? Number(limit) : limit
+    if (typeof n !== 'number' || !Number.isInteger(n) || n < 1 || n > 500) {
+      invalid('limit must be an integer from 1 to 500')
+    }
+    search.limit = n
+  }
+  return search
+}
+
+/** The store's patch shape: absent fields untouched, null meaning cleared. */
+export function taskPatch(write: TaskWrite): Partial<Task> {
+  const patch: Partial<Task> = {}
+  if (write.title !== undefined) patch.title = write.title
+  if (write.description !== undefined) patch.description = write.description
+  if (write.type !== undefined) patch.type = write.type
+  if (write.status !== undefined) patch.status = write.status
+  if (write.priority !== undefined) patch.priority = write.priority
+  if (write.start !== undefined) patch.start = write.start
+  if (write.due !== undefined) patch.due = write.due
+  if (write.progress !== undefined) patch.progress = write.progress
+  if (write.assignees !== undefined) patch.assignees = write.assignees
+  if (write.tags !== undefined) patch.tags = write.tags
+  if (write.dependencies !== undefined) patch.dependencies = write.dependencies
+  if (write.recurrence !== undefined) patch.recurrence = write.recurrence ?? undefined
+  if (write.timeEstimate !== undefined) patch.timeEstimate = write.timeEstimate ?? undefined
+  if (write.customFields !== undefined) patch.customFields = write.customFields
+  return patch
+}

--- a/packages/api/src/router.test.ts
+++ b/packages/api/src/router.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { FakeApi } from '../test/fakeApi'
+import { bearerAuth, handleHttp, tokenMatches, type HttpHost, type HttpRequest } from './router'
+
+const TOKEN = 'secret-token-0123456789'
+
+function request(method: string, path: string, extra: Partial<HttpRequest> = {}): HttpRequest {
+  return {
+    method,
+    path,
+    query: {},
+    headers: { authorization: `Bearer ${TOKEN}` },
+    body: undefined,
+    ...extra
+  }
+}
+
+describe('handleHttp', () => {
+  let api: FakeApi
+  let host: HttpHost
+
+  beforeEach(() => {
+    api = new FakeApi()
+    host = { api, info: { name: 'dotpm', version: '9.9.9' }, authorized: bearerAuth(() => TOKEN) }
+  })
+
+  it('answers health without a token', async () => {
+    const res = await handleHttp(request('GET', '/v1/health', { headers: {} }), host)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true, name: 'dotpm', version: '9.9.9' })
+  })
+
+  it('refuses everything else without the token', async () => {
+    const res = await handleHttp(request('GET', '/v1/projects', { headers: {} }), host)
+    expect(res.status).toBe(401)
+    expect(api.calls).toEqual([])
+  })
+
+  it('lists and reads projects and tasks', async () => {
+    expect((await handleHttp(request('GET', '/v1/projects'), host)).body).toEqual([
+      expect.objectContaining({ id: 'p1', title: 'Demo', taskCount: 2, doneCount: 1 })
+    ])
+    expect((await handleHttp(request('GET', '/v1/projects/p1'), host)).body).toMatchObject({
+      id: 'p1',
+      statuses: expect.any(Array)
+    })
+    const tasks = await handleHttp(request('GET', '/v1/projects/p1/tasks'), host)
+    expect((tasks.body as unknown[]).length).toBe(2)
+    expect((await handleHttp(request('GET', '/v1/tasks/t2'), host)).body).toMatchObject({ id: 't2', position: 1 })
+  })
+
+  it('maps client mistakes to statuses', async () => {
+    expect((await handleHttp(request('GET', '/v1/projects/nope'), host)).status).toBe(404)
+    expect((await handleHttp(request('GET', '/v1/nothing/here'), host)).status).toBe(404)
+    const bad = await handleHttp(request('POST', '/v1/projects/p1/tasks', { body: { title: '' } }), host)
+    expect(bad.status).toBe(400)
+    expect(bad.body).toEqual({ error: { code: 'invalid', message: 'title must not be empty' } })
+  })
+
+  it('creates, updates with If-Match, moves, archives and deletes', async () => {
+    const created = await handleHttp(
+      request('POST', '/v1/projects/p1/tasks', { body: { title: 'Third', due: '2030-01-02' } }),
+      host
+    )
+    expect(created.status).toBe(201)
+    expect(created.body).toMatchObject({ id: 't3', title: 'Third', due: '2030-01-02' })
+
+    const stale = await handleHttp(
+      request('PATCH', '/v1/tasks/t3', {
+        body: { status: 'done' },
+        headers: { authorization: `Bearer ${TOKEN}`, 'if-match': '"old"' }
+      }),
+      host
+    )
+    expect(stale.status).toBe(412)
+    const updated = await handleHttp(request('PATCH', '/v1/tasks/t3', { body: { status: 'done' } }), host)
+    expect(updated.body).toMatchObject({ status: 'done' })
+
+    await handleHttp(request('POST', '/v1/tasks/t3/move', { body: { parentId: 't1' } }), host)
+    expect(api.calls).toContain('moveTask t3 {"parentId":"t1"}')
+
+    expect((await handleHttp(request('POST', '/v1/tasks/t3/archive'), host)).body).toMatchObject({ archived: true })
+    expect(
+      (await handleHttp(request('POST', '/v1/tasks/t3/archive', { body: { archived: false } }), host)).body
+    ).toMatchObject({
+      archived: false
+    })
+
+    expect((await handleHttp(request('DELETE', '/v1/tasks/t3'), host)).status).toBe(204)
+    expect((await handleHttp(request('GET', '/v1/tasks/t3'), host)).status).toBe(404)
+  })
+
+  it('searches with the q parameter and pages changes by cursor', async () => {
+    const found = await handleHttp(request('GET', '/v1/search', { query: { q: 'sec', limit: '5' } }), host)
+    expect((found.body as Array<{ id: string }>).map((t) => t.id)).toEqual(['t2'])
+    expect(api.calls.at(-1)).toBe('searchTasks {"query":"sec","limit":5}')
+
+    expect((await handleHttp(request('GET', '/v1/changes', { query: { since: 'x' } }), host)).status).toBe(400)
+    await handleHttp(request('GET', '/v1/changes', { query: { since: '3' } }), host)
+    expect(api.calls.at(-1)).toBe('changes 3')
+  })
+
+  it('serves MCP on /mcp and rejects other methods there', async () => {
+    const init = await handleHttp(
+      request('POST', '/mcp', {
+        body: { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26' } }
+      }),
+      host
+    )
+    expect(init.status).toBe(200)
+    expect(init.body).toMatchObject({ id: 1, result: { protocolVersion: '2025-03-26', serverInfo: { name: 'dotpm' } } })
+    const note = await handleHttp(
+      request('POST', '/mcp', { body: { jsonrpc: '2.0', method: 'notifications/initialized' } }),
+      host
+    )
+    expect(note.status).toBe(202)
+    expect((await handleHttp(request('GET', '/mcp'), host)).status).toBe(405)
+    expect((await handleHttp(request('DELETE', '/mcp'), host)).status).toBe(204)
+  })
+})
+
+describe('tokenMatches', () => {
+  it('needs an exact, non-empty match', () => {
+    expect(tokenMatches('abc', 'abc')).toBe(true)
+    expect(tokenMatches('abd', 'abc')).toBe(false)
+    expect(tokenMatches('ab', 'abc')).toBe(false)
+    expect(tokenMatches(null, 'abc')).toBe(false)
+    expect(tokenMatches('', '')).toBe(false)
+  })
+})

--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -1,0 +1,146 @@
+import { ApiRequestError, ERROR_STATUS, type DomainApi } from './contract'
+import { handleMcp, type ServerInfo } from './mcp'
+import { parseTaskSearch } from './resources'
+
+export interface HttpRequest {
+  method: string
+  /** Pathname only, no query string. */
+  path: string
+  query: Record<string, string>
+  /** Lower-cased header names. */
+  headers: Record<string, string>
+  body: unknown
+}
+
+export interface HttpResponse {
+  status: number
+  body?: unknown
+  headers?: Record<string, string>
+}
+
+export interface HttpHost {
+  api: DomainApi
+  info: ServerInfo
+  authorized(req: HttpRequest): boolean
+}
+
+function json(status: number, body: unknown): HttpResponse {
+  return { status, body }
+}
+
+function error(code: keyof typeof ERROR_STATUS, message: string): HttpResponse {
+  return json(ERROR_STATUS[code], { error: { code, message } })
+}
+
+/** Matches `/v1/tasks/:id/move` style patterns, returning the named segments. */
+function match(pattern: string, path: string): Record<string, string> | null {
+  const want = pattern.split('/')
+  const have = path.split('/')
+  if (want.length !== have.length) return null
+  const params: Record<string, string> = {}
+  for (let i = 0; i < want.length; i++) {
+    if (want[i].startsWith(':')) {
+      if (!have[i]) return null
+      params[want[i].slice(1)] = decodeURIComponent(have[i])
+    } else if (want[i] !== have[i]) {
+      return null
+    }
+  }
+  return params
+}
+
+function bearer(req: HttpRequest): string | null {
+  const header = req.headers['authorization'] ?? ''
+  return header.startsWith('Bearer ') ? header.slice(7).trim() : null
+}
+
+/** Constant-time compare, so the token can't be guessed byte by byte through timing. */
+export function tokenMatches(presented: string | null, expected: string): boolean {
+  if (!presented || !expected || presented.length !== expected.length) return false
+  let diff = 0
+  for (let i = 0; i < expected.length; i++) diff |= presented.charCodeAt(i) ^ expected.charCodeAt(i)
+  return diff === 0
+}
+
+export function bearerAuth(token: () => string): (req: HttpRequest) => boolean {
+  return (req) => tokenMatches(bearer(req), token())
+}
+
+async function route(req: HttpRequest, host: HttpHost): Promise<HttpResponse> {
+  const { api } = host
+  const { method, path } = req
+  let p: Record<string, string> | null
+
+  if (path === '/mcp') {
+    if (method === 'POST') {
+      const result = await handleMcp(req.body, api, host.info)
+      return result === null ? { status: 202 } : json(200, result)
+    }
+    if (method === 'DELETE') return { status: 204 }
+    return { status: 405, headers: { allow: 'POST, DELETE' } }
+  }
+
+  if (path === '/v1/projects' && method === 'GET') return json(200, await api.listProjects())
+
+  if ((p = match('/v1/projects/:id', path)) && method === 'GET') return json(200, await api.getProject(p['id']))
+
+  if ((p = match('/v1/projects/:id/tasks', path))) {
+    if (method === 'GET') return json(200, await api.listTasks(p['id'], req.query['includeArchived'] === 'true'))
+    if (method === 'POST') return json(201, await api.createTask(p['id'], req.body))
+  }
+
+  if ((p = match('/v1/tasks/:id', path))) {
+    if (method === 'GET') return json(200, await api.getTask(p['id']))
+    if (method === 'PATCH') {
+      const expected = req.headers['if-match']?.replace(/^"|"$/g, '')
+      return json(200, await api.updateTask(p['id'], req.body, expected))
+    }
+    if (method === 'DELETE') {
+      await api.deleteTask(p['id'])
+      return { status: 204 }
+    }
+  }
+
+  if ((p = match('/v1/tasks/:id/move', path)) && method === 'POST') {
+    return json(200, await api.moveTask(p['id'], req.body))
+  }
+
+  if ((p = match('/v1/tasks/:id/archive', path)) && method === 'POST') {
+    const body = (req.body ?? {}) as { archived?: unknown }
+    return json(200, await api.archiveTask(p['id'], body.archived !== false))
+  }
+
+  if (path === '/v1/search' && method === 'GET') {
+    return json(
+      200,
+      await api.searchTasks(parseTaskSearch({ ...req.query, query: req.query['q'] ?? req.query['query'] }))
+    )
+  }
+
+  if (path === '/v1/changes' && method === 'GET') {
+    const since = req.query['since']
+    const cursor = since === undefined || since === '' ? null : Number(since)
+    if (cursor !== null && !Number.isInteger(cursor)) return error('invalid', 'since must be an integer cursor')
+    return json(200, await api.changes(cursor))
+  }
+
+  return error('not_found', `no route for ${method} ${path}`)
+}
+
+/**
+ * The whole HTTP surface, independent of any server: the host reads the request, hands
+ * it here, and writes whatever comes back. `/v1/health` needs no token.
+ */
+export async function handleHttp(req: HttpRequest, host: HttpHost): Promise<HttpResponse> {
+  if (req.path === '/v1/health' && req.method === 'GET') {
+    return json(200, { ok: true, name: host.info.name, version: host.info.version })
+  }
+  if (!host.authorized(req)) return error('unauthorized', 'missing or wrong bearer token')
+  try {
+    return await route(req, host)
+  } catch (err: unknown) {
+    if (err instanceof ApiRequestError) return error(err.code, err.message)
+    console.error('[PM] api request failed', err)
+    return json(500, { error: { code: 'internal', message: 'request failed; see the developer console' } })
+  }
+}

--- a/packages/api/test/fakeApi.ts
+++ b/packages/api/test/fakeApi.ts
@@ -1,0 +1,154 @@
+import { DEFAULT_PRIORITIES, DEFAULT_STATUSES, makeProject, makeTask, type Project } from '@dotpm/core'
+import type {
+  Change,
+  ChangePage,
+  DomainApi,
+  ProjectResource,
+  ProjectSummary,
+  TaskResource,
+  TaskSearch
+} from '../src/contract'
+import { ApiRequestError } from '../src/contract'
+import {
+  parseTaskCreate,
+  parseTaskMove,
+  parseTaskWrite,
+  taskPatch,
+  taskResources,
+  toTaskResource
+} from '../src/resources'
+
+const CONFIG = {
+  statuses: DEFAULT_STATUSES,
+  priorities: DEFAULT_PRIORITIES,
+  priorityIcons: 'chevrons' as const,
+  customFields: [],
+  defaultView: 'table' as const,
+  autoSchedule: false,
+  pullForwardOnEarlyFinish: false,
+  autoArchiveDays: 0,
+  showSubtreeConnections: true,
+  lineBorders: 'none' as const,
+  kanbanShowSubtasks: false,
+  kanbanShowDescriptionPreview: false
+}
+
+/** An in-memory host for testing the transports: one project, tasks as a flat list. */
+export class FakeApi implements DomainApi {
+  project: Project = makeProject('Demo', 'Projects/Demo/Demo.md')
+  calls: string[] = []
+  changeLog: Change[] = []
+
+  constructor() {
+    this.project.id = 'p1'
+    this.project.tasks = [
+      makeTask({ id: 't1', title: 'First' }),
+      makeTask({ id: 't2', title: 'Second', status: 'done' })
+    ]
+  }
+
+  private summary(): ProjectSummary {
+    return {
+      id: this.project.id,
+      path: this.project.filePath,
+      title: this.project.title,
+      icon: this.project.icon,
+      color: this.project.color,
+      parentId: null,
+      taskCount: this.project.tasks.length,
+      doneCount: this.project.tasks.filter((t) => t.status === 'done').length
+    }
+  }
+
+  private find(taskId: string): TaskResource {
+    const index = this.project.tasks.findIndex((t) => t.id === taskId)
+    if (index < 0) throw new ApiRequestError('not_found', `task ${taskId} not found`)
+    return toTaskResource(this.project.tasks[index], this.project.id, null, index)
+  }
+
+  private checkProject(projectId: string): void {
+    if (projectId !== this.project.id) throw new ApiRequestError('not_found', `project ${projectId} not found`)
+  }
+
+  async listProjects(): Promise<ProjectSummary[]> {
+    this.calls.push('listProjects')
+    return [this.summary()]
+  }
+
+  async getProject(projectId: string): Promise<ProjectResource> {
+    this.calls.push(`getProject ${projectId}`)
+    this.checkProject(projectId)
+    return {
+      ...this.summary(),
+      description: this.project.description,
+      teamMembers: [],
+      customFields: [],
+      statuses: CONFIG.statuses,
+      priorities: CONFIG.priorities,
+      createdAt: this.project.createdAt,
+      updatedAt: this.project.updatedAt
+    }
+  }
+
+  async listTasks(projectId: string, includeArchived = false): Promise<TaskResource[]> {
+    this.calls.push(`listTasks ${projectId}`)
+    this.checkProject(projectId)
+    return taskResources(this.project, this.project.id, includeArchived)
+  }
+
+  async getTask(taskId: string): Promise<TaskResource> {
+    this.calls.push(`getTask ${taskId}`)
+    return this.find(taskId)
+  }
+
+  async searchTasks(search: TaskSearch): Promise<TaskResource[]> {
+    this.calls.push(`searchTasks ${JSON.stringify(search)}`)
+    const q = search.query?.toLowerCase()
+    return taskResources(this.project, this.project.id, true).filter((t) => !q || t.title.toLowerCase().includes(q))
+  }
+
+  async createTask(projectId: string, input: unknown): Promise<TaskResource> {
+    this.calls.push(`createTask ${projectId}`)
+    this.checkProject(projectId)
+    const create = parseTaskCreate(input, CONFIG)
+    const task = makeTask({ id: `t${this.project.tasks.length + 1}`, ...taskPatch(create) })
+    this.project.tasks.push(task)
+    return this.find(task.id)
+  }
+
+  async updateTask(taskId: string, input: unknown, expectedUpdatedAt?: string): Promise<TaskResource> {
+    this.calls.push(`updateTask ${taskId}${expectedUpdatedAt ? ` if ${expectedUpdatedAt}` : ''}`)
+    const current = this.find(taskId)
+    if (expectedUpdatedAt !== undefined && expectedUpdatedAt !== current.updatedAt) {
+      throw new ApiRequestError('conflict', 'task changed')
+    }
+    const write = parseTaskWrite(input, CONFIG)
+    Object.assign(this.project.tasks[current.position], taskPatch(write), { updatedAt: '2030-01-01T00:00:00.000Z' })
+    return this.find(taskId)
+  }
+
+  async moveTask(taskId: string, input: unknown): Promise<TaskResource> {
+    this.calls.push(`moveTask ${taskId} ${JSON.stringify(parseTaskMove(input))}`)
+    return this.find(taskId)
+  }
+
+  async archiveTask(taskId: string, archived: boolean): Promise<TaskResource> {
+    this.calls.push(`archiveTask ${taskId} ${archived}`)
+    this.project.tasks[this.find(taskId).position].archived = archived
+    return this.find(taskId)
+  }
+
+  async deleteTask(taskId: string): Promise<void> {
+    this.calls.push(`deleteTask ${taskId}`)
+    this.project.tasks.splice(this.find(taskId).position, 1)
+  }
+
+  async changes(since: number | null): Promise<ChangePage> {
+    this.calls.push(`changes ${since}`)
+    return {
+      cursor: this.changeLog.length,
+      changes: this.changeLog.filter((c) => since !== null && c.seq > since),
+      reset: false
+    }
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -235,6 +235,10 @@ export interface PMSettings {
   collapsedTasks: Record<string, string[]>
   /** Paths of projects whose sub-projects are collapsed in the project list. */
   collapsedProjects: string[]
+  /** A localhost HTTP and MCP server for other tools on this machine. Desktop only. */
+  localApiEnabled: boolean
+  localApiPort: number
+  localApiToken: string
 }
 
 export const DEFAULT_STATUSES: StatusConfig[] = [
@@ -252,6 +256,14 @@ export const DEFAULT_PRIORITIES: PriorityConfig[] = [
   { id: 'medium', label: 'Medium', color: '#8a94a0', icon: '' },
   { id: 'low', label: 'Low', color: '#79b58d', icon: '' }
 ]
+
+/**
+ * The band a vault's default local API port is drawn from. It sits clear of the numbers
+ * other Obsidian plugins take by default, and below every operating system's ephemeral
+ * range, so an outgoing connection can never be holding the port when the server starts.
+ */
+export const LOCAL_API_PORT_BASE = 27140
+export const LOCAL_API_PORT_SPAN = 100
 
 export const DEFAULT_SETTINGS: PMSettings = {
   projectsFolder: 'Projects',
@@ -283,7 +295,10 @@ export const DEFAULT_SETTINGS: PMSettings = {
   projectFilters: {},
   scopeViews: {},
   collapsedTasks: {},
-  collapsedProjects: []
+  collapsedProjects: [],
+  localApiEnabled: false,
+  localApiPort: LOCAL_API_PORT_BASE,
+  localApiToken: ''
 }
 
 export function makeId(): string {

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { dedupePeople, displayName, dueUrgency, priorityIcon } from './utils'
-import { makeTask, DEFAULT_PRIORITIES, type PriorityConfig, type StatusConfig } from './types'
+import { dedupePeople, displayName, dueUrgency, localApiPortFor, priorityIcon } from './utils'
+import {
+  makeTask,
+  DEFAULT_PRIORITIES,
+  LOCAL_API_PORT_BASE,
+  LOCAL_API_PORT_SPAN,
+  type PriorityConfig,
+  type StatusConfig
+} from './types'
 import { today } from './dates'
 
 const statuses: StatusConfig[] = [
@@ -170,5 +177,23 @@ describe('dedupePeople with a key function', () => {
 
   it('collapses two spellings the key function calls the same', () => {
     expect(dedupePeople(['[[People/Jane]]', 'Jane'], keyOf)).toEqual(['[[People/Jane]]'])
+  })
+})
+
+describe('localApiPortFor', () => {
+  it('stays inside the band', () => {
+    for (const name of ['', 'Work', 'Personal notes', 'a'.repeat(200), '仕事', 'Vault/With:Odd*Chars']) {
+      const port = localApiPortFor(name)
+      expect(port).toBeGreaterThanOrEqual(LOCAL_API_PORT_BASE)
+      expect(port).toBeLessThan(LOCAL_API_PORT_BASE + LOCAL_API_PORT_SPAN)
+    }
+  })
+
+  it('gives one vault the same port every time', () => {
+    expect(localApiPortFor('Work')).toBe(localApiPortFor('Work'))
+  })
+
+  it('gives two vaults different ports', () => {
+    expect(localApiPortFor('Work')).not.toBe(localApiPortFor('Personal'))
   })
 })

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,5 +1,5 @@
 import type { DueUrgency, Task, StatusConfig, PriorityConfig, TaskPriority, PriorityIconSet } from './types'
-import { PRIORITY_ICON_SETS } from './types'
+import { LOCAL_API_PORT_BASE, LOCAL_API_PORT_SPAN, PRIORITY_ICON_SETS } from './types'
 import { today, parsePlainDate } from './dates'
 
 export function displayName(raw: string): string {
@@ -40,6 +40,17 @@ export function stringToColor(s: string): string {
   let hash = 0
   for (let i = 0; i < s.length; i++) hash = s.charCodeAt(i) + ((hash << 5) - hash)
   return `hsl(${Math.abs(hash) % 360}, 55%, 45%)`
+}
+
+/**
+ * The port a vault's local API listens on until the user picks another. Two vaults open at
+ * once would otherwise want the same one, and deriving it from the name gives each the same
+ * port on every restart, so a client configured once keeps reaching it.
+ */
+export function localApiPortFor(vaultName: string): number {
+  let hash = 0
+  for (let i = 0; i < vaultName.length; i++) hash = vaultName.charCodeAt(i) + ((hash << 5) - hash)
+  return LOCAL_API_PORT_BASE + (Math.abs(hash) % LOCAL_API_PORT_SPAN)
 }
 
 export function isTerminalStatus(status: string, statuses: StatusConfig[]): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@2bad/tsconfig':
         specifier: 4.0.0
         version: 4.0.0(typescript@6.0.3)
+      '@dotpm/api':
+        specifier: workspace:*
+        version: link:packages/api
       '@dotpm/core':
         specifier: workspace:*
         version: link:packages/core
@@ -69,6 +72,12 @@ importers:
       yaml:
         specifier: 2.9.0
         version: 2.9.0
+
+  packages/api:
+    dependencies:
+      '@dotpm/core':
+        specifier: workspace:*
+        version: link:../core
 
   packages/core:
     dependencies:

--- a/src/api/ChangeLog.ts
+++ b/src/api/ChangeLog.ts
@@ -1,0 +1,84 @@
+import type { Project, Task } from '@dotpm/core'
+import type { Change, ChangePage } from '@dotpm/api'
+
+interface Snapshot {
+  projectId: string
+  updatedAt: string
+  /** Task id to a fingerprint of what a client would see for it. */
+  tasks: Map<string, string>
+}
+
+function fingerprints(tasks: Task[], parentId: string | null, out: Map<string, string>): void {
+  tasks.forEach((task, position) => {
+    out.set(task.id, `${task.updatedAt}|${parentId ?? ''}|${position}|${task.archived ? 'a' : ''}`)
+    fingerprints(task.subtasks, task.id, out)
+  })
+}
+
+/**
+ * A bounded log of what changed, for clients polling `changes`. It learns about
+ * changes by comparing a project against the last time it saw it, so it only covers
+ * projects that have been loaded in this session.
+ */
+export class ChangeLog {
+  private seq = 0
+  private entries: Change[] = []
+  private snapshots = new Map<string, Snapshot>()
+
+  constructor(private readonly capacity = 1000) {}
+
+  get cursor(): number {
+    return this.seq
+  }
+
+  /**
+   * Compares a project with its last snapshot and records the differences. A project
+   * seen for the first time records nothing unless `announce` is set, since a client
+   * that never fetched it has nothing to update.
+   */
+  observe(project: Project, announce: boolean): void {
+    const next: Snapshot = { projectId: project.id, updatedAt: project.updatedAt, tasks: new Map() }
+    fingerprints(project.tasks, null, next.tasks)
+    const prev = this.snapshots.get(project.filePath)
+    this.snapshots.set(project.filePath, next)
+    if (!prev) {
+      if (announce) this.push('project', 'upsert', project.id, project.id)
+      return
+    }
+    if (prev.updatedAt !== next.updatedAt || prev.projectId !== next.projectId) {
+      this.push('project', 'upsert', project.id, project.id)
+    }
+    for (const [id, fingerprint] of next.tasks) {
+      if (prev.tasks.get(id) !== fingerprint) this.push('task', 'upsert', id, project.id)
+    }
+    for (const id of prev.tasks.keys()) {
+      if (!next.tasks.has(id)) this.push('task', 'delete', id, project.id)
+    }
+  }
+
+  /** The project at this path is gone: its tasks go with it. */
+  forget(path: string): void {
+    const prev = this.snapshots.get(path)
+    if (!prev) return
+    this.snapshots.delete(path)
+    for (const id of prev.tasks.keys()) this.push('task', 'delete', id, prev.projectId)
+    this.push('project', 'delete', prev.projectId, prev.projectId)
+  }
+
+  trackedPaths(): string[] {
+    return [...this.snapshots.keys()]
+  }
+
+  since(cursor: number | null): ChangePage {
+    if (cursor === null) return { cursor: this.seq, changes: [], reset: false }
+    const oldest = this.entries[0]?.seq ?? this.seq + 1
+    if (cursor < oldest - 1) return { cursor: this.seq, changes: [], reset: true }
+    return { cursor: this.seq, changes: this.entries.filter((change) => change.seq > cursor), reset: false }
+  }
+
+  private push(kind: Change['kind'], op: Change['op'], id: string, projectId: string): void {
+    this.seq++
+    this.entries.push({ seq: this.seq, at: new Date().toISOString(), kind, op, id, projectId })
+    if (this.entries.length > this.capacity) this.entries.splice(0, this.entries.length - this.capacity)
+  }
+}

--- a/src/api/LocalApi.test.ts
+++ b/src/api/LocalApi.test.ts
@@ -1,0 +1,141 @@
+import type { App } from 'obsidian'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { DEFAULT_SETTINGS, makeTask, type PMSettings } from '@dotpm/core'
+import { ApiRequestError } from '@dotpm/api'
+import { makeFakeApp } from '../../test/fakeVault'
+import type PMPlugin from '../main'
+import { ProjectStore } from '../store/ProjectStore'
+import { VaultIndex } from '../store/VaultIndex'
+import { LocalApi } from './LocalApi'
+
+const SETTINGS: PMSettings = { ...DEFAULT_SETTINGS, autoSchedule: false }
+
+function newApi(): { api: LocalApi; store: ProjectStore; index: VaultIndex; refreshes: () => number } {
+  const { app } = makeFakeApp({ liveMetadataCache: true })
+  const typed = app as unknown as App
+  const index = new VaultIndex(typed, () => SETTINGS)
+  const store = new ProjectStore(typed, () => SETTINGS, index)
+  let refreshed = 0
+  const plugin = {
+    app: typed,
+    index,
+    store,
+    settings: SETTINGS,
+    refreshViews: () => {
+      refreshed++
+    }
+  } as unknown as PMPlugin
+  return { api: new LocalApi(plugin), store, index, refreshes: () => refreshed }
+}
+
+async function rejectsWith(promise: Promise<unknown>, code: string): Promise<void> {
+  await expect(promise).rejects.toBeInstanceOf(ApiRequestError)
+  await expect(promise).rejects.toMatchObject({ code })
+}
+
+describe('LocalApi over the vault', () => {
+  let api: LocalApi
+  let store: ProjectStore
+  let index: VaultIndex
+  let refreshes: () => number
+  let projectId: string
+
+  beforeEach(async () => {
+    ;({ api, store, index, refreshes } = newApi())
+    const project = await store.createProject('Roadmap', 'Projects')
+    await store.insertTask(project, makeTask({ id: 'a', title: 'Alpha', due: '2030-02-01' }))
+    await store.insertTask(project, makeTask({ id: 'b', title: 'Beta' }))
+    await store.insertTask(project, makeTask({ id: 'a1', title: 'Alpha child' }), 'a')
+    index.build()
+    projectId = project.id
+  })
+
+  it('lists projects from the index and reads them with their config', async () => {
+    const projects = await api.listProjects()
+    expect(projects).toEqual([expect.objectContaining({ id: projectId, title: 'Roadmap', taskCount: 3, doneCount: 0 })])
+    const project = await api.getProject(projectId)
+    expect(project.statuses.map((s) => s.id)).toEqual(SETTINGS.statuses.map((s) => s.id))
+    await rejectsWith(api.getProject('missing'), 'not_found')
+  })
+
+  it('reads tasks with parents and positions', async () => {
+    const tasks = await api.listTasks(projectId)
+    expect(tasks.map((t) => [t.id, t.parentId, t.position])).toEqual([
+      ['a', null, 0],
+      ['a1', 'a', 0],
+      ['b', null, 1]
+    ])
+    expect(await api.getTask('a1')).toMatchObject({ id: 'a1', projectId, parentId: 'a', due: '' })
+    await rejectsWith(api.getTask('nope'), 'not_found')
+  })
+
+  it('searches through the index', async () => {
+    expect((await api.searchTasks({ query: 'alpha' })).map((t) => t.id)).toEqual(['a', 'a1'])
+    expect((await api.searchTasks({ query: 'alpha', limit: 1 })).map((t) => t.id)).toEqual(['a'])
+    expect((await api.searchTasks({ status: 'todo', projectId })).length).toBe(3)
+  })
+
+  it('creates and updates through the store and refreshes the views', async () => {
+    const created = await api.createTask(projectId, {
+      title: 'Gamma',
+      parentId: 'b',
+      priority: 'high',
+      description: 'Body text'
+    })
+    expect(created).toMatchObject({ title: 'Gamma', parentId: 'b', priority: 'high', position: 0 })
+    expect(await api.getTask(created.id)).toMatchObject({ title: 'Gamma', description: 'Body text' })
+    expect((await api.listTasks(projectId)).find((task) => task.id === created.id)?.description).toBe('Body text')
+
+    await rejectsWith(api.createTask(projectId, { title: 'Orphan', parentId: 'nope' }), 'not_found')
+    await rejectsWith(api.createTask(projectId, { title: 'Bad', status: 'nope' }), 'invalid')
+
+    const before = await api.getTask('a')
+    await rejectsWith(api.updateTask('a', { title: 'Alpha!' }, 'stale'), 'conflict')
+    const updated = await api.updateTask('a', { title: 'Alpha!', status: 'done' }, before.updatedAt)
+    expect(updated).toMatchObject({ title: 'Alpha!', status: 'done' })
+    expect(updated.completed).not.toBe('')
+    expect(refreshes()).toBeGreaterThanOrEqual(2)
+  })
+
+  it('moves between parents, reorders among siblings, and refuses cycles', async () => {
+    expect(await api.moveTask('b', { parentId: 'a' })).toMatchObject({ parentId: 'a', position: 1 })
+    expect(await api.moveTask('b', { before: 'a1' })).toMatchObject({ parentId: 'a', position: 0 })
+    await rejectsWith(api.moveTask('a', { parentId: 'a1' }), 'invalid')
+    await rejectsWith(api.moveTask('a1', { after: 'zzz' }), 'not_found')
+    expect(await api.moveTask('a1', { parentId: null })).toMatchObject({ parentId: null, position: 1 })
+  })
+
+  it('archives, unarchives and deletes', async () => {
+    expect(await api.archiveTask('b', true)).toMatchObject({ archived: true })
+    expect((await api.listTasks(projectId)).map((t) => t.id)).toEqual(['a', 'a1'])
+    expect((await api.listTasks(projectId, true)).map((t) => t.id)).toEqual(['a', 'a1', 'b'])
+    expect(await api.archiveTask('b', false)).toMatchObject({ archived: false })
+    await api.deleteTask('a')
+    expect((await api.listTasks(projectId)).map((t) => t.id)).toEqual(['b'])
+    await rejectsWith(api.deleteTask('a'), 'not_found')
+  })
+
+  it('records what changed for pollers', async () => {
+    const off = api.attach()
+    const start = await api.changes(null)
+    expect(start).toEqual({ cursor: expect.any(Number), changes: [], reset: false })
+
+    await api.listTasks(projectId)
+    await api.updateTask('b', { title: 'Beta 2' })
+    await api.deleteTask('a1')
+    await new Promise((resolve) => window.setTimeout(resolve, 0))
+
+    const page = await api.changes(start.cursor)
+    expect(page.reset).toBe(false)
+    expect(page.changes.map((c) => [c.kind, c.op, c.id])).toEqual(
+      expect.arrayContaining([
+        ['task', 'upsert', 'b'],
+        ['task', 'delete', 'a1']
+      ])
+    )
+    expect(page.changes.every((c) => c.projectId === projectId)).toBe(true)
+    expect((await api.changes(page.cursor)).changes).toEqual([])
+    expect((await api.changes(-5)).reset).toBe(true)
+    off()
+  })
+})

--- a/src/api/LocalApi.ts
+++ b/src/api/LocalApi.ts
@@ -1,0 +1,233 @@
+import type { Project, Task } from '@dotpm/core'
+import { displayName, findParentId, findTaskById, flattenTasks, makeTask } from '@dotpm/core'
+import {
+  ApiRequestError,
+  parseTaskCreate,
+  parseTaskMove,
+  parseTaskWrite,
+  taskPatch,
+  taskResources,
+  toProjectResource,
+  toTaskResource,
+  type ChangePage,
+  type DomainApi,
+  type ProjectResource,
+  type ProjectSummary,
+  type TaskResource,
+  type TaskSearch,
+  type TaskWrite
+} from '@dotpm/api'
+import type PMPlugin from '../main'
+import type { ProjectRef } from '../store'
+import { ChangeLog } from './ChangeLog'
+
+const SCHEDULE_FIELDS: Array<keyof TaskWrite> = ['start', 'due', 'dependencies', 'status', 'type']
+
+function notFound(what: string, id: string): never {
+  throw new ApiRequestError('not_found', `${what} ${id} not found`)
+}
+
+/** The contract over this vault: ids resolve through the index, data through the store. */
+export class LocalApi implements DomainApi {
+  readonly changeLog = new ChangeLog()
+  /** Task id to project path for every task served so far. The index learns about a new
+   * file only once the metadata cache has parsed it, and a client that just created a
+   * task reads it back before then. */
+  private readonly known = new Map<string, string>()
+
+  constructor(private readonly plugin: PMPlugin) {}
+
+  /** Feeds the change log from the store and the index. Returns the unsubscribe function. */
+  attach(): () => void {
+    const offStore = this.plugin.store.onProjectChanged((path) => {
+      void (async () => {
+        const project = await this.plugin.store.loadProjectByPath(path)
+        if (project) this.changeLog.observe(project, true)
+      })()
+    })
+    const offIndex = this.plugin.index.onChange(() => {
+      for (const path of this.changeLog.trackedPaths()) {
+        if (!this.plugin.index.projectRef(path)) this.changeLog.forget(path)
+      }
+    })
+    return () => {
+      offStore()
+      offIndex()
+    }
+  }
+
+  async listProjects(): Promise<ProjectSummary[]> {
+    return this.plugin.index.projectRefs().map((ref) => this.summary(ref))
+  }
+
+  async getProject(projectId: string): Promise<ProjectResource> {
+    const ref = this.refById(projectId)
+    const project = await this.load(ref)
+    return toProjectResource(project, this.plugin.store.configFor(project), this.summary(ref))
+  }
+
+  async listTasks(projectId: string, includeArchived = false): Promise<TaskResource[]> {
+    const ref = this.refById(projectId)
+    const project = await this.load(ref)
+    await Promise.all(flattenTasks(project.tasks).map(({ task }) => this.plugin.store.loadTaskBody(task)))
+    return taskResources(project, ref.id, includeArchived)
+  }
+
+  async getTask(taskId: string): Promise<TaskResource> {
+    const { project, ref, task } = await this.locate(taskId)
+    return this.serve(project, ref, task)
+  }
+
+  async searchTasks(search: TaskSearch): Promise<TaskResource[]> {
+    const query = search.query?.toLowerCase()
+    const projectPath = search.projectId ? this.refById(search.projectId).path : undefined
+    const assignee = search.assignee ? displayName(search.assignee).toLowerCase() : undefined
+    const limit = search.limit ?? 50
+    const hits = this.plugin.index.allTaskRefs().filter((ref) => {
+      if (ref.archived && !search.includeArchived) return false
+      if (projectPath && ref.projectPath !== projectPath) return false
+      if (search.status && ref.status !== search.status) return false
+      if (query && !ref.title.toLowerCase().includes(query)) return false
+      if (assignee && !ref.assignees.some((raw) => displayName(raw).toLowerCase() === assignee)) return false
+      return true
+    })
+    const out: TaskResource[] = []
+    for (const hit of hits) {
+      if (out.length >= limit) break
+      if (!hit.projectPath) continue
+      const ref = this.plugin.index.projectRef(hit.projectPath)
+      if (!ref) continue
+      const project = await this.load(ref)
+      const task = findTaskById(project, hit.id)
+      if (task) out.push(await this.serve(project, ref, task))
+    }
+    return out
+  }
+
+  async createTask(projectId: string, input: unknown): Promise<TaskResource> {
+    const ref = this.refById(projectId)
+    const project = await this.load(ref)
+    const create = parseTaskCreate(input, this.plugin.store.configFor(project))
+    if (create.parentId && !findTaskById(project, create.parentId)) notFound('parent task', create.parentId)
+    const task = makeTask(taskPatch(create))
+    await this.plugin.store.insertTask(project, task, create.parentId ?? null)
+    this.known.set(task.id, project.filePath)
+    await this.plugin.store.scheduleAfterChange(project, task.id)
+    this.plugin.refreshViews()
+    return this.serve(project, ref, this.taskOf(project, task.id))
+  }
+
+  async updateTask(taskId: string, input: unknown, expectedUpdatedAt?: string): Promise<TaskResource> {
+    const { project, ref, task } = await this.locate(taskId)
+    if (expectedUpdatedAt !== undefined && expectedUpdatedAt !== task.updatedAt) {
+      throw new ApiRequestError('conflict', `task ${taskId} changed at ${task.updatedAt}`)
+    }
+    const write = parseTaskWrite(input, this.plugin.store.configFor(project))
+    await this.plugin.store.updateTask(project, taskId, taskPatch(write))
+    if (SCHEDULE_FIELDS.some((field) => write[field] !== undefined)) {
+      await this.plugin.store.scheduleAfterChange(project, taskId)
+    }
+    this.plugin.refreshViews()
+    return this.serve(project, ref, this.taskOf(project, taskId))
+  }
+
+  async moveTask(taskId: string, input: unknown): Promise<TaskResource> {
+    const move = parseTaskMove(input)
+    const located = await this.locate(taskId)
+    let { project, ref } = located
+    const store = this.plugin.store
+
+    if (move.projectId !== undefined && move.projectId !== ref.id) {
+      const targetRef = this.refById(move.projectId)
+      const target = await this.load(targetRef)
+      const parentId = move.parentId ?? null
+      if (parentId && !findTaskById(target, parentId)) notFound('parent task', parentId)
+      await store.moveTaskToProject(project, target, taskId, parentId)
+      project = target
+      ref = targetRef
+    } else if (move.parentId !== undefined && move.parentId !== findParentId(project, taskId)) {
+      if (move.parentId && !findTaskById(project, move.parentId)) notFound('parent task', move.parentId)
+      if (move.parentId && this.inSubtree(located.task, move.parentId)) {
+        throw new ApiRequestError('invalid', 'a task cannot be moved under itself')
+      }
+      await store.moveTask(project, taskId, move.parentId)
+    }
+
+    const sibling = move.before ?? move.after
+    if (sibling) {
+      if (!findTaskById(project, sibling)) notFound('sibling task', sibling)
+      if (findParentId(project, sibling) !== findParentId(project, taskId)) {
+        throw new ApiRequestError('invalid', 'before and after must name a sibling; pass parentId to re-parent first')
+      }
+      await store.reorderTask(project, taskId, sibling, move.before ? 'before' : 'after')
+    }
+    this.plugin.refreshViews()
+    return this.serve(project, ref, this.taskOf(project, taskId))
+  }
+
+  async archiveTask(taskId: string, archived: boolean): Promise<TaskResource> {
+    const { project, ref, task } = await this.locate(taskId)
+    if (archived && !task.archived) await this.plugin.store.archiveTask(project, taskId)
+    if (!archived && task.archived) await this.plugin.store.unarchiveTask(project, taskId)
+    this.plugin.refreshViews()
+    return this.serve(project, ref, this.taskOf(project, taskId))
+  }
+
+  async deleteTask(taskId: string): Promise<void> {
+    const { project } = await this.locate(taskId)
+    await this.plugin.store.deleteTask(project, taskId)
+    this.plugin.refreshViews()
+  }
+
+  async changes(since: number | null): Promise<ChangePage> {
+    return this.changeLog.since(since)
+  }
+
+  private refById(projectId: string): ProjectRef {
+    return this.plugin.index.projectRefs().find((ref) => ref.id === projectId) ?? notFound('project', projectId)
+  }
+
+  private summary(ref: ProjectRef): ProjectSummary {
+    const counts = this.plugin.index.counts(ref)
+    return {
+      id: ref.id,
+      path: ref.path,
+      title: ref.title,
+      icon: ref.icon,
+      color: ref.color,
+      parentId: this.plugin.index.parentOf(ref.path)?.id ?? null,
+      taskCount: counts.total,
+      doneCount: counts.done
+    }
+  }
+
+  private async load(ref: ProjectRef): Promise<Project> {
+    const project = (await this.plugin.store.loadProjectByPath(ref.path)) ?? notFound('project', ref.id)
+    this.changeLog.observe(project, false)
+    for (const { task } of flattenTasks(project.tasks)) this.known.set(task.id, project.filePath)
+    return project
+  }
+
+  private async locate(taskId: string): Promise<{ project: Project; ref: ProjectRef; task: Task }> {
+    const path = this.plugin.index.task(taskId)?.projectPath ?? this.known.get(taskId) ?? notFound('task', taskId)
+    const ref = this.plugin.index.projectRef(path) ?? notFound('task', taskId)
+    const project = await this.load(ref)
+    return { project, ref, task: this.taskOf(project, taskId) }
+  }
+
+  private taskOf(project: Project, taskId: string): Task {
+    return findTaskById(project, taskId) ?? notFound('task', taskId)
+  }
+
+  /** The task as a client sees it, with its note body loaded. */
+  private async serve(project: Project, ref: ProjectRef, task: Task): Promise<TaskResource> {
+    await this.plugin.store.loadTaskBody(task)
+    const parentId = findParentId(project, task.id)
+    const siblings = parentId ? (findTaskById(project, parentId)?.subtasks ?? []) : project.tasks
+    return toTaskResource(task, ref.id, parentId, siblings.indexOf(task))
+  }
+
+  private inSubtree(root: Task, id: string): boolean {
+    return root.id === id || root.subtasks.some((sub) => this.inSubtree(sub, id))
+  }
+}

--- a/src/api/LocalApiServer.ts
+++ b/src/api/LocalApiServer.ts
@@ -1,0 +1,117 @@
+/// <reference types="node" />
+import { handleHttp, type HttpHost } from '@dotpm/api'
+
+type HttpModule = typeof import('node:http')
+type Server = import('node:http').Server
+type IncomingMessage = import('node:http').IncomingMessage
+type ServerResponse = import('node:http').ServerResponse
+
+const MAX_BODY_BYTES = 1024 * 1024
+
+export function generateToken(): string {
+  const bytes = new Uint8Array(24)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+/**
+ * The localhost server in front of `handleHttp`. Node's `http` is reached through the
+ * desktop app's `require`, so this file loads on mobile but `start` refuses there.
+ */
+export class LocalApiServer {
+  private server: Server | null = null
+  private boundPort = 0
+
+  constructor(
+    private readonly host: HttpHost,
+    private readonly port: () => number
+  ) {}
+
+  get running(): boolean {
+    return this.server !== null
+  }
+
+  get address(): string | null {
+    return this.server ? `http://127.0.0.1:${this.boundPort}` : null
+  }
+
+  async start(): Promise<void> {
+    if (this.server) return
+    const nodeRequire = (window as Window & { require?: (id: string) => unknown }).require
+    if (!nodeRequire) throw new Error('the local API needs the desktop app')
+    const http = nodeRequire('http') as HttpModule
+    const server = http.createServer((req, res) => {
+      void this.respond(req, res)
+    })
+    const port = this.port()
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(port, '127.0.0.1', () => {
+        server.off('error', reject)
+        resolve()
+      })
+    })
+    this.server = server
+    this.boundPort = port
+  }
+
+  async stop(): Promise<void> {
+    const server = this.server
+    if (!server) return
+    this.server = null
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve())
+      server.closeAllConnections()
+    })
+  }
+
+  async restart(): Promise<void> {
+    await this.stop()
+    await this.start()
+  }
+
+  private async respond(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+    const decoder = new TextDecoder()
+    let raw = ''
+    let size = 0
+    for await (const chunk of req as AsyncIterable<Uint8Array>) {
+      size += chunk.byteLength
+      if (size > MAX_BODY_BYTES) {
+        res.writeHead(413).end()
+        return
+      }
+      raw += decoder.decode(chunk, { stream: true })
+    }
+    raw += decoder.decode()
+    let body: unknown
+    if (raw.trim()) {
+      try {
+        body = JSON.parse(raw)
+      } catch {
+        this.write(res, 400, { error: { code: 'invalid', message: 'body is not valid JSON' } })
+        return
+      }
+    }
+    const headers: Record<string, string> = {}
+    for (const [name, value] of Object.entries(req.headers)) {
+      headers[name] = Array.isArray(value) ? value.join(', ') : (value ?? '')
+    }
+    const response = await handleHttp(
+      { method: req.method ?? 'GET', path: url.pathname, query: Object.fromEntries(url.searchParams), headers, body },
+      this.host
+    )
+    this.write(res, response.status, response.body, response.headers)
+  }
+
+  private write(res: ServerResponse, status: number, body: unknown, extra: Record<string, string> = {}): void {
+    const payload = body === undefined ? '' : JSON.stringify(body)
+    res.writeHead(status, {
+      'content-type': 'application/json',
+      'content-length': String(new TextEncoder().encode(payload).byteLength),
+      'cache-control': 'no-store',
+      ...extra
+    })
+    res.end(payload)
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
-import { MarkdownView, Plugin, Notice } from 'obsidian'
+import { MarkdownView, Notice, Platform, Plugin } from 'obsidian'
+import { bearerAuth } from '@dotpm/api'
 import {
   DEFAULT_SETTINGS,
   makeDefaultFilter,
@@ -8,7 +9,8 @@ import {
   flattenTasks,
   findTask,
   dedupePeople,
-  displayName
+  displayName,
+  localApiPortFor
 } from '@dotpm/core'
 import {
   matchPersonNotes,
@@ -43,6 +45,8 @@ import { Notifier } from './components/Notifier'
 import { AutoArchiver } from './components/AutoArchiver'
 import { IdRepair } from './components/IdRepair'
 import { migrateProjects, migrateProjectLayout } from './migration'
+import { LocalApi } from './api/LocalApi'
+import { generateToken, LocalApiServer } from './api/LocalApiServer'
 
 export default class PMPlugin extends Plugin {
   settings: PMSettings = { ...DEFAULT_SETTINGS }
@@ -52,6 +56,7 @@ export default class PMPlugin extends Plugin {
   autoArchiver!: AutoArchiver
   idRepair!: IdRepair
   router!: PMViewRouter
+  localApi!: LocalApiServer
   /** Paths deliberately sent to the markdown editor, which the swap then leaves alone. */
   private markdownEscapes = new Set<string>()
   private viewRefreshScheduled = false
@@ -95,6 +100,16 @@ export default class PMPlugin extends Plugin {
     this.autoArchiver = new AutoArchiver(this)
     this.idRepair = new IdRepair(this)
     this.router = new PMViewRouter(this)
+    const api = new LocalApi(this)
+    this.register(api.attach())
+    this.localApi = new LocalApiServer(
+      {
+        api,
+        info: { name: 'dotpm', version: this.manifest.version },
+        authorized: bearerAuth(() => this.settings.localApiToken)
+      },
+      () => this.settings.localApiPort
+    )
 
     this.registerView(PM_PROJECT_VIEW_TYPE, (leaf) => new ProjectView(leaf, this))
     this.registerView(PM_PROJECT_OVERVIEW_VIEW_TYPE, (leaf) => new ProjectOverviewView(leaf, this))
@@ -108,6 +123,7 @@ export default class PMPlugin extends Plugin {
       safeAsync(async () => {
         this.index.build()
         await this.startupSweep()
+        await this.syncLocalApi()
       })
     )
 
@@ -290,6 +306,22 @@ export default class PMPlugin extends Plugin {
 
   onunload(): void {
     this.notifier.stop()
+    void this.localApi.stop()
+  }
+
+  /** Brings the local API in line with the settings. Mobile has nothing to run. */
+  async syncLocalApi(): Promise<void> {
+    if (!Platform.isDesktopApp) return
+    if (!this.settings.localApiEnabled) {
+      await this.localApi.stop()
+      return
+    }
+    try {
+      await this.localApi.restart()
+    } catch (err: unknown) {
+      console.error('[PM] local API failed to start', err)
+      new Notice(`The local API could not listen on port ${this.settings.localApiPort}.`)
+    }
   }
 
   /** Opens a task note in Obsidian's own editor, where the swap leaves it alone. */
@@ -360,6 +392,16 @@ export default class PMPlugin extends Plugin {
           entry.filter.statuses = nonTerminal
         }
       }
+      migrated = true
+    }
+
+    if (saved?.localApiPort === undefined) {
+      this.settings.localApiPort = localApiPortFor(this.app.vault.getName())
+      migrated = true
+    }
+
+    if (!this.settings.localApiToken) {
+      this.settings.localApiToken = generateToken()
       migrated = true
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { App, Notice, PluginSettingTab, Setting, debounce } from 'obsidian'
+import { App, Notice, Platform, PluginSettingTab, Setting, debounce } from 'obsidian'
 import type { SettingDefinitionItem, SettingDefinitionPage } from 'obsidian'
 import type PMPlugin from './main'
 import { type PMSettings, DEFAULT_SETTINGS, PRIORITY_ICON_SET_LABELS, makeId, flattenTasks } from '@dotpm/core'
@@ -12,6 +12,7 @@ import {
 } from './integrations/tasknotes'
 import { renderPaletteFields, renderStatusDoneToggle } from './ui/PaletteListEditor'
 import { renderPersonPicker } from './ui/PersonPicker'
+import { generateToken } from './api/LocalApiServer'
 
 export type { PMSettings }
 export { DEFAULT_SETTINGS }
@@ -253,6 +254,7 @@ export class PMSettingTab extends PluginSettingTab {
           }
         ]
       },
+      this.localApiGroup(),
       {
         type: 'group',
         heading: 'Task fields',
@@ -274,8 +276,67 @@ export class PMSettingTab extends PluginSettingTab {
       this.plugin.settings.lastAutoArchiveDate = ''
       await this.plugin.autoArchiver.check()
     }
+    if (key.startsWith('localApi')) await this.plugin.syncLocalApi()
     this.plugin.refreshViews()
     this.refreshDomState()
+  }
+
+  private async regenerateLocalApiToken(): Promise<void> {
+    this.plugin.settings.localApiToken = generateToken()
+    await this.plugin.saveSettings()
+    this.update()
+  }
+
+  private localApiGroup(): SettingDefinitionItem {
+    const enabled = (): boolean => this.plugin.settings.localApiEnabled
+    return {
+      type: 'group',
+      heading: 'Local API',
+      visible: () => Platform.isDesktopApp,
+      items: [
+        {
+          name: 'Serve projects to other apps',
+          desc: `Lets tools on this computer read and edit tasks over HTTP and MCP at http://127.0.0.1:${this.plugin.settings.localApiPort}. Only this computer can connect, and every request needs the token. The MCP endpoint is /mcp.`,
+          aliases: ['api', 'mcp', 'server', 'agent', 'local'],
+          control: { type: 'toggle', key: 'localApiEnabled' }
+        },
+        {
+          name: 'Port',
+          desc: 'Starts out derived from the vault name, so two open vaults do not want the same one.',
+          aliases: ['api', 'mcp'],
+          control: {
+            type: 'number',
+            key: 'localApiPort',
+            min: 1024,
+            max: 65535,
+            step: 1,
+            validate: (value) =>
+              Number.isInteger(value) && value >= 1024 && value <= 65535 ? undefined : 'Use a port from 1024 to 65535.',
+            disabled: () => !enabled()
+          }
+        },
+        {
+          name: 'Token',
+          desc: 'Clients send it as a bearer token.',
+          aliases: ['api', 'mcp', 'secret'],
+          control: {
+            type: 'text',
+            key: 'localApiToken',
+            validate: (value) => (value.trim().length >= 16 ? undefined : 'Use at least 16 characters.'),
+            disabled: () => !enabled()
+          }
+        },
+        {
+          name: 'Regenerate token',
+          desc: 'Every connected client will need the new one.',
+          aliases: ['api', 'mcp', 'secret'],
+          action: () => {
+            void this.regenerateLocalApiToken()
+          },
+          disabled: () => !enabled()
+        }
+      ]
+    }
   }
 
   private statusesPage(): SettingDefinitionPage {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "include": [
     "src/**/*.ts",
     "packages/*/src/**/*.ts",
+    "packages/*/test/**/*.ts",
     "test/**/*.ts"
   ],
   "compilerOptions": {


### PR DESCRIPTION
Adds an optional localhost server, off by default and desktop only, that lets other programs on the same computer read and edit tasks over HTTP and over MCP for coding agents. Every request needs the bearer token shown in settings, and writes go through the same store the views use, so they show up in Obsidian at once and run the scheduler. The routes and tools live in a new `@dotpm/api` package with no Obsidian dependency; the plugin binds them to the vault and the socket.

Stacked on #292.