### PR TITLE
serve mcp through mcp-lite instead of a hand-rolled json-rpc handler

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -30,7 +30,7 @@ Cursor, Claude Desktop and other clients that take a JSON config:
 }
 ```
 
-The server is stateless: every request stands alone, there is no session to keep, and it does not push notifications. Clients that insist on a Server-Sent Events stream get `405` from `GET /mcp` and fall back to plain requests.
+The server is stateless: every request stands alone, there is no session to keep, and it does not push notifications. A client that asks for `text/event-stream` on its POST gets the reply as one event and the stream closes; the standalone `GET /mcp` stream and `DELETE /mcp` need a session, so both answer `405`. Protocol versions `2025-06-18` and `2025-03-26` are supported, and one message per request: JSON-RPC batches are refused.
 
 Tools: `list_projects`, `get_project`, `list_tasks`, `get_task`, `search_tasks`, `create_task`, `update_task`, `move_task`, `archive_task`, `delete_task`, `list_changes`. Resources: `dotpm://projects/{id}` (the project with its tasks) and `dotpm://tasks/{id}`.
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@dotpm/core": "workspace:*"
+    "@dotpm/core": "workspace:*",
+    "mcp-lite": "0.10.0"
   }
 }

--- a/packages/api/src/mcp.test.ts
+++ b/packages/api/src/mcp.test.ts
@@ -1,41 +1,62 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { FakeApi } from '../test/fakeApi'
-import { handleMcp, MCP_PROTOCOL_VERSION, type JsonRpcResponse } from './mcp'
+import { createMcpHandler } from './mcp'
 
 const INFO = { name: 'dotpm', version: '9.9.9' }
 
-function rpc(method: string, params?: unknown, id: number | string = 1): unknown {
-  return { jsonrpc: '2.0', id, method, params }
+interface Reply {
+  status: number
+  id?: unknown
+  result?: Record<string, unknown>
+  error?: { code: number; message: string }
 }
 
-function parsed(reply: JsonRpcResponse | JsonRpcResponse[] | null): unknown {
-  const one = reply as JsonRpcResponse
-  const content = (one.result as { content: Array<{ text: string }> }).content
-  return JSON.parse(content[0].text)
-}
-
-describe('handleMcp', () => {
+describe('createMcpHandler', () => {
   let api: FakeApi
+  let handle: (request: Request) => Promise<Response>
 
   beforeEach(() => {
     api = new FakeApi()
+    handle = createMcpHandler(api, INFO)
   })
 
-  it('initializes with a supported protocol version and falls back to the newest', async () => {
-    const old = (await handleMcp(rpc('initialize', { protocolVersion: '2024-11-05' }), api, INFO)) as JsonRpcResponse
-    expect(old.result).toMatchObject({ protocolVersion: '2024-11-05', capabilities: { tools: {} } })
-    const unknown = (await handleMcp(
-      rpc('initialize', { protocolVersion: '1999-01-01' }),
-      api,
-      INFO
-    )) as JsonRpcResponse
-    expect(unknown.result).toMatchObject({ protocolVersion: MCP_PROTOCOL_VERSION })
+  async function rpc(method: string, params?: unknown, id: number | string = 1): Promise<Reply> {
+    const response = await handle(
+      new Request('http://127.0.0.1/mcp', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id, method, params })
+      })
+    )
+    const raw = await response.text()
+    return { status: response.status, ...(raw ? JSON.parse(raw) : {}) }
+  }
+
+  function parsed(reply: Reply): unknown {
+    const content = (reply.result as { content: Array<{ text: string }> }).content
+    return JSON.parse(content[0].text)
+  }
+
+  async function call(name: string, args: Record<string, unknown>): Promise<Reply> {
+    return rpc('tools/call', { name, arguments: args })
+  }
+
+  it('initializes with a supported protocol version and instructions', async () => {
+    const old = await rpc('initialize', { protocolVersion: '2025-03-26' })
+    expect(old.result).toMatchObject({
+      protocolVersion: '2025-03-26',
+      serverInfo: INFO,
+      capabilities: { tools: {} },
+      instructions: expect.stringContaining('status and priority ids')
+    })
+    const unknown = await rpc('initialize', { protocolVersion: '1999-01-01' })
+    expect(unknown.result).toMatchObject({ protocolVersion: '2025-03-26' })
   })
 
   it('lists tools with schemas and reports unknown methods', async () => {
-    const tools = (await handleMcp(rpc('tools/list'), api, INFO)) as JsonRpcResponse
-    const names = (tools.result as { tools: Array<{ name: string; inputSchema: object }> }).tools.map((t) => t.name)
-    expect(names).toEqual([
+    const tools = await rpc('tools/list')
+    const listed = (tools.result as { tools: Array<{ name: string; inputSchema: object }> }).tools
+    expect(listed.map((tool) => tool.name)).toEqual([
       'list_projects',
       'get_project',
       'list_tasks',
@@ -48,73 +69,85 @@ describe('handleMcp', () => {
       'delete_task',
       'list_changes'
     ])
-    const missing = (await handleMcp(rpc('nope/method'), api, INFO)) as JsonRpcResponse
-    expect(missing.error?.code).toBe(-32601)
+    expect(listed[1].inputSchema).toMatchObject({ required: ['projectId'] })
+    expect((await rpc('nope/method')).error?.code).toBe(-32601)
   })
 
   it('calls tools and returns JSON text content', async () => {
-    const reply = await handleMcp(rpc('tools/call', { name: 'list_projects', arguments: {} }), api, INFO)
-    expect(parsed(reply)).toEqual([expect.objectContaining({ id: 'p1', title: 'Demo' })])
+    expect(parsed(await call('list_projects', {}))).toEqual([expect.objectContaining({ id: 'p1', title: 'Demo' })])
 
-    const created = await handleMcp(
-      rpc('tools/call', { name: 'create_task', arguments: { projectId: 'p1', title: 'Via MCP', tags: ['agent'] } }),
-      api,
-      INFO
-    )
+    const created = await call('create_task', { projectId: 'p1', title: 'Via MCP', tags: ['agent'] })
     expect(parsed(created)).toMatchObject({ id: 't3', title: 'Via MCP', tags: ['agent'] })
     expect(api.calls).toContain('createTask p1')
 
-    await handleMcp(
-      rpc('tools/call', {
-        name: 'update_task',
-        arguments: { taskId: 't3', status: 'done', expectedUpdatedAt: 'stale' }
-      }),
-      api,
-      INFO
-    )
+    await call('update_task', { taskId: 't3', status: 'done', expectedUpdatedAt: 'stale' })
     expect(api.calls.at(-1)).toBe('updateTask t3 if stale')
   })
 
   it('reports a client mistake as a tool error instead of a protocol error', async () => {
-    const reply = (await handleMcp(
-      rpc('tools/call', { name: 'get_task', arguments: { taskId: 'zzz' } }),
-      api,
-      INFO
-    )) as JsonRpcResponse
+    const reply = await call('get_task', { taskId: 'zzz' })
     expect(reply.error).toBeUndefined()
     expect(reply.result).toMatchObject({ isError: true })
     expect(parsed(reply)).toEqual({ error: 'not_found', message: 'task zzz not found' })
   })
 
-  it('exposes projects as resources and reads tasks by uri', async () => {
-    const list = (await handleMcp(rpc('resources/list'), api, INFO)) as JsonRpcResponse
+  it('exposes projects as resources and reads them by uri', async () => {
+    const list = await rpc('resources/list')
     expect(list.result).toEqual({
       resources: [expect.objectContaining({ uri: 'dotpm://projects/p1', name: 'Demo', mimeType: 'application/json' })]
     })
-    const read = (await handleMcp(rpc('resources/read', { uri: 'dotpm://tasks/t1' }), api, INFO)) as JsonRpcResponse
+    const templates = await rpc('resources/templates/list')
+    expect((templates.result as { resourceTemplates: Array<{ uriTemplate: string }> }).resourceTemplates).toEqual([
+      expect.objectContaining({ uriTemplate: 'dotpm://projects/{projectId}' }),
+      expect.objectContaining({ uriTemplate: 'dotpm://tasks/{taskId}' })
+    ])
+
+    const read = await rpc('resources/read', { uri: 'dotpm://tasks/t1' })
     const contents = (read.result as { contents: Array<{ uri: string; text: string }> }).contents
     expect(contents[0].uri).toBe('dotpm://tasks/t1')
     expect(JSON.parse(contents[0].text)).toMatchObject({ id: 't1', title: 'First' })
-    const project = (await handleMcp(
-      rpc('resources/read', { uri: 'dotpm://projects/p1' }),
-      api,
-      INFO
-    )) as JsonRpcResponse
+
+    const project = await rpc('resources/read', { uri: 'dotpm://projects/p1' })
     expect(JSON.parse((project.result as { contents: Array<{ text: string }> }).contents[0].text)).toMatchObject({
       id: 'p1',
       tasks: [expect.objectContaining({ id: 't1' }), expect.objectContaining({ id: 't2' })]
     })
   })
 
-  it('handles batches and stays quiet for notifications', async () => {
-    expect(await handleMcp({ jsonrpc: '2.0', method: 'notifications/initialized' }, api, INFO)).toBeNull()
-    const batch = (await handleMcp(
-      [rpc('ping', undefined, 'a'), { jsonrpc: '2.0', method: 'notifications/initialized' }],
-      api,
-      INFO
-    )) as JsonRpcResponse[]
-    expect(batch).toEqual([{ jsonrpc: '2.0', id: 'a', result: {} }])
-    const bad = (await handleMcp({ hello: 'world' }, api, INFO)) as JsonRpcResponse
-    expect(bad.error?.code).toBe(-32600)
+  it('answers a notification with 202 and no body', async () => {
+    const response = await handle(
+      new Request('http://127.0.0.1/mcp', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })
+      })
+    )
+    expect(response.status).toBe(202)
+    expect(await response.text()).toBe('')
+  })
+
+  it('streams the reply when the client asks for events', async () => {
+    const response = await handle(
+      new Request('http://127.0.0.1/mcp', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 7, method: 'tools/call', params: { name: 'list_projects' } })
+      })
+    )
+    expect(response.headers.get('content-type')).toBe('text/event-stream')
+    const frames = await response.text()
+    expect(frames).toContain('"id":7')
+    expect(frames).toContain('Demo')
+  })
+
+  it('refuses a malformed message and a standalone event stream', async () => {
+    const bad = await handle(
+      new Request('http://127.0.0.1/mcp', { method: 'POST', body: JSON.stringify({ hello: 'world' }) })
+    )
+    expect(bad.status).toBe(400)
+    const stream = await handle(
+      new Request('http://127.0.0.1/mcp', { method: 'GET', headers: { accept: 'text/event-stream' } })
+    )
+    expect(stream.status).toBe(405)
   })
 })

--- a/packages/api/src/mcp.ts
+++ b/packages/api/src/mcp.ts
@@ -1,3 +1,11 @@
+import {
+  JSON_RPC_ERROR_CODES,
+  McpServer,
+  RpcError,
+  StreamableHttpTransport,
+  type JsonRpcError,
+  type ToolCallResult
+} from 'mcp-lite'
 import { ApiRequestError, type DomainApi } from './contract'
 import { parseTaskSearch } from './resources'
 
@@ -6,27 +14,13 @@ export interface ServerInfo {
   version: string
 }
 
-export interface JsonRpcRequest {
-  jsonrpc: '2.0'
-  id?: number | string | null
-  method: string
-  params?: unknown
-}
+const SERVER_ERROR = -32000
 
-export interface JsonRpcResponse {
-  jsonrpc: '2.0'
-  id: number | string | null
-  result?: unknown
-  error?: { code: number; message: string; data?: unknown }
-}
+const INSTRUCTIONS =
+  'Projects hold tasks in a tree. Read a project first to learn its status and priority ids before writing tasks.'
 
-export const MCP_PROTOCOL_VERSION = '2025-06-18'
-const SUPPORTED_PROTOCOL_VERSIONS = new Set(['2025-06-18', '2025-03-26', '2024-11-05'])
-
-const PARSE_ERROR = -32700
-const INVALID_REQUEST = -32600
-const METHOD_NOT_FOUND = -32601
-const INVALID_PARAMS = -32602
+const PROJECT_TEMPLATE = 'dotpm://projects/{projectId}'
+const TASK_TEMPLATE = 'dotpm://tasks/{taskId}'
 
 type JsonSchema = Record<string, unknown>
 
@@ -55,145 +49,6 @@ const TASK_FIELDS: Record<string, JsonSchema> = {
   customFields: { type: 'object', additionalProperties: true }
 }
 
-interface ToolDefinition {
-  name: string
-  description: string
-  inputSchema: JsonSchema
-}
-
-const TOOLS: ToolDefinition[] = [
-  {
-    name: 'list_projects',
-    description: 'Every project in the vault with its id, title, parent and task counts.',
-    inputSchema: { type: 'object', properties: {}, additionalProperties: false }
-  },
-  {
-    name: 'get_project',
-    description: 'One project with its description, team, custom fields and the status and priority ids its tasks use.',
-    inputSchema: {
-      type: 'object',
-      properties: { projectId: { type: 'string' } },
-      required: ['projectId'],
-      additionalProperties: false
-    }
-  },
-  {
-    name: 'list_tasks',
-    description: 'All tasks of a project in tree order. Each carries parentId and position.',
-    inputSchema: {
-      type: 'object',
-      properties: { projectId: { type: 'string' }, includeArchived: { type: 'boolean' } },
-      required: ['projectId'],
-      additionalProperties: false
-    }
-  },
-  {
-    name: 'get_task',
-    description: 'One task by id, including its description.',
-    inputSchema: {
-      type: 'object',
-      properties: { taskId: { type: 'string' } },
-      required: ['taskId'],
-      additionalProperties: false
-    }
-  },
-  {
-    name: 'search_tasks',
-    description: 'Find tasks across every project by title text, project, status or assignee.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        query: { type: 'string', description: 'Case-insensitive match on the title' },
-        projectId: { type: 'string' },
-        status: { type: 'string' },
-        assignee: { type: 'string' },
-        includeArchived: { type: 'boolean' },
-        limit: { type: 'integer', minimum: 1, maximum: 500 }
-      },
-      additionalProperties: false
-    }
-  },
-  {
-    name: 'create_task',
-    description: 'Create a task in a project, at the top level or under parentId.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        projectId: { type: 'string' },
-        parentId: { type: ['string', 'null'] },
-        ...TASK_FIELDS
-      },
-      required: ['projectId', 'title'],
-      additionalProperties: false
-    }
-  },
-  {
-    name: 'update_task',
-    description:
-      'Change fields of a task. Only the fields passed change. Pass expectedUpdatedAt from a previous read to refuse the write when the task changed since.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        taskId: { type: 'string' },
-        expectedUpdatedAt: { type: 'string' },
-        ...TASK_FIELDS
-      },
-      required: ['taskId'],
-      additionalProperties: false
-    }
-  },
-  {
-    name: 'move_task',
-    description:
-      'Re-parent a task (parentId, null for top level), move it to another project (projectId), or reorder it among its siblings (before or after a sibling id).',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        taskId: { type: 'string' },
-        parentId: { type: ['string', 'null'] },
-        projectId: { type: 'string' },
-        before: { type: 'string' },
-        after: { type: 'string' }
-      },
-      required: ['taskId'],
-      additionalProperties: false
-    }
-  },
-  {
-    name: 'archive_task',
-    description: 'Archive a task and its subtasks, or bring them back with archived: false.',
-    inputSchema: {
-      type: 'object',
-      properties: { taskId: { type: 'string' }, archived: { type: 'boolean', default: true } },
-      required: ['taskId'],
-      additionalProperties: false
-    }
-  },
-  {
-    name: 'delete_task',
-    description: 'Delete a task and its subtasks. Cannot be undone.',
-    inputSchema: {
-      type: 'object',
-      properties: { taskId: { type: 'string' } },
-      required: ['taskId'],
-      additionalProperties: false
-    }
-  },
-  {
-    name: 'list_changes',
-    description:
-      'Projects and tasks changed since a cursor, oldest first. Omit since for the current cursor only. A reset of true means the cursor was too old: refetch.',
-    inputSchema: {
-      type: 'object',
-      properties: { since: { type: 'integer' } },
-      additionalProperties: false
-    }
-  }
-]
-
-const PROJECT_URI = /^dotpm:\/\/projects\/([^/]+)$/
-const TASK_URI = /^dotpm:\/\/tasks\/([^/]+)$/
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
@@ -210,21 +65,122 @@ function withoutKeys(params: Record<string, unknown>, keys: string[]): Record<st
   return rest
 }
 
-async function callTool(name: string, params: Record<string, unknown>, api: DomainApi): Promise<unknown> {
-  switch (name) {
-    case 'list_projects':
-      return api.listProjects()
-    case 'get_project':
-      return api.getProject(requireString(params, 'projectId'))
-    case 'list_tasks':
-      return api.listTasks(requireString(params, 'projectId'), params['includeArchived'] === true)
-    case 'get_task':
-      return api.getTask(requireString(params, 'taskId'))
-    case 'search_tasks':
-      return api.searchTasks(parseTaskSearch(params))
-    case 'create_task':
-      return api.createTask(requireString(params, 'projectId'), withoutKeys(params, ['projectId']))
-    case 'update_task': {
+function text(value: unknown): ToolCallResult {
+  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] }
+}
+
+function jsonContents(
+  uri: string,
+  value: unknown
+): { contents: [{ uri: string; type: 'text'; mimeType: string; text: string }] } {
+  return { contents: [{ uri, type: 'text', mimeType: 'application/json', text: JSON.stringify(value, null, 2) }] }
+}
+
+/**
+ * Registers one tool, with the arguments narrowed and the client-mistake contract in one
+ * place: a mistake comes back as a tool result marked `isError`, not a protocol error.
+ */
+function tool(
+  server: McpServer,
+  name: string,
+  def: {
+    description: string
+    inputSchema: JsonSchema
+    run: (params: Record<string, unknown>) => Promise<unknown>
+  }
+): void {
+  server.tool<unknown>(name, {
+    description: def.description,
+    inputSchema: def.inputSchema,
+    handler: async (raw) => {
+      try {
+        return text(await def.run(isRecord(raw) ? raw : {}))
+      } catch (err: unknown) {
+        if (err instanceof ApiRequestError) return { ...text({ error: err.code, message: err.message }), isError: true }
+        throw err
+      }
+    }
+  })
+}
+
+function registerTools(server: McpServer, api: DomainApi): void {
+  tool(server, 'list_projects', {
+    description: 'Every project in the vault with its id, title, parent and task counts.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    run: () => api.listProjects()
+  })
+
+  tool(server, 'get_project', {
+    description: 'One project with its description, team, custom fields and the status and priority ids its tasks use.',
+    inputSchema: {
+      type: 'object',
+      properties: { projectId: { type: 'string' } },
+      required: ['projectId'],
+      additionalProperties: false
+    },
+    run: (params) => api.getProject(requireString(params, 'projectId'))
+  })
+
+  tool(server, 'list_tasks', {
+    description: 'All tasks of a project in tree order. Each carries parentId and position.',
+    inputSchema: {
+      type: 'object',
+      properties: { projectId: { type: 'string' }, includeArchived: { type: 'boolean' } },
+      required: ['projectId'],
+      additionalProperties: false
+    },
+    run: (params) => api.listTasks(requireString(params, 'projectId'), params['includeArchived'] === true)
+  })
+
+  tool(server, 'get_task', {
+    description: 'One task by id, including its description.',
+    inputSchema: {
+      type: 'object',
+      properties: { taskId: { type: 'string' } },
+      required: ['taskId'],
+      additionalProperties: false
+    },
+    run: (params) => api.getTask(requireString(params, 'taskId'))
+  })
+
+  tool(server, 'search_tasks', {
+    description: 'Find tasks across every project by title text, project, status or assignee.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Case-insensitive match on the title' },
+        projectId: { type: 'string' },
+        status: { type: 'string' },
+        assignee: { type: 'string' },
+        includeArchived: { type: 'boolean' },
+        limit: { type: 'integer', minimum: 1, maximum: 500 }
+      },
+      additionalProperties: false
+    },
+    run: (params) => api.searchTasks(parseTaskSearch(params))
+  })
+
+  tool(server, 'create_task', {
+    description: 'Create a task in a project, at the top level or under parentId.',
+    inputSchema: {
+      type: 'object',
+      properties: { projectId: { type: 'string' }, parentId: { type: ['string', 'null'] }, ...TASK_FIELDS },
+      required: ['projectId', 'title'],
+      additionalProperties: false
+    },
+    run: (params) => api.createTask(requireString(params, 'projectId'), withoutKeys(params, ['projectId']))
+  })
+
+  tool(server, 'update_task', {
+    description:
+      'Change fields of a task. Only the fields passed change. Pass expectedUpdatedAt from a previous read to refuse the write when the task changed since.',
+    inputSchema: {
+      type: 'object',
+      properties: { taskId: { type: 'string' }, expectedUpdatedAt: { type: 'string' }, ...TASK_FIELDS },
+      required: ['taskId'],
+      additionalProperties: false
+    },
+    run: (params) => {
       const expected = params['expectedUpdatedAt']
       return api.updateTask(
         requireString(params, 'taskId'),
@@ -232,137 +188,116 @@ async function callTool(name: string, params: Record<string, unknown>, api: Doma
         typeof expected === 'string' ? expected : undefined
       )
     }
-    case 'move_task':
-      return api.moveTask(requireString(params, 'taskId'), withoutKeys(params, ['taskId']))
-    case 'archive_task':
-      return api.archiveTask(requireString(params, 'taskId'), params['archived'] !== false)
-    case 'delete_task':
+  })
+
+  tool(server, 'move_task', {
+    description:
+      'Re-parent a task (parentId, null for top level), move it to another project (projectId), or reorder it among its siblings (before or after a sibling id).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        taskId: { type: 'string' },
+        parentId: { type: ['string', 'null'] },
+        projectId: { type: 'string' },
+        before: { type: 'string' },
+        after: { type: 'string' }
+      },
+      required: ['taskId'],
+      additionalProperties: false
+    },
+    run: (params) => api.moveTask(requireString(params, 'taskId'), withoutKeys(params, ['taskId']))
+  })
+
+  tool(server, 'archive_task', {
+    description: 'Archive a task and its subtasks, or bring them back with archived: false.',
+    inputSchema: {
+      type: 'object',
+      properties: { taskId: { type: 'string' }, archived: { type: 'boolean', default: true } },
+      required: ['taskId'],
+      additionalProperties: false
+    },
+    run: (params) => api.archiveTask(requireString(params, 'taskId'), params['archived'] !== false)
+  })
+
+  tool(server, 'delete_task', {
+    description: 'Delete a task and its subtasks. Cannot be undone.',
+    inputSchema: {
+      type: 'object',
+      properties: { taskId: { type: 'string' } },
+      required: ['taskId'],
+      additionalProperties: false
+    },
+    run: async (params) => {
       await api.deleteTask(requireString(params, 'taskId'))
       return { deleted: true }
-    case 'list_changes': {
+    }
+  })
+
+  tool(server, 'list_changes', {
+    description:
+      'Projects and tasks changed since a cursor, oldest first. Omit since for the current cursor only. A reset of true means the cursor was too old: refetch.',
+    inputSchema: { type: 'object', properties: { since: { type: 'integer' } }, additionalProperties: false },
+    run: (params) => {
       const since = params['since']
       return api.changes(typeof since === 'number' ? since : null)
     }
-    default:
-      throw new ApiRequestError('not_found', `unknown tool ${name}`)
-  }
+  })
 }
 
-function text(value: unknown): { content: Array<{ type: 'text'; text: string }>; isError?: boolean } {
-  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] }
-}
+function registerResources(server: McpServer, api: DomainApi): void {
+  server.resource(PROJECT_TEMPLATE, { name: 'Project with tasks', mimeType: 'application/json' }, async (uri, vars) => {
+    const projectId = String(vars['projectId'])
+    const [project, tasks] = await Promise.all([api.getProject(projectId), api.listTasks(projectId)])
+    return jsonContents(uri.href, { ...project, tasks })
+  })
 
-async function readResource(uri: string, api: DomainApi): Promise<unknown> {
-  const project = PROJECT_URI.exec(uri)
-  if (project) {
-    const [resource, tasks] = await Promise.all([api.getProject(project[1]), api.listTasks(project[1])])
-    return { ...resource, tasks }
-  }
-  const task = TASK_URI.exec(uri)
-  if (task) return api.getTask(task[1])
-  throw new ApiRequestError('not_found', `unknown resource ${uri}`)
-}
-
-async function dispatch(method: string, params: unknown, api: DomainApi, info: ServerInfo): Promise<unknown> {
-  const p = isRecord(params) ? params : {}
-  switch (method) {
-    case 'initialize': {
-      const requested = p['protocolVersion']
-      const protocolVersion =
-        typeof requested === 'string' && SUPPORTED_PROTOCOL_VERSIONS.has(requested) ? requested : MCP_PROTOCOL_VERSION
-      return {
-        protocolVersion,
-        capabilities: { tools: { listChanged: false }, resources: { subscribe: false, listChanged: false } },
-        serverInfo: info,
-        instructions:
-          'Projects hold tasks in a tree. Read a project first to learn its status and priority ids before writing tasks.'
-      }
-    }
-    case 'ping':
-      return {}
-    case 'tools/list':
-      return { tools: TOOLS }
-    case 'tools/call': {
-      const name = p['name']
-      if (typeof name !== 'string') throw new ApiRequestError('invalid', 'tool name is required')
-      const args = isRecord(p['arguments']) ? p['arguments'] : {}
-      try {
-        return text(await callTool(name, args, api))
-      } catch (err: unknown) {
-        if (err instanceof ApiRequestError) return { ...text({ error: err.code, message: err.message }), isError: true }
-        throw err
-      }
-    }
-    case 'resources/list': {
-      const projects = await api.listProjects()
-      return {
-        resources: projects.map((project) => ({
-          uri: `dotpm://projects/${project.id}`,
-          name: project.title,
-          description: `${project.taskCount} tasks, ${project.doneCount} done`,
-          mimeType: 'application/json'
-        }))
-      }
-    }
-    case 'resources/templates/list':
-      return {
-        resourceTemplates: [
-          { uriTemplate: 'dotpm://tasks/{taskId}', name: 'Task', mimeType: 'application/json' },
-          { uriTemplate: 'dotpm://projects/{projectId}', name: 'Project with tasks', mimeType: 'application/json' }
-        ]
-      }
-    case 'resources/read': {
-      const uri = p['uri']
-      if (typeof uri !== 'string') throw new ApiRequestError('invalid', 'uri is required')
-      const body = await readResource(uri, api)
-      return { contents: [{ uri, mimeType: 'application/json', text: JSON.stringify(body, null, 2) }] }
-    }
-    default:
-      return undefined
-  }
-}
-
-function errorResponse(id: number | string | null, code: number, message: string): JsonRpcResponse {
-  return { jsonrpc: '2.0', id, error: { code, message } }
-}
-
-async function handleOne(message: unknown, api: DomainApi, info: ServerInfo): Promise<JsonRpcResponse | null> {
-  if (!isRecord(message) || message['jsonrpc'] !== '2.0' || typeof message['method'] !== 'string') {
-    return errorResponse(null, INVALID_REQUEST, 'expected a JSON-RPC 2.0 request')
-  }
-  const request = message as unknown as JsonRpcRequest
-  const id = request.id ?? null
-  const isNotification = request.id === undefined
-  try {
-    const result = await dispatch(request.method, request.params, api, info)
-    if (isNotification) return null
-    if (result === undefined) return errorResponse(id, METHOD_NOT_FOUND, `unknown method ${request.method}`)
-    return { jsonrpc: '2.0', id, result }
-  } catch (err: unknown) {
-    if (isNotification) return null
-    if (err instanceof ApiRequestError) {
-      return errorResponse(id, err.code === 'invalid' ? INVALID_PARAMS : -32000, err.message)
-    }
-    console.error('[PM] mcp request failed', err)
-    return errorResponse(id, -32603, 'request failed; see the developer console')
-  }
+  server.resource(TASK_TEMPLATE, { name: 'Task', mimeType: 'application/json' }, async (uri, vars) =>
+    jsonContents(uri.href, await api.getTask(String(vars['taskId'])))
+  )
 }
 
 /**
- * MCP over Streamable HTTP in its stateless form: one POST carries one message (or a
- * batch), the reply is plain JSON, and notifications get no body. Returns null when
- * there is nothing to send back.
+ * Two results mcp-lite has no hook for: `initialize` carries no instructions, and
+ * `resources/list` knows only what was registered, never one entry per project.
  */
-export async function handleMcp(
-  body: unknown,
-  api: DomainApi,
-  info: ServerInfo
-): Promise<JsonRpcResponse | JsonRpcResponse[] | null> {
-  if (body === undefined || body === null) return errorResponse(null, PARSE_ERROR, 'empty body')
-  if (Array.isArray(body)) {
-    const replies = await Promise.all(body.map((message) => handleOne(message, api, info)))
-    const sent = replies.filter((reply): reply is JsonRpcResponse => reply !== null)
-    return sent.length ? sent : null
+function completeResults(server: McpServer, api: DomainApi): void {
+  server.use(async (ctx, next) => {
+    await next()
+    const result = ctx.response?.result
+    if (!isRecord(result)) return
+    if (ctx.request.method === 'initialize') result['instructions'] = INSTRUCTIONS
+    if (ctx.request.method === 'resources/list') {
+      const projects = await api.listProjects()
+      result['resources'] = projects.map((project) => ({
+        uri: `dotpm://projects/${project.id}`,
+        name: project.title,
+        description: `${project.taskCount} tasks, ${project.doneCount} done`,
+        mimeType: 'application/json'
+      }))
+    }
+  })
+}
+
+/** Anything the protocol itself raised already says what went wrong and passes through. */
+function toRpcError(err: unknown): JsonRpcError | undefined {
+  if (err instanceof ApiRequestError) {
+    return { code: err.code === 'invalid' ? JSON_RPC_ERROR_CODES.INVALID_PARAMS : SERVER_ERROR, message: err.message }
   }
-  return handleOne(body, api, info)
+  if (err instanceof RpcError) return undefined
+  console.error('[PM] mcp request failed', err)
+  return { code: JSON_RPC_ERROR_CODES.INTERNAL_ERROR, message: 'request failed; see the developer console' }
+}
+
+/**
+ * MCP over Streamable HTTP in its stateless form: one POST carries one message, and the
+ * reply is JSON unless the client asked for an event stream. There is no session, so a
+ * client that wants the standalone `GET` stream is told the method is not allowed.
+ */
+export function createMcpHandler(api: DomainApi, info: ServerInfo): (request: Request) => Promise<Response> {
+  const server = new McpServer({ name: info.name, version: info.version })
+  server.onError(toRpcError)
+  completeResults(server, api)
+  registerTools(server, api)
+  registerResources(server, api)
+  return new StreamableHttpTransport().bind(server)
 }

--- a/packages/api/src/router.test.ts
+++ b/packages/api/src/router.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { FakeApi } from '../test/fakeApi'
-import { bearerAuth, handleHttp, tokenMatches, type HttpHost, type HttpRequest } from './router'
+import { bearerAuth, createRouter, tokenMatches, type HttpRequest, type HttpResponse } from './router'
 
 const TOKEN = 'secret-token-0123456789'
 
@@ -15,107 +15,120 @@ function request(method: string, path: string, extra: Partial<HttpRequest> = {})
   }
 }
 
-describe('handleHttp', () => {
+describe('createRouter', () => {
   let api: FakeApi
-  let host: HttpHost
+  let route: (req: HttpRequest) => Promise<HttpResponse>
 
   beforeEach(() => {
     api = new FakeApi()
-    host = { api, info: { name: 'dotpm', version: '9.9.9' }, authorized: bearerAuth(() => TOKEN) }
+    route = createRouter({ api, info: { name: 'dotpm', version: '9.9.9' }, authorized: bearerAuth(() => TOKEN) })
   })
 
   it('answers health without a token', async () => {
-    const res = await handleHttp(request('GET', '/v1/health', { headers: {} }), host)
+    const res = await route(request('GET', '/v1/health', { headers: {} }))
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ ok: true, name: 'dotpm', version: '9.9.9' })
   })
 
   it('refuses everything else without the token', async () => {
-    const res = await handleHttp(request('GET', '/v1/projects', { headers: {} }), host)
+    const res = await route(request('GET', '/v1/projects', { headers: {} }))
     expect(res.status).toBe(401)
     expect(api.calls).toEqual([])
   })
 
   it('lists and reads projects and tasks', async () => {
-    expect((await handleHttp(request('GET', '/v1/projects'), host)).body).toEqual([
+    expect((await route(request('GET', '/v1/projects'))).body).toEqual([
       expect.objectContaining({ id: 'p1', title: 'Demo', taskCount: 2, doneCount: 1 })
     ])
-    expect((await handleHttp(request('GET', '/v1/projects/p1'), host)).body).toMatchObject({
+    expect((await route(request('GET', '/v1/projects/p1'))).body).toMatchObject({
       id: 'p1',
       statuses: expect.any(Array)
     })
-    const tasks = await handleHttp(request('GET', '/v1/projects/p1/tasks'), host)
+    const tasks = await route(request('GET', '/v1/projects/p1/tasks'))
     expect((tasks.body as unknown[]).length).toBe(2)
-    expect((await handleHttp(request('GET', '/v1/tasks/t2'), host)).body).toMatchObject({ id: 't2', position: 1 })
+    expect((await route(request('GET', '/v1/tasks/t2'))).body).toMatchObject({ id: 't2', position: 1 })
   })
 
   it('maps client mistakes to statuses', async () => {
-    expect((await handleHttp(request('GET', '/v1/projects/nope'), host)).status).toBe(404)
-    expect((await handleHttp(request('GET', '/v1/nothing/here'), host)).status).toBe(404)
-    const bad = await handleHttp(request('POST', '/v1/projects/p1/tasks', { body: { title: '' } }), host)
+    expect((await route(request('GET', '/v1/projects/nope'))).status).toBe(404)
+    expect((await route(request('GET', '/v1/nothing/here'))).status).toBe(404)
+    const bad = await route(request('POST', '/v1/projects/p1/tasks', { body: { title: '' } }))
     expect(bad.status).toBe(400)
     expect(bad.body).toEqual({ error: { code: 'invalid', message: 'title must not be empty' } })
   })
 
   it('creates, updates with If-Match, moves, archives and deletes', async () => {
-    const created = await handleHttp(
-      request('POST', '/v1/projects/p1/tasks', { body: { title: 'Third', due: '2030-01-02' } }),
-      host
+    const created = await route(
+      request('POST', '/v1/projects/p1/tasks', { body: { title: 'Third', due: '2030-01-02' } })
     )
     expect(created.status).toBe(201)
     expect(created.body).toMatchObject({ id: 't3', title: 'Third', due: '2030-01-02' })
 
-    const stale = await handleHttp(
+    const stale = await route(
       request('PATCH', '/v1/tasks/t3', {
         body: { status: 'done' },
         headers: { authorization: `Bearer ${TOKEN}`, 'if-match': '"old"' }
-      }),
-      host
+      })
     )
     expect(stale.status).toBe(412)
-    const updated = await handleHttp(request('PATCH', '/v1/tasks/t3', { body: { status: 'done' } }), host)
+    const updated = await route(request('PATCH', '/v1/tasks/t3', { body: { status: 'done' } }))
     expect(updated.body).toMatchObject({ status: 'done' })
 
-    await handleHttp(request('POST', '/v1/tasks/t3/move', { body: { parentId: 't1' } }), host)
+    await route(request('POST', '/v1/tasks/t3/move', { body: { parentId: 't1' } }))
     expect(api.calls).toContain('moveTask t3 {"parentId":"t1"}')
 
-    expect((await handleHttp(request('POST', '/v1/tasks/t3/archive'), host)).body).toMatchObject({ archived: true })
-    expect(
-      (await handleHttp(request('POST', '/v1/tasks/t3/archive', { body: { archived: false } }), host)).body
-    ).toMatchObject({
+    expect((await route(request('POST', '/v1/tasks/t3/archive'))).body).toMatchObject({ archived: true })
+    expect((await route(request('POST', '/v1/tasks/t3/archive', { body: { archived: false } }))).body).toMatchObject({
       archived: false
     })
 
-    expect((await handleHttp(request('DELETE', '/v1/tasks/t3'), host)).status).toBe(204)
-    expect((await handleHttp(request('GET', '/v1/tasks/t3'), host)).status).toBe(404)
+    expect((await route(request('DELETE', '/v1/tasks/t3'))).status).toBe(204)
+    expect((await route(request('GET', '/v1/tasks/t3'))).status).toBe(404)
   })
 
   it('searches with the q parameter and pages changes by cursor', async () => {
-    const found = await handleHttp(request('GET', '/v1/search', { query: { q: 'sec', limit: '5' } }), host)
+    const found = await route(request('GET', '/v1/search', { query: { q: 'sec', limit: '5' } }))
     expect((found.body as Array<{ id: string }>).map((t) => t.id)).toEqual(['t2'])
     expect(api.calls.at(-1)).toBe('searchTasks {"query":"sec","limit":5}')
 
-    expect((await handleHttp(request('GET', '/v1/changes', { query: { since: 'x' } }), host)).status).toBe(400)
-    await handleHttp(request('GET', '/v1/changes', { query: { since: '3' } }), host)
+    expect((await route(request('GET', '/v1/changes', { query: { since: 'x' } }))).status).toBe(400)
+    await route(request('GET', '/v1/changes', { query: { since: '3' } }))
     expect(api.calls.at(-1)).toBe('changes 3')
   })
 
-  it('serves MCP on /mcp and rejects other methods there', async () => {
-    const init = await handleHttp(
+  it('serves MCP on /mcp and rejects the session methods it has no session for', async () => {
+    const init = await route(
       request('POST', '/mcp', {
         body: { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26' } }
-      }),
-      host
+      })
     )
     expect(init.status).toBe(200)
     expect(init.body).toMatchObject({ id: 1, result: { protocolVersion: '2025-03-26', serverInfo: { name: 'dotpm' } } })
-    const note = await handleHttp(
-      request('POST', '/mcp', { body: { jsonrpc: '2.0', method: 'notifications/initialized' } }),
-      host
-    )
+
+    const note = await route(request('POST', '/mcp', { body: { jsonrpc: '2.0', method: 'notifications/initialized' } }))
     expect(note.status).toBe(202)
-    expect((await handleHttp(request('GET', '/mcp'), host)).status).toBe(405)
-    expect((await handleHttp(request('DELETE', '/mcp'), host)).status).toBe(204)
+    expect(note.body).toBeUndefined()
+
+    const headers = { authorization: `Bearer ${TOKEN}`, accept: 'text/event-stream' }
+    expect((await route(request('GET', '/mcp', { headers }))).status).toBe(405)
+    expect((await route(request('DELETE', '/mcp'))).status).toBe(405)
+  })
+
+  it('hands an event stream back to the host untouched', async () => {
+    const res = await route(
+      request('POST', '/mcp', {
+        headers: { authorization: `Bearer ${TOKEN}`, accept: 'application/json, text/event-stream' },
+        body: { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'list_projects' } }
+      })
+    )
+    expect(res.headers).toMatchObject({ 'content-type': 'text/event-stream' })
+    expect(res.body).toBeUndefined()
+    expect(await new Response(res.stream).text()).toContain('"id":4')
+  })
+
+  it('needs the token for MCP too', async () => {
+    const res = await route(request('POST', '/mcp', { headers: {}, body: { jsonrpc: '2.0', id: 1, method: 'ping' } }))
+    expect(res.status).toBe(401)
   })
 })
 

--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -1,5 +1,5 @@
 import { ApiRequestError, ERROR_STATUS, type DomainApi } from './contract'
-import { handleMcp, type ServerInfo } from './mcp'
+import { createMcpHandler, type ServerInfo } from './mcp'
 import { parseTaskSearch } from './resources'
 
 export interface HttpRequest {
@@ -16,6 +16,8 @@ export interface HttpResponse {
   status: number
   body?: unknown
   headers?: Record<string, string>
+  /** Set instead of `body` when the host must pipe the bytes through unchanged. */
+  stream?: ReadableStream<Uint8Array>
 }
 
 export interface HttpHost {
@@ -71,15 +73,6 @@ async function route(req: HttpRequest, host: HttpHost): Promise<HttpResponse> {
   const { method, path } = req
   let p: Record<string, string> | null
 
-  if (path === '/mcp') {
-    if (method === 'POST') {
-      const result = await handleMcp(req.body, api, host.info)
-      return result === null ? { status: 202 } : json(200, result)
-    }
-    if (method === 'DELETE') return { status: 204 }
-    return { status: 405, headers: { allow: 'POST, DELETE' } }
-  }
-
   if (path === '/v1/projects' && method === 'GET') return json(200, await api.listProjects())
 
   if ((p = match('/v1/projects/:id', path)) && method === 'GET') return json(200, await api.getProject(p['id']))
@@ -127,20 +120,44 @@ async function route(req: HttpRequest, host: HttpHost): Promise<HttpResponse> {
   return error('not_found', `no route for ${method} ${path}`)
 }
 
+/** The MCP transport speaks fetch, so the request is rebuilt and the reply unwrapped. */
+async function mcp(handle: (request: Request) => Promise<Response>, req: HttpRequest): Promise<HttpResponse> {
+  const headers = new Headers(req.headers)
+  headers.delete('content-length')
+  const response = await handle(
+    new Request('http://127.0.0.1/mcp', {
+      method: req.method,
+      headers,
+      body: req.body === undefined ? undefined : JSON.stringify(req.body)
+    })
+  )
+  const contentType = response.headers.get('content-type') ?? ''
+  if (contentType.startsWith('text/event-stream') && response.body) {
+    return { status: response.status, stream: response.body, headers: { 'content-type': contentType } }
+  }
+  if (!contentType.startsWith('application/json')) return { status: response.status }
+  const raw = await response.text()
+  return { status: response.status, body: raw ? JSON.parse(raw) : undefined }
+}
+
 /**
  * The whole HTTP surface, independent of any server: the host reads the request, hands
- * it here, and writes whatever comes back. `/v1/health` needs no token.
+ * it here, and writes whatever comes back. `/v1/health` needs no token. The MCP server
+ * behind `/mcp` is built once, so build the router once too.
  */
-export async function handleHttp(req: HttpRequest, host: HttpHost): Promise<HttpResponse> {
-  if (req.path === '/v1/health' && req.method === 'GET') {
-    return json(200, { ok: true, name: host.info.name, version: host.info.version })
-  }
-  if (!host.authorized(req)) return error('unauthorized', 'missing or wrong bearer token')
-  try {
-    return await route(req, host)
-  } catch (err: unknown) {
-    if (err instanceof ApiRequestError) return error(err.code, err.message)
-    console.error('[PM] api request failed', err)
-    return json(500, { error: { code: 'internal', message: 'request failed; see the developer console' } })
+export function createRouter(host: HttpHost): (req: HttpRequest) => Promise<HttpResponse> {
+  const handleMcp = createMcpHandler(host.api, host.info)
+  return async (req) => {
+    if (req.path === '/v1/health' && req.method === 'GET') {
+      return json(200, { ok: true, name: host.info.name, version: host.info.version })
+    }
+    if (!host.authorized(req)) return error('unauthorized', 'missing or wrong bearer token')
+    try {
+      return req.path === '/mcp' ? await mcp(handleMcp, req) : await route(req, host)
+    } catch (err: unknown) {
+      if (err instanceof ApiRequestError) return error(err.code, err.message)
+      console.error('[PM] api request failed', err)
+      return json(500, { error: { code: 'internal', message: 'request failed; see the developer console' } })
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@dotpm/core':
         specifier: workspace:*
         version: link:../core
+      mcp-lite:
+        specifier: 0.10.0
+        version: 0.10.0
 
   packages/core:
     dependencies:
@@ -727,6 +730,9 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -1827,6 +1833,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mcp-lite@0.10.0:
+    resolution: {integrity: sha512-ts1PgXO5+MER3W77YjYUMqngF45l6eyh2V4Vc0O4S+oKU55ghvd3Q+/XpA4kqtMISqI9v5s1E8pChDICudxwXQ==}
+
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
     engines: {node: '>= 0.10.0'}
@@ -2910,6 +2919,8 @@ snapshots:
   '@rolldown/pluginutils@1.0.1': {}
 
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -4214,6 +4225,10 @@ snapshots:
       source-map-js: 1.2.1
 
   math-intrinsics@1.1.0: {}
+
+  mcp-lite@0.10.0:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
 
   memorystream@0.3.1: {}
 

--- a/src/api/LocalApiServer.test.ts
+++ b/src/api/LocalApiServer.test.ts
@@ -1,0 +1,64 @@
+import { createRequire } from 'node:module'
+import { bearerAuth } from '@dotpm/api'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { FakeApi } from '../../packages/api/test/fakeApi'
+import { LocalApiServer } from './LocalApiServer'
+
+const TOKEN = 'secret-token-0123456789'
+const PORT = 39871
+
+describe('LocalApiServer', () => {
+  let base: string
+
+  beforeAll(async () => {
+    ;(globalThis as unknown as { window: unknown }).window = { require: createRequire(import.meta.url) }
+    const server = new LocalApiServer(
+      { api: new FakeApi(), info: { name: 'dotpm', version: '9.9.9' }, authorized: bearerAuth(() => TOKEN) },
+      () => PORT
+    )
+    await server.start()
+    base = server.address ?? ''
+    return async () => {
+      await server.stop()
+    }
+  })
+
+  it('answers health', async () => {
+    const res = await fetch(`${base}/v1/health`)
+    expect(await res.json()).toMatchObject({ ok: true })
+  })
+
+  it('speaks MCP with a plain JSON reply', async () => {
+    const res = await fetch(`${base}/mcp`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${TOKEN}`, 'content-type': 'application/json', accept: 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } })
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ id: 1, result: { serverInfo: { name: 'dotpm' } } })
+  })
+
+  it('streams a tool call when the client accepts events', async () => {
+    const res = await fetch(`${base}/mcp`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        'mcp-protocol-version': '2025-06-18'
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'list_projects' } })
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/event-stream')
+    expect(res.headers.get('content-length')).toBeNull()
+    const body = await res.text()
+    expect(body.startsWith('data: ')).toBe(true)
+    expect(body).toContain('Demo')
+  })
+
+  it('refuses a request without the token', async () => {
+    const res = await fetch(`${base}/mcp`, { method: 'POST', body: '{}' })
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/api/LocalApiServer.ts
+++ b/src/api/LocalApiServer.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import { handleHttp, type HttpHost } from '@dotpm/api'
+import { createRouter, type HttpHost, type HttpRequest, type HttpResponse } from '@dotpm/api'
 
 type HttpModule = typeof import('node:http')
 type Server = import('node:http').Server
@@ -15,17 +15,20 @@ export function generateToken(): string {
 }
 
 /**
- * The localhost server in front of `handleHttp`. Node's `http` is reached through the
+ * The localhost server in front of the router. Node's `http` is reached through the
  * desktop app's `require`, so this file loads on mobile but `start` refuses there.
  */
 export class LocalApiServer {
   private server: Server | null = null
   private boundPort = 0
+  private readonly route: (req: HttpRequest) => Promise<HttpResponse>
 
   constructor(
-    private readonly host: HttpHost,
+    host: HttpHost,
     private readonly port: () => number
-  ) {}
+  ) {
+    this.route = createRouter(host)
+  }
 
   get running(): boolean {
     return this.server !== null
@@ -97,11 +100,34 @@ export class LocalApiServer {
     for (const [name, value] of Object.entries(req.headers)) {
       headers[name] = Array.isArray(value) ? value.join(', ') : (value ?? '')
     }
-    const response = await handleHttp(
-      { method: req.method ?? 'GET', path: url.pathname, query: Object.fromEntries(url.searchParams), headers, body },
-      this.host
-    )
+    const response = await this.route({
+      method: req.method ?? 'GET',
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+      headers,
+      body
+    })
+    if (response.stream) {
+      await this.pipe(res, response.status, response.stream, response.headers)
+      return
+    }
     this.write(res, response.status, response.body, response.headers)
+  }
+
+  private async pipe(
+    res: ServerResponse,
+    status: number,
+    stream: ReadableStream<Uint8Array>,
+    extra: Record<string, string> = {}
+  ): Promise<void> {
+    res.writeHead(status, { 'cache-control': 'no-store', ...extra })
+    const reader = stream.getReader()
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      res.write(value)
+    }
+    res.end()
   }
 
   private write(res: ServerResponse, status: number, body: unknown, extra: Record<string, string> = {}): void {


### PR DESCRIPTION
The MCP endpoint now runs on mcp-lite's Streamable HTTP transport instead of our own JSON-RPC handling. A POST that accepts text/event-stream gets the reply as an event, which is what most clients send. Batches are refused, 2024-11-05 is no longer accepted, and DELETE /mcp answers 405 since the server keeps no session.

The bundle grows 29 KB minified and still requires nothing but obsidian, so it keeps loading on mobile.