### PR TITLE
define the api input schemas once and check them with valibot

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,6 +8,8 @@
   },
   "dependencies": {
     "@dotpm/core": "workspace:*",
-    "mcp-lite": "0.10.0"
+    "@valibot/to-json-schema": "1.7.1",
+    "mcp-lite": "0.10.0",
+    "valibot": "1.4.2"
   }
 }

--- a/packages/api/src/mcp.test.ts
+++ b/packages/api/src/mcp.test.ts
@@ -73,8 +73,34 @@ describe('createMcpHandler', () => {
     expect((await rpc('nope/method')).error?.code).toBe(-32601)
   })
 
+  it('advertises the schema the arguments are checked against', async () => {
+    const tools = await rpc('tools/list')
+    const create = (
+      tools.result as { tools: Array<{ name: string; inputSchema: Record<string, unknown> }> }
+    ).tools.find((tool) => tool.name === 'create_task')
+    expect(create?.inputSchema).toMatchObject({
+      type: 'object',
+      required: ['projectId', 'title'],
+      properties: {
+        progress: { type: 'integer', minimum: 0, maximum: 100 },
+        type: { enum: ['task', 'milestone', 'subtask'] },
+        due: { type: 'string', description: expect.stringContaining('YYYY-MM-DD') }
+      }
+    })
+    expect(create?.inputSchema['$schema']).toBeUndefined()
+
+    const refused = await call('create_task', { projectId: 'p1', title: 'Too far', progress: 101 })
+    expect(refused.error).toMatchObject({
+      code: -32602,
+      message: expect.stringContaining('progress must be an integer')
+    })
+    expect(api.calls).not.toContain('createTask p1')
+  })
+
   it('calls tools and returns JSON text content', async () => {
-    expect(parsed(await call('list_projects', {}))).toEqual([expect.objectContaining({ id: 'p1', title: 'Demo' })])
+    expect(parsed(await rpc('tools/call', { name: 'list_projects' }))).toEqual([
+      expect.objectContaining({ id: 'p1', title: 'Demo' })
+    ])
 
     const created = await call('create_task', { projectId: 'p1', title: 'Via MCP', tags: ['agent'] })
     expect(parsed(created)).toMatchObject({ id: 't3', title: 'Via MCP', tags: ['agent'] })

--- a/packages/api/src/mcp.ts
+++ b/packages/api/src/mcp.ts
@@ -1,3 +1,4 @@
+import { toJsonSchema } from '@valibot/to-json-schema'
 import {
   JSON_RPC_ERROR_CODES,
   McpServer,
@@ -6,8 +7,9 @@ import {
   type JsonRpcError,
   type ToolCallResult
 } from 'mcp-lite'
+import * as v from 'valibot'
 import { ApiRequestError, type DomainApi } from './contract'
-import { parseTaskSearch } from './resources'
+import { CREATE_FIELDS, MOVE_FIELDS, parseTaskSearch, SEARCH_FIELDS, TASK_FIELDS } from './resources'
 
 export interface ServerInfo {
   name: string
@@ -22,47 +24,23 @@ const INSTRUCTIONS =
 const PROJECT_TEMPLATE = 'dotpm://projects/{projectId}'
 const TASK_TEMPLATE = 'dotpm://tasks/{taskId}'
 
-type JsonSchema = Record<string, unknown>
-
-const TASK_FIELDS: Record<string, JsonSchema> = {
-  title: { type: 'string' },
-  description: { type: 'string', description: 'Markdown body of the task note' },
-  type: { type: 'string', enum: ['task', 'milestone', 'subtask'] },
-  status: { type: 'string', description: "One of the project's status ids (see get_project)" },
-  priority: { type: 'string', description: "One of the project's priority ids (see get_project)" },
-  start: { type: 'string', description: 'YYYY-MM-DD, or empty to clear' },
-  due: { type: 'string', description: 'YYYY-MM-DD, or empty to clear' },
-  progress: { type: 'integer', minimum: 0, maximum: 100 },
-  assignees: { type: 'array', items: { type: 'string' } },
-  tags: { type: 'array', items: { type: 'string' } },
-  dependencies: { type: 'array', items: { type: 'string' }, description: 'Ids of tasks this one waits for' },
-  recurrence: {
-    type: ['object', 'null'],
-    properties: {
-      interval: { type: 'string', enum: ['daily', 'weekly', 'monthly', 'yearly'] },
-      every: { type: 'integer', minimum: 1 },
-      endDate: { type: 'string' }
-    },
-    required: ['interval', 'every']
-  },
-  timeEstimate: { type: ['number', 'null'], description: 'Hours' },
-  customFields: { type: 'object', additionalProperties: true }
+function idField(name: string, description: string): v.GenericSchema<string, string> {
+  return v.pipe(v.string(`${name} is required`), v.description(description))
 }
+
+const projectId = idField('projectId', 'Id of the project, from list_projects')
+const taskId = idField('taskId', 'Id of the task, from list_tasks or search_tasks')
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function requireString(params: Record<string, unknown>, key: string): string {
-  const value = params[key]
-  if (typeof value !== 'string' || !value) throw new ApiRequestError('invalid', `${key} is required`)
-  return value
-}
-
-function withoutKeys(params: Record<string, unknown>, keys: string[]): Record<string, unknown> {
-  const rest: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(params)) if (!keys.includes(key)) rest[key] = value
-  return rest
+/** What a tool advertises. The two root keys the conversion adds are noise to a client. */
+function jsonSchema(schema: v.GenericSchema): Record<string, unknown> {
+  const converted = toJsonSchema(schema, { errorMode: 'ignore', typeMode: 'input' }) as Record<string, unknown>
+  delete converted['$schema']
+  delete converted['default']
+  return converted
 }
 
 function text(value: unknown): ToolCallResult {
@@ -77,24 +55,22 @@ function jsonContents(
 }
 
 /**
- * Registers one tool, with the arguments narrowed and the client-mistake contract in one
- * place: a mistake comes back as a tool result marked `isError`, not a protocol error.
+ * Registers one tool. The schema both checks the arguments, through the transport, and
+ * becomes the JSON Schema clients read. A call may leave `arguments` out entirely, which
+ * stands for an empty object; a value the vault refuses comes back as a tool result
+ * marked `isError` rather than a protocol error.
  */
-function tool(
+function tool<S extends v.GenericSchema>(
   server: McpServer,
   name: string,
-  def: {
-    description: string
-    inputSchema: JsonSchema
-    run: (params: Record<string, unknown>) => Promise<unknown>
-  }
+  def: { description: string; inputSchema: S; run: (args: v.InferOutput<S>) => Promise<unknown> }
 ): void {
-  server.tool<unknown>(name, {
+  server.tool<v.InferOutput<S>>(name, {
     description: def.description,
-    inputSchema: def.inputSchema,
-    handler: async (raw) => {
+    inputSchema: v.optional(def.inputSchema, () => ({}) as v.InferInput<S>),
+    handler: async (args) => {
       try {
-        return text(await def.run(isRecord(raw) ? raw : {}))
+        return text(await def.run(args))
       } catch (err: unknown) {
         if (err instanceof ApiRequestError) return { ...text({ error: err.code, message: err.message }), isError: true }
         throw err
@@ -106,129 +82,71 @@ function tool(
 function registerTools(server: McpServer, api: DomainApi): void {
   tool(server, 'list_projects', {
     description: 'Every project in the vault with its id, title, parent and task counts.',
-    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    inputSchema: v.object({}),
     run: () => api.listProjects()
   })
 
   tool(server, 'get_project', {
     description: 'One project with its description, team, custom fields and the status and priority ids its tasks use.',
-    inputSchema: {
-      type: 'object',
-      properties: { projectId: { type: 'string' } },
-      required: ['projectId'],
-      additionalProperties: false
-    },
-    run: (params) => api.getProject(requireString(params, 'projectId'))
+    inputSchema: v.object({ projectId }),
+    run: (args) => api.getProject(args.projectId)
   })
 
   tool(server, 'list_tasks', {
     description: 'All tasks of a project in tree order. Each carries parentId and position.',
-    inputSchema: {
-      type: 'object',
-      properties: { projectId: { type: 'string' }, includeArchived: { type: 'boolean' } },
-      required: ['projectId'],
-      additionalProperties: false
-    },
-    run: (params) => api.listTasks(requireString(params, 'projectId'), params['includeArchived'] === true)
+    inputSchema: v.object({ projectId, includeArchived: v.optional(v.boolean(), false) }),
+    run: (args) => api.listTasks(args.projectId, args.includeArchived)
   })
 
   tool(server, 'get_task', {
     description: 'One task by id, including its description.',
-    inputSchema: {
-      type: 'object',
-      properties: { taskId: { type: 'string' } },
-      required: ['taskId'],
-      additionalProperties: false
-    },
-    run: (params) => api.getTask(requireString(params, 'taskId'))
+    inputSchema: v.object({ taskId }),
+    run: (args) => api.getTask(args.taskId)
   })
 
   tool(server, 'search_tasks', {
     description: 'Find tasks across every project by title text, project, status or assignee.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        query: { type: 'string', description: 'Case-insensitive match on the title' },
-        projectId: { type: 'string' },
-        status: { type: 'string' },
-        assignee: { type: 'string' },
-        includeArchived: { type: 'boolean' },
-        limit: { type: 'integer', minimum: 1, maximum: 500 }
-      },
-      additionalProperties: false
-    },
-    run: (params) => api.searchTasks(parseTaskSearch(params))
+    inputSchema: v.object(SEARCH_FIELDS),
+    run: (args) => api.searchTasks(parseTaskSearch(args))
   })
 
   tool(server, 'create_task', {
     description: 'Create a task in a project, at the top level or under parentId.',
-    inputSchema: {
-      type: 'object',
-      properties: { projectId: { type: 'string' }, parentId: { type: ['string', 'null'] }, ...TASK_FIELDS },
-      required: ['projectId', 'title'],
-      additionalProperties: false
-    },
-    run: (params) => api.createTask(requireString(params, 'projectId'), withoutKeys(params, ['projectId']))
+    inputSchema: v.object({ projectId, ...CREATE_FIELDS }),
+    run: ({ projectId: project, ...create }) => api.createTask(project, create)
   })
 
   tool(server, 'update_task', {
     description:
       'Change fields of a task. Only the fields passed change. Pass expectedUpdatedAt from a previous read to refuse the write when the task changed since.',
-    inputSchema: {
-      type: 'object',
-      properties: { taskId: { type: 'string' }, expectedUpdatedAt: { type: 'string' }, ...TASK_FIELDS },
-      required: ['taskId'],
-      additionalProperties: false
-    },
-    run: (params) => {
-      const expected = params['expectedUpdatedAt']
-      return api.updateTask(
-        requireString(params, 'taskId'),
-        withoutKeys(params, ['taskId', 'expectedUpdatedAt']),
-        typeof expected === 'string' ? expected : undefined
-      )
-    }
+    inputSchema: v.object({
+      taskId,
+      expectedUpdatedAt: v.optional(
+        v.pipe(v.string('expectedUpdatedAt must be a string'), v.description('updatedAt from an earlier read'))
+      ),
+      ...TASK_FIELDS
+    }),
+    run: ({ taskId: task, expectedUpdatedAt, ...write }) => api.updateTask(task, write, expectedUpdatedAt)
   })
 
   tool(server, 'move_task', {
     description:
       'Re-parent a task (parentId, null for top level), move it to another project (projectId), or reorder it among its siblings (before or after a sibling id).',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        taskId: { type: 'string' },
-        parentId: { type: ['string', 'null'] },
-        projectId: { type: 'string' },
-        before: { type: 'string' },
-        after: { type: 'string' }
-      },
-      required: ['taskId'],
-      additionalProperties: false
-    },
-    run: (params) => api.moveTask(requireString(params, 'taskId'), withoutKeys(params, ['taskId']))
+    inputSchema: v.object({ taskId, ...MOVE_FIELDS }),
+    run: ({ taskId: task, ...move }) => api.moveTask(task, move)
   })
 
   tool(server, 'archive_task', {
     description: 'Archive a task and its subtasks, or bring them back with archived: false.',
-    inputSchema: {
-      type: 'object',
-      properties: { taskId: { type: 'string' }, archived: { type: 'boolean', default: true } },
-      required: ['taskId'],
-      additionalProperties: false
-    },
-    run: (params) => api.archiveTask(requireString(params, 'taskId'), params['archived'] !== false)
+    inputSchema: v.object({ taskId, archived: v.optional(v.boolean('archived must be true or false'), true) }),
+    run: (args) => api.archiveTask(args.taskId, args.archived)
   })
 
   tool(server, 'delete_task', {
     description: 'Delete a task and its subtasks. Cannot be undone.',
-    inputSchema: {
-      type: 'object',
-      properties: { taskId: { type: 'string' } },
-      required: ['taskId'],
-      additionalProperties: false
-    },
-    run: async (params) => {
-      await api.deleteTask(requireString(params, 'taskId'))
+    inputSchema: v.object({ taskId }),
+    run: async (args) => {
+      await api.deleteTask(args.taskId)
       return { deleted: true }
     }
   })
@@ -236,19 +154,20 @@ function registerTools(server: McpServer, api: DomainApi): void {
   tool(server, 'list_changes', {
     description:
       'Projects and tasks changed since a cursor, oldest first. Omit since for the current cursor only. A reset of true means the cursor was too old: refetch.',
-    inputSchema: { type: 'object', properties: { since: { type: 'integer' } }, additionalProperties: false },
-    run: (params) => {
-      const since = params['since']
-      return api.changes(typeof since === 'number' ? since : null)
-    }
+    inputSchema: v.object({
+      since: v.optional(
+        v.pipe(v.number('since must be an integer cursor'), v.integer('since must be an integer cursor'))
+      )
+    }),
+    run: (args) => api.changes(args.since ?? null)
   })
 }
 
 function registerResources(server: McpServer, api: DomainApi): void {
   server.resource(PROJECT_TEMPLATE, { name: 'Project with tasks', mimeType: 'application/json' }, async (uri, vars) => {
-    const projectId = String(vars['projectId'])
-    const [project, tasks] = await Promise.all([api.getProject(projectId), api.listTasks(projectId)])
-    return jsonContents(uri.href, { ...project, tasks })
+    const project = String(vars['projectId'])
+    const [resource, tasks] = await Promise.all([api.getProject(project), api.listTasks(project)])
+    return jsonContents(uri.href, { ...resource, tasks })
   })
 
   server.resource(TASK_TEMPLATE, { name: 'Task', mimeType: 'application/json' }, async (uri, vars) =>
@@ -294,7 +213,11 @@ function toRpcError(err: unknown): JsonRpcError | undefined {
  * client that wants the standalone `GET` stream is told the method is not allowed.
  */
 export function createMcpHandler(api: DomainApi, info: ServerInfo): (request: Request) => Promise<Response> {
-  const server = new McpServer({ name: info.name, version: info.version })
+  const server = new McpServer({
+    name: info.name,
+    version: info.version,
+    schemaAdapter: (schema) => jsonSchema(schema as v.GenericSchema)
+  })
   server.onError(toRpcError)
   completeResults(server, api)
   registerTools(server, api)

--- a/packages/api/src/resources.test.ts
+++ b/packages/api/src/resources.test.ts
@@ -97,13 +97,14 @@ describe('parseTaskMove', () => {
 })
 
 describe('parseTaskSearch', () => {
-  it('reads query-string shaped input', () => {
-    expect(parseTaskSearch({ query: 'x', includeArchived: 'true', limit: '10', status: '' })).toEqual({
+  it('keeps the filters that carry a value', () => {
+    expect(parseTaskSearch({ query: 'x', includeArchived: true, limit: 10, status: '' })).toEqual({
       query: 'x',
       includeArchived: true,
       limit: 10
     })
     rejects(() => parseTaskSearch({ limit: 0 }), 'limit must be an integer from 1 to 500')
+    rejects(() => parseTaskSearch({ includeArchived: 'true' }), 'includeArchived must be true or false')
   })
 })
 

--- a/packages/api/src/resources.ts
+++ b/packages/api/src/resources.ts
@@ -1,5 +1,6 @@
-import type { Project, Recurrence, ResolvedProjectConfig, Task, TaskType } from '@dotpm/core'
+import type { Project, ResolvedProjectConfig, Task } from '@dotpm/core'
 import { makeTask, parsePlainDate } from '@dotpm/core'
+import * as v from 'valibot'
 import {
   ApiRequestError,
   type ProjectResource,
@@ -11,15 +12,29 @@ import {
   type TaskWrite
 } from './contract'
 
-const TASK_TYPES: TaskType[] = ['task', 'milestone', 'subtask']
-const RECURRENCE_INTERVALS: Recurrence['interval'][] = ['daily', 'weekly', 'monthly', 'yearly']
+const TASK_TYPES = ['task', 'milestone', 'subtask'] as const
+const RECURRENCE_INTERVALS = ['daily', 'weekly', 'monthly', 'yearly'] as const
 
 export function invalid(message: string): never {
   throw new ApiRequestError('invalid', message)
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
+/**
+ * Every schema below carries its own message, so a client reads the same words whether it
+ * came in over HTTP, where this runs, or over MCP, where the transport validates first.
+ */
+function parse<S extends v.GenericSchema>(schema: S, input: unknown): v.InferOutput<S> {
+  const result = v.safeParse(schema, input)
+  if (!result.success) invalid(result.issues[0].message)
+  return result.output
+}
+
+/** An object reports both a wrong type and a key it is missing, so it names the key itself. */
+function missingKey(wrongType: string, prefix = ''): (issue: v.ObjectIssue) => string {
+  return (issue) => {
+    const key = issue.path?.[0]?.key
+    return typeof key === 'string' ? `${prefix}${key} is required` : wrongType
+  }
 }
 
 export function toTaskResource(task: Task, projectId: string, parentId: string | null, position: number): TaskResource {
@@ -82,153 +97,146 @@ export function toProjectResource(
   }
 }
 
-function readString(input: Record<string, unknown>, key: string): string | undefined {
-  const value = input[key]
-  if (value === undefined) return undefined
-  if (typeof value !== 'string') invalid(`${key} must be a string`)
-  return value
+function isCalendarDate(value: string): boolean {
+  return value === '' || (/^\d{4}-\d{2}-\d{2}$/.test(value) && parsePlainDate(value) !== null)
 }
 
-function readDate(input: Record<string, unknown>, key: string): string | undefined {
-  const value = readString(input, key)
-  if (value === undefined || value === '') return value
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value) || !parsePlainDate(value)) invalid(`${key} must be YYYY-MM-DD or empty`)
-  return value
+function stringField(name: string, description: string): v.GenericSchema<string, string> {
+  return v.pipe(v.string(`${name} must be a string`), v.description(description))
 }
 
-function readStringList(input: Record<string, unknown>, key: string): string[] | undefined {
-  const value = input[key]
-  if (value === undefined) return undefined
-  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
-    invalid(`${key} must be a list of strings`)
-  }
-  return value as string[]
+function dateField(name: string): v.GenericSchema<string, string> {
+  return v.pipe(
+    v.string(`${name} must be a string`),
+    v.check(isCalendarDate, `${name} must be YYYY-MM-DD or empty`),
+    v.description('YYYY-MM-DD, or empty to clear')
+  )
 }
 
-function readRecurrence(input: Record<string, unknown>): Recurrence | null | undefined {
-  const value = input['recurrence']
-  if (value === undefined) return undefined
-  if (value === null) return null
-  if (!isRecord(value)) invalid('recurrence must be an object or null')
-  const interval = value['interval']
-  const every = value['every']
-  if (!RECURRENCE_INTERVALS.includes(interval as Recurrence['interval'])) {
-    invalid(`recurrence.interval must be one of ${RECURRENCE_INTERVALS.join(', ')}`)
+function listField(name: string, description: string): v.GenericSchema<string[], string[]> {
+  const message = `${name} must be a list of strings`
+  return v.pipe(v.array(v.string(message), message), v.description(description))
+}
+
+function integerField(name: string, min: number, max: number): v.GenericSchema<number, number> {
+  const message = `${name} must be an integer from ${min} to ${max}`
+  return v.pipe(v.number(message), v.integer(message), v.minValue(min, message), v.maxValue(max, message))
+}
+
+const RECURRENCE = v.object(
+  {
+    interval: v.picklist(RECURRENCE_INTERVALS, `recurrence.interval must be one of ${RECURRENCE_INTERVALS.join(', ')}`),
+    every: v.pipe(
+      v.number('recurrence.every must be a positive integer'),
+      v.integer('recurrence.every must be a positive integer'),
+      v.minValue(1, 'recurrence.every must be a positive integer')
+    ),
+    endDate: v.optional(dateField('recurrence.endDate'))
+  },
+  missingKey('recurrence must be an object or null', 'recurrence.')
+)
+
+/** The fields a client may write, defining both what is accepted and what MCP advertises. */
+export const TASK_FIELDS = {
+  title: v.optional(
+    v.pipe(
+      v.string('title must be a string'),
+      v.check((title) => title.trim() !== '', 'title must not be empty')
+    )
+  ),
+  description: v.optional(stringField('description', 'Markdown body of the task note')),
+  type: v.optional(v.picklist(TASK_TYPES, `type must be one of ${TASK_TYPES.join(', ')}`)),
+  status: v.optional(stringField('status', "One of the project's status ids (see get_project)")),
+  priority: v.optional(stringField('priority', "One of the project's priority ids (see get_project)")),
+  start: v.optional(dateField('start')),
+  due: v.optional(dateField('due')),
+  progress: v.optional(integerField('progress', 0, 100)),
+  assignees: v.optional(listField('assignees', 'Names or wikilinks of the people on the task')),
+  tags: v.optional(listField('tags', 'Tags without the leading hash')),
+  dependencies: v.optional(listField('dependencies', 'Ids of tasks this one waits for')),
+  recurrence: v.optional(v.nullable(RECURRENCE)),
+  timeEstimate: v.optional(
+    v.nullable(
+      v.pipe(
+        v.number('timeEstimate must be a non-negative number or null'),
+        v.minValue(0, 'timeEstimate must be a non-negative number or null'),
+        v.description('Hours')
+      )
+    )
+  ),
+  customFields: v.optional(v.record(v.string(), v.unknown(), 'customFields must be an object'))
+}
+
+/** `title` is what separates a create from a patch, so only here is it required. */
+export const CREATE_FIELDS = {
+  ...TASK_FIELDS,
+  title: v.pipe(
+    v.string('title must be a string'),
+    v.check((title) => title.trim() !== '', 'title must not be empty')
+  ),
+  parentId: v.optional(v.nullable(v.string('parentId must be a string or null')), null)
+}
+
+export const MOVE_FIELDS = {
+  parentId: v.optional(v.nullable(v.string('parentId must be a string or null'))),
+  projectId: v.optional(stringField('projectId', 'Move the task to this project')),
+  before: v.optional(stringField('before', 'Id of the sibling to sit in front of')),
+  after: v.optional(stringField('after', 'Id of the sibling to sit behind'))
+}
+
+export const SEARCH_FIELDS = {
+  query: v.optional(stringField('query', 'Case-insensitive match on the title')),
+  projectId: v.optional(stringField('projectId', 'Only tasks of this project')),
+  status: v.optional(stringField('status', 'Only tasks with this status id')),
+  assignee: v.optional(stringField('assignee', 'Only tasks this person is on')),
+  includeArchived: v.optional(v.boolean('includeArchived must be true or false')),
+  limit: v.optional(integerField('limit', 1, 500))
+}
+
+const TASK_WRITE = v.object(TASK_FIELDS, missingKey('expected an object'))
+const TASK_CREATE = v.object(CREATE_FIELDS, missingKey('expected an object'))
+
+const TASK_MOVE = v.pipe(
+  v.object(MOVE_FIELDS, missingKey('expected an object')),
+  v.check((move) => move.before === undefined || move.after === undefined, 'pass before or after, not both'),
+  v.check(
+    (move) => move.parentId !== undefined || move.projectId !== undefined || Boolean(move.before || move.after),
+    'nothing to move: pass parentId, projectId, before or after'
+  )
+)
+
+const TASK_SEARCH = v.object(SEARCH_FIELDS, missingKey('expected an object'))
+
+/** Only the project knows which status and priority ids its tasks may carry. */
+function checkAgainstConfig(write: TaskWrite, config: ResolvedProjectConfig): void {
+  if (write.status !== undefined && !config.statuses.some((status) => status.id === write.status)) {
+    invalid(`status must be one of ${config.statuses.map((status) => status.id).join(', ')}`)
   }
-  if (typeof every !== 'number' || !Number.isInteger(every) || every < 1) {
-    invalid('recurrence.every must be a positive integer')
+  if (write.priority !== undefined && !config.priorities.some((priority) => priority.id === write.priority)) {
+    invalid(`priority must be one of ${config.priorities.map((priority) => priority.id).join(', ')}`)
   }
-  const endDate = readDate(value, 'endDate')
-  return { interval: interval as Recurrence['interval'], every, ...(endDate ? { endDate } : {}) }
 }
 
 export function parseTaskWrite(input: unknown, config: ResolvedProjectConfig): TaskWrite {
-  if (!isRecord(input)) invalid('expected an object')
-  const write: TaskWrite = {}
-  const title = readString(input, 'title')
-  if (title !== undefined) {
-    if (!title.trim()) invalid('title must not be empty')
-    write.title = title
-  }
-  const description = readString(input, 'description')
-  if (description !== undefined) write.description = description
-  const type = readString(input, 'type')
-  if (type !== undefined) {
-    if (!TASK_TYPES.includes(type as TaskType)) invalid(`type must be one of ${TASK_TYPES.join(', ')}`)
-    write.type = type as TaskType
-  }
-  const status = readString(input, 'status')
-  if (status !== undefined) {
-    if (!config.statuses.some((s) => s.id === status)) {
-      invalid(`status must be one of ${config.statuses.map((s) => s.id).join(', ')}`)
-    }
-    write.status = status
-  }
-  const priority = readString(input, 'priority')
-  if (priority !== undefined) {
-    if (!config.priorities.some((p) => p.id === priority)) {
-      invalid(`priority must be one of ${config.priorities.map((p) => p.id).join(', ')}`)
-    }
-    write.priority = priority
-  }
-  const start = readDate(input, 'start')
-  if (start !== undefined) write.start = start
-  const due = readDate(input, 'due')
-  if (due !== undefined) write.due = due
-  const progress = input['progress']
-  if (progress !== undefined) {
-    if (typeof progress !== 'number' || !Number.isInteger(progress) || progress < 0 || progress > 100) {
-      invalid('progress must be an integer from 0 to 100')
-    }
-    write.progress = progress
-  }
-  for (const key of ['assignees', 'tags', 'dependencies'] as const) {
-    const list = readStringList(input, key)
-    if (list !== undefined) write[key] = list
-  }
-  const recurrence = readRecurrence(input)
-  if (recurrence !== undefined) write.recurrence = recurrence
-  const timeEstimate = input['timeEstimate']
-  if (timeEstimate !== undefined) {
-    if (timeEstimate !== null && (typeof timeEstimate !== 'number' || timeEstimate < 0)) {
-      invalid('timeEstimate must be a non-negative number or null')
-    }
-    write.timeEstimate = timeEstimate
-  }
-  const customFields = input['customFields']
-  if (customFields !== undefined) {
-    if (!isRecord(customFields)) invalid('customFields must be an object')
-    write.customFields = customFields
-  }
+  const write = parse(TASK_WRITE, input)
+  checkAgainstConfig(write, config)
   return write
 }
 
 export function parseTaskCreate(input: unknown, config: ResolvedProjectConfig): TaskCreate {
-  const write = parseTaskWrite(input, config)
-  if (write.title === undefined) invalid('title is required')
-  const record = input as Record<string, unknown>
-  const parentId = record['parentId']
-  if (parentId !== undefined && parentId !== null && typeof parentId !== 'string') {
-    invalid('parentId must be a string or null')
-  }
-  return { ...write, title: write.title, parentId: parentId ?? null }
+  const create = parse(TASK_CREATE, input)
+  checkAgainstConfig(create, config)
+  return create
 }
 
 export function parseTaskMove(input: unknown): TaskMove {
-  if (!isRecord(input)) invalid('expected an object')
-  const move: TaskMove = {}
-  const parentId = input['parentId']
-  if (parentId !== undefined) {
-    if (parentId !== null && typeof parentId !== 'string') invalid('parentId must be a string or null')
-    move.parentId = parentId
-  }
-  for (const key of ['projectId', 'before', 'after'] as const) {
-    const value = readString(input, key)
-    if (value !== undefined) move[key] = value
-  }
-  if (move.before !== undefined && move.after !== undefined) invalid('pass before or after, not both')
-  if (move.parentId === undefined && move.projectId === undefined && !move.before && !move.after) {
-    invalid('nothing to move: pass parentId, projectId, before or after')
-  }
-  return move
+  return parse(TASK_MOVE, input)
 }
 
 export function parseTaskSearch(input: unknown): TaskSearch {
-  if (!isRecord(input)) invalid('expected an object')
-  const search: TaskSearch = {}
+  const search = parse(TASK_SEARCH, input)
   for (const key of ['query', 'projectId', 'status', 'assignee'] as const) {
-    const value = readString(input, key)
-    if (value !== undefined && value !== '') search[key] = value
-  }
-  const includeArchived = input['includeArchived']
-  if (includeArchived !== undefined) search.includeArchived = includeArchived === true || includeArchived === 'true'
-  const limit = input['limit']
-  if (limit !== undefined) {
-    const n = typeof limit === 'string' ? Number(limit) : limit
-    if (typeof n !== 'number' || !Number.isInteger(n) || n < 1 || n > 500) {
-      invalid('limit must be an integer from 1 to 500')
-    }
-    search.limit = n
+    if (search[key] === '') search[key] = undefined
   }
   return search
 }

--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -51,6 +51,17 @@ function match(pattern: string, path: string): Record<string, string> | null {
   return params
 }
 
+/** A query string carries only strings, while the search fields are typed. */
+function search(req: HttpRequest): Record<string, unknown> {
+  const { includeArchived, limit, q, query, ...rest } = req.query
+  return {
+    ...rest,
+    query: q ?? query,
+    ...(includeArchived === undefined ? {} : { includeArchived: includeArchived === 'true' }),
+    ...(limit === undefined ? {} : { limit: Number(limit) })
+  }
+}
+
 function bearer(req: HttpRequest): string | null {
   const header = req.headers['authorization'] ?? ''
   return header.startsWith('Bearer ') ? header.slice(7).trim() : null
@@ -103,12 +114,7 @@ async function route(req: HttpRequest, host: HttpHost): Promise<HttpResponse> {
     return json(200, await api.archiveTask(p['id'], body.archived !== false))
   }
 
-  if (path === '/v1/search' && method === 'GET') {
-    return json(
-      200,
-      await api.searchTasks(parseTaskSearch({ ...req.query, query: req.query['q'] ?? req.query['query'] }))
-    )
-  }
+  if (path === '/v1/search' && method === 'GET') return json(200, await api.searchTasks(parseTaskSearch(search(req))))
 
   if (path === '/v1/changes' && method === 'GET') {
     const since = req.query['since']

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,15 @@ importers:
       '@dotpm/core':
         specifier: workspace:*
         version: link:../core
+      '@valibot/to-json-schema':
+        specifier: 1.7.1
+        version: 1.7.1(valibot@1.4.2(typescript@6.0.3))
       mcp-lite:
         specifier: 0.10.0
         version: 0.10.0
+      valibot:
+        specifier: 1.4.2
+        version: 1.4.2(typescript@6.0.3)
 
   packages/core:
     dependencies:
@@ -878,6 +884,11 @@ packages:
   '@typescript-eslint/visitor-keys@8.69.0':
     resolution: {integrity: sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@valibot/to-json-schema@1.7.1':
+    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
+    peerDependencies:
+      valibot: ^1.4.0
 
   '@vitest/coverage-v8@5.0.0':
     resolution: {integrity: sha512-toMg6PZGCIa/lQNCDoASrfb1ly4hsUKXFtFYC9kD4t78o5Y6LyNJU7AENt8eHPr3quYdxaxK7hj2mnbFfUk9NA==}
@@ -2361,6 +2372,14 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   verkit@0.4.0:
     resolution: {integrity: sha512-sXMwN6DMHeouPfCxkxWkKAmxphWKEenHYY5H1nIBzU3PmDsmJp6kBXJdshjVdpMZuWCmL9SH7KFRx29AylpP6g==}
     engines: {node: '>=18.12.0'}
@@ -3150,6 +3169,10 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.69.0
       eslint-visitor-keys: 5.0.1
+
+  '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))':
+    dependencies:
+      valibot: 1.4.2(typescript@6.0.3)
 
   '@vitest/coverage-v8@5.0.0(vitest@5.0.0)':
     dependencies:
@@ -4849,6 +4872,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  valibot@1.4.2(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   verkit@0.4.0: {}
 


### PR DESCRIPTION
Task write, move and search fields are now defined once as valibot schemas that both check incoming values and produce the JSON Schema MCP clients read. The two were written out separately and could disagree.

Tools now advertise field descriptions, the progress and limit ranges and their required ids, and arguments the schema rejects come back as -32602 instead of reaching the vault. includeArchived has to be a real boolean now; the HTTP router converts the query string.