### PR TITLE
serve the api as a hono fetch handler

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@dotpm/core": "workspace:*",
     "@valibot/to-json-schema": "1.7.1",
+    "hono": "4.13.7",
     "mcp-lite": "0.10.0",
     "valibot": "1.4.2"
   }

--- a/packages/api/src/router.test.ts
+++ b/packages/api/src/router.test.ts
@@ -1,133 +1,144 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { FakeApi } from '../test/fakeApi'
-import { bearerAuth, createRouter, tokenMatches, type HttpRequest, type HttpResponse } from './router'
+import { createRouter, tokenMatches } from './router'
 
 const TOKEN = 'secret-token-0123456789'
 
-function request(method: string, path: string, extra: Partial<HttpRequest> = {}): HttpRequest {
-  return {
-    method,
-    path,
-    query: {},
-    headers: { authorization: `Bearer ${TOKEN}` },
-    body: undefined,
-    ...extra
-  }
-}
-
 describe('createRouter', () => {
   let api: FakeApi
-  let route: (req: HttpRequest) => Promise<HttpResponse>
+  let route: (request: Request) => Response | Promise<Response>
 
   beforeEach(() => {
     api = new FakeApi()
-    route = createRouter({ api, info: { name: 'dotpm', version: '9.9.9' }, authorized: bearerAuth(() => TOKEN) })
+    route = createRouter({ api, info: { name: 'dotpm', version: '9.9.9' }, token: () => TOKEN })
   })
 
+  async function send(
+    method: string,
+    path: string,
+    extra: { body?: unknown; headers?: Record<string, string> } = {}
+  ): Promise<Response> {
+    return route(
+      new Request(`http://127.0.0.1${path}`, {
+        method,
+        headers: { authorization: `Bearer ${TOKEN}`, ...extra.headers },
+        body: extra.body === undefined ? undefined : JSON.stringify(extra.body)
+      })
+    )
+  }
+
+  async function json(method: string, path: string, extra?: { body?: unknown; headers?: Record<string, string> }) {
+    const res = await send(method, path, extra)
+    return { status: res.status, body: res.status === 204 ? undefined : await res.json() }
+  }
+
   it('answers health without a token', async () => {
-    const res = await route(request('GET', '/v1/health', { headers: {} }))
+    const res = await send('GET', '/v1/health', { headers: { authorization: '' } })
     expect(res.status).toBe(200)
-    expect(res.body).toEqual({ ok: true, name: 'dotpm', version: '9.9.9' })
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    expect(await res.json()).toEqual({ ok: true, name: 'dotpm', version: '9.9.9' })
   })
 
   it('refuses everything else without the token', async () => {
-    const res = await route(request('GET', '/v1/projects', { headers: {} }))
-    expect(res.status).toBe(401)
+    const missing = await route(new Request('http://127.0.0.1/v1/projects'))
+    expect(missing.status).toBe(401)
+    expect(await missing.json()).toEqual({ error: { code: 'unauthorized', message: expect.any(String) } })
+    expect((await send('GET', '/v1/projects', { headers: { authorization: 'Bearer nope' } })).status).toBe(401)
     expect(api.calls).toEqual([])
   })
 
   it('lists and reads projects and tasks', async () => {
-    expect((await route(request('GET', '/v1/projects'))).body).toEqual([
+    expect((await json('GET', '/v1/projects')).body).toEqual([
       expect.objectContaining({ id: 'p1', title: 'Demo', taskCount: 2, doneCount: 1 })
     ])
-    expect((await route(request('GET', '/v1/projects/p1'))).body).toMatchObject({
-      id: 'p1',
-      statuses: expect.any(Array)
-    })
-    const tasks = await route(request('GET', '/v1/projects/p1/tasks'))
+    expect((await json('GET', '/v1/projects/p1')).body).toMatchObject({ id: 'p1', statuses: expect.any(Array) })
+    const tasks = await json('GET', '/v1/projects/p1/tasks')
     expect((tasks.body as unknown[]).length).toBe(2)
-    expect((await route(request('GET', '/v1/tasks/t2'))).body).toMatchObject({ id: 't2', position: 1 })
+    expect((await json('GET', '/v1/tasks/t2')).body).toMatchObject({ id: 't2', position: 1 })
   })
 
   it('maps client mistakes to statuses', async () => {
-    expect((await route(request('GET', '/v1/projects/nope'))).status).toBe(404)
-    expect((await route(request('GET', '/v1/nothing/here'))).status).toBe(404)
-    const bad = await route(request('POST', '/v1/projects/p1/tasks', { body: { title: '' } }))
+    expect((await json('GET', '/v1/projects/nope')).status).toBe(404)
+    const unknown = await json('GET', '/v1/nothing/here')
+    expect(unknown.status).toBe(404)
+    expect(unknown.body).toMatchObject({ error: { code: 'not_found' } })
+    const bad = await json('POST', '/v1/projects/p1/tasks', { body: { title: '' } })
     expect(bad.status).toBe(400)
     expect(bad.body).toEqual({ error: { code: 'invalid', message: 'title must not be empty' } })
+    const broken = await route(
+      new Request('http://127.0.0.1/v1/projects/p1/tasks', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${TOKEN}` },
+        body: '{ not json'
+      })
+    )
+    expect(broken.status).toBe(400)
+    expect(await broken.json()).toEqual({ error: { code: 'invalid', message: 'body is not valid JSON' } })
   })
 
   it('creates, updates with If-Match, moves, archives and deletes', async () => {
-    const created = await route(
-      request('POST', '/v1/projects/p1/tasks', { body: { title: 'Third', due: '2030-01-02' } })
-    )
+    const created = await json('POST', '/v1/projects/p1/tasks', { body: { title: 'Third', due: '2030-01-02' } })
     expect(created.status).toBe(201)
     expect(created.body).toMatchObject({ id: 't3', title: 'Third', due: '2030-01-02' })
 
-    const stale = await route(
-      request('PATCH', '/v1/tasks/t3', {
-        body: { status: 'done' },
-        headers: { authorization: `Bearer ${TOKEN}`, 'if-match': '"old"' }
-      })
-    )
+    const stale = await json('PATCH', '/v1/tasks/t3', {
+      body: { status: 'done' },
+      headers: { 'if-match': '"old"' }
+    })
     expect(stale.status).toBe(412)
-    const updated = await route(request('PATCH', '/v1/tasks/t3', { body: { status: 'done' } }))
-    expect(updated.body).toMatchObject({ status: 'done' })
+    expect((await json('PATCH', '/v1/tasks/t3', { body: { status: 'done' } })).body).toMatchObject({ status: 'done' })
 
-    await route(request('POST', '/v1/tasks/t3/move', { body: { parentId: 't1' } }))
+    await json('POST', '/v1/tasks/t3/move', { body: { parentId: 't1' } })
     expect(api.calls).toContain('moveTask t3 {"parentId":"t1"}')
 
-    expect((await route(request('POST', '/v1/tasks/t3/archive'))).body).toMatchObject({ archived: true })
-    expect((await route(request('POST', '/v1/tasks/t3/archive', { body: { archived: false } }))).body).toMatchObject({
+    expect((await json('POST', '/v1/tasks/t3/archive')).body).toMatchObject({ archived: true })
+    expect((await json('POST', '/v1/tasks/t3/archive', { body: { archived: false } })).body).toMatchObject({
       archived: false
     })
 
-    expect((await route(request('DELETE', '/v1/tasks/t3'))).status).toBe(204)
-    expect((await route(request('GET', '/v1/tasks/t3'))).status).toBe(404)
+    expect((await json('DELETE', '/v1/tasks/t3')).status).toBe(204)
+    expect((await json('GET', '/v1/tasks/t3')).status).toBe(404)
   })
 
   it('searches with the q parameter and pages changes by cursor', async () => {
-    const found = await route(request('GET', '/v1/search', { query: { q: 'sec', limit: '5' } }))
-    expect((found.body as Array<{ id: string }>).map((t) => t.id)).toEqual(['t2'])
+    const found = await json('GET', '/v1/search?q=sec&limit=5')
+    expect((found.body as Array<{ id: string }>).map((task) => task.id)).toEqual(['t2'])
     expect(api.calls.at(-1)).toBe('searchTasks {"query":"sec","limit":5}')
 
-    expect((await route(request('GET', '/v1/changes', { query: { since: 'x' } }))).status).toBe(400)
-    await route(request('GET', '/v1/changes', { query: { since: '3' } }))
+    expect((await json('GET', '/v1/changes?since=x')).status).toBe(400)
+    await json('GET', '/v1/changes?since=3')
     expect(api.calls.at(-1)).toBe('changes 3')
   })
 
   it('serves MCP on /mcp and rejects the session methods it has no session for', async () => {
-    const init = await route(
-      request('POST', '/mcp', {
-        body: { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26' } }
-      })
-    )
+    const init = await json('POST', '/mcp', {
+      body: { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26' } }
+    })
     expect(init.status).toBe(200)
     expect(init.body).toMatchObject({ id: 1, result: { protocolVersion: '2025-03-26', serverInfo: { name: 'dotpm' } } })
 
-    const note = await route(request('POST', '/mcp', { body: { jsonrpc: '2.0', method: 'notifications/initialized' } }))
+    const note = await send('POST', '/mcp', { body: { jsonrpc: '2.0', method: 'notifications/initialized' } })
     expect(note.status).toBe(202)
-    expect(note.body).toBeUndefined()
+    expect(await note.text()).toBe('')
 
-    const headers = { authorization: `Bearer ${TOKEN}`, accept: 'text/event-stream' }
-    expect((await route(request('GET', '/mcp', { headers }))).status).toBe(405)
-    expect((await route(request('DELETE', '/mcp'))).status).toBe(405)
+    expect((await send('GET', '/mcp', { headers: { accept: 'text/event-stream' } })).status).toBe(405)
+    expect((await send('DELETE', '/mcp')).status).toBe(405)
   })
 
-  it('hands an event stream back to the host untouched', async () => {
-    const res = await route(
-      request('POST', '/mcp', {
-        headers: { authorization: `Bearer ${TOKEN}`, accept: 'application/json, text/event-stream' },
-        body: { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'list_projects' } }
-      })
-    )
-    expect(res.headers).toMatchObject({ 'content-type': 'text/event-stream' })
-    expect(res.body).toBeUndefined()
-    expect(await new Response(res.stream).text()).toContain('"id":4')
+  it('hands an event stream straight back', async () => {
+    const res = await send('POST', '/mcp', {
+      headers: { accept: 'application/json, text/event-stream' },
+      body: { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'list_projects' } }
+    })
+    expect(res.headers.get('content-type')).toBe('text/event-stream')
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    expect(await res.text()).toContain('"id":4')
   })
 
   it('needs the token for MCP too', async () => {
-    const res = await route(request('POST', '/mcp', { headers: {}, body: { jsonrpc: '2.0', id: 1, method: 'ping' } }))
+    const res = await route(
+      new Request('http://127.0.0.1/mcp', { method: 'POST', body: JSON.stringify({ jsonrpc: '2.0', id: 1 }) })
+    )
     expect(res.status).toBe(401)
   })
 })
@@ -137,7 +148,7 @@ describe('tokenMatches', () => {
     expect(tokenMatches('abc', 'abc')).toBe(true)
     expect(tokenMatches('abd', 'abc')).toBe(false)
     expect(tokenMatches('ab', 'abc')).toBe(false)
-    expect(tokenMatches(null, 'abc')).toBe(false)
+    expect(tokenMatches('', 'abc')).toBe(false)
     expect(tokenMatches('', '')).toBe(false)
   })
 })

--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -1,59 +1,54 @@
-import { ApiRequestError, ERROR_STATUS, type DomainApi } from './contract'
+import { Hono, type Context } from 'hono'
+import { bearerAuth } from 'hono/bearer-auth'
+import { except } from 'hono/combine'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
+import { ApiRequestError, ERROR_STATUS, type ApiErrorCode, type DomainApi } from './contract'
 import { createMcpHandler, type ServerInfo } from './mcp'
 import { parseTaskSearch } from './resources'
-
-export interface HttpRequest {
-  method: string
-  /** Pathname only, no query string. */
-  path: string
-  query: Record<string, string>
-  /** Lower-cased header names. */
-  headers: Record<string, string>
-  body: unknown
-}
-
-export interface HttpResponse {
-  status: number
-  body?: unknown
-  headers?: Record<string, string>
-  /** Set instead of `body` when the host must pipe the bytes through unchanged. */
-  stream?: ReadableStream<Uint8Array>
-}
 
 export interface HttpHost {
   api: DomainApi
   info: ServerInfo
-  authorized(req: HttpRequest): boolean
+  token: () => string
 }
 
-function json(status: number, body: unknown): HttpResponse {
-  return { status, body }
+function fail(code: ApiErrorCode, message: string): { error: { code: ApiErrorCode; message: string } } {
+  return { error: { code, message } }
 }
 
-function error(code: keyof typeof ERROR_STATUS, message: string): HttpResponse {
-  return json(ERROR_STATUS[code], { error: { code, message } })
+/** Constant-time compare, so the token can't be guessed byte by byte through timing. */
+export function tokenMatches(presented: string, expected: string): boolean {
+  if (!presented || !expected || presented.length !== expected.length) return false
+  let diff = 0
+  for (let i = 0; i < expected.length; i++) diff |= presented.charCodeAt(i) ^ expected.charCodeAt(i)
+  return diff === 0
 }
 
-/** Matches `/v1/tasks/:id/move` style patterns, returning the named segments. */
-function match(pattern: string, path: string): Record<string, string> | null {
-  const want = pattern.split('/')
-  const have = path.split('/')
-  if (want.length !== have.length) return null
-  const params: Record<string, string> = {}
-  for (let i = 0; i < want.length; i++) {
-    if (want[i].startsWith(':')) {
-      if (!have[i]) return null
-      params[want[i].slice(1)] = decodeURIComponent(have[i])
-    } else if (want[i] !== have[i]) {
-      return null
-    }
+/** An empty body is not a mistake: `archive` and the pickers read their defaults from it. */
+async function body(c: Context): Promise<unknown> {
+  const raw = await c.req.text()
+  if (!raw.trim()) return undefined
+  try {
+    return JSON.parse(raw)
+  } catch {
+    throw new ApiRequestError('invalid', 'body is not valid JSON')
   }
-  return params
+}
+
+/** Hono's own failures already carry a response; ours become the error shape clients read. */
+function toResponse(err: unknown, c: Context): Response {
+  if (err instanceof HTTPException) return err.getResponse()
+  if (err instanceof ApiRequestError) {
+    return c.json(fail(err.code, err.message), ERROR_STATUS[err.code] as ContentfulStatusCode)
+  }
+  console.error('[PM] api request failed', err)
+  return c.json({ error: { code: 'internal', message: 'request failed; see the developer console' } }, 500)
 }
 
 /** A query string carries only strings, while the search fields are typed. */
-function search(req: HttpRequest): Record<string, unknown> {
-  const { includeArchived, limit, q, query, ...rest } = req.query
+function search(c: Context): Record<string, unknown> {
+  const { includeArchived, limit, q, query, ...rest } = c.req.query()
   return {
     ...rest,
     query: q ?? query,
@@ -62,108 +57,80 @@ function search(req: HttpRequest): Record<string, unknown> {
   }
 }
 
-function bearer(req: HttpRequest): string | null {
-  const header = req.headers['authorization'] ?? ''
-  return header.startsWith('Bearer ') ? header.slice(7).trim() : null
-}
-
-/** Constant-time compare, so the token can't be guessed byte by byte through timing. */
-export function tokenMatches(presented: string | null, expected: string): boolean {
-  if (!presented || !expected || presented.length !== expected.length) return false
-  let diff = 0
-  for (let i = 0; i < expected.length; i++) diff |= presented.charCodeAt(i) ^ expected.charCodeAt(i)
-  return diff === 0
-}
-
-export function bearerAuth(token: () => string): (req: HttpRequest) => boolean {
-  return (req) => tokenMatches(bearer(req), token())
-}
-
-async function route(req: HttpRequest, host: HttpHost): Promise<HttpResponse> {
-  const { api } = host
-  const { method, path } = req
-  let p: Record<string, string> | null
-
-  if (path === '/v1/projects' && method === 'GET') return json(200, await api.listProjects())
-
-  if ((p = match('/v1/projects/:id', path)) && method === 'GET') return json(200, await api.getProject(p['id']))
-
-  if ((p = match('/v1/projects/:id/tasks', path))) {
-    if (method === 'GET') return json(200, await api.listTasks(p['id'], req.query['includeArchived'] === 'true'))
-    if (method === 'POST') return json(201, await api.createTask(p['id'], req.body))
-  }
-
-  if ((p = match('/v1/tasks/:id', path))) {
-    if (method === 'GET') return json(200, await api.getTask(p['id']))
-    if (method === 'PATCH') {
-      const expected = req.headers['if-match']?.replace(/^"|"$/g, '')
-      return json(200, await api.updateTask(p['id'], req.body, expected))
-    }
-    if (method === 'DELETE') {
-      await api.deleteTask(p['id'])
-      return { status: 204 }
-    }
-  }
-
-  if ((p = match('/v1/tasks/:id/move', path)) && method === 'POST') {
-    return json(200, await api.moveTask(p['id'], req.body))
-  }
-
-  if ((p = match('/v1/tasks/:id/archive', path)) && method === 'POST') {
-    const body = (req.body ?? {}) as { archived?: unknown }
-    return json(200, await api.archiveTask(p['id'], body.archived !== false))
-  }
-
-  if (path === '/v1/search' && method === 'GET') return json(200, await api.searchTasks(parseTaskSearch(search(req))))
-
-  if (path === '/v1/changes' && method === 'GET') {
-    const since = req.query['since']
-    const cursor = since === undefined || since === '' ? null : Number(since)
-    if (cursor !== null && !Number.isInteger(cursor)) return error('invalid', 'since must be an integer cursor')
-    return json(200, await api.changes(cursor))
-  }
-
-  return error('not_found', `no route for ${method} ${path}`)
-}
-
-/** The MCP transport speaks fetch, so the request is rebuilt and the reply unwrapped. */
-async function mcp(handle: (request: Request) => Promise<Response>, req: HttpRequest): Promise<HttpResponse> {
-  const headers = new Headers(req.headers)
-  headers.delete('content-length')
-  const response = await handle(
-    new Request('http://127.0.0.1/mcp', {
-      method: req.method,
-      headers,
-      body: req.body === undefined ? undefined : JSON.stringify(req.body)
-    })
-  )
-  const contentType = response.headers.get('content-type') ?? ''
-  if (contentType.startsWith('text/event-stream') && response.body) {
-    return { status: response.status, stream: response.body, headers: { 'content-type': contentType } }
-  }
-  if (!contentType.startsWith('application/json')) return { status: response.status }
-  const raw = await response.text()
-  return { status: response.status, body: raw ? JSON.parse(raw) : undefined }
-}
-
 /**
- * The whole HTTP surface, independent of any server: the host reads the request, hands
- * it here, and writes whatever comes back. `/v1/health` needs no token. The MCP server
+ * The whole HTTP surface as a fetch handler, so it runs in front of any server that can
+ * hand it a `Request`. `/v1/health` is the one route that needs no token. The MCP server
  * behind `/mcp` is built once, so build the router once too.
  */
-export function createRouter(host: HttpHost): (req: HttpRequest) => Promise<HttpResponse> {
-  const handleMcp = createMcpHandler(host.api, host.info)
-  return async (req) => {
-    if (req.path === '/v1/health' && req.method === 'GET') {
-      return json(200, { ok: true, name: host.info.name, version: host.info.version })
+export function createRouter(host: HttpHost): (request: Request) => Response | Promise<Response> {
+  const { api } = host
+  const mcp = createMcpHandler(api, host.info)
+  const app = new Hono()
+
+  app.use(async (c, next) => {
+    await next()
+    c.header('cache-control', 'no-store')
+  })
+
+  app.use(
+    except(
+      '/v1/health',
+      bearerAuth({
+        verifyToken: (token) => tokenMatches(token, host.token()),
+        noAuthenticationHeader: { message: fail('unauthorized', 'missing or wrong bearer token') },
+        invalidAuthenticationHeader: { message: fail('invalid', 'the authorization header is malformed') },
+        invalidToken: { message: fail('unauthorized', 'missing or wrong bearer token') }
+      })
+    )
+  )
+
+  app.get('/v1/health', (c) => c.json({ ok: true, name: host.info.name, version: host.info.version }))
+
+  app.all('/mcp', (c) => mcp(c.req.raw))
+
+  app.get('/v1/projects', async (c) => c.json(await api.listProjects()))
+
+  app.get('/v1/projects/:id', async (c) => c.json(await api.getProject(c.req.param('id'))))
+
+  app.get('/v1/projects/:id/tasks', async (c) =>
+    c.json(await api.listTasks(c.req.param('id'), c.req.query('includeArchived') === 'true'))
+  )
+
+  app.post('/v1/projects/:id/tasks', async (c) => c.json(await api.createTask(c.req.param('id'), await body(c)), 201))
+
+  app.get('/v1/tasks/:id', async (c) => c.json(await api.getTask(c.req.param('id'))))
+
+  app.patch('/v1/tasks/:id', async (c) => {
+    const expected = c.req.header('if-match')?.replace(/^"|"$/g, '')
+    return c.json(await api.updateTask(c.req.param('id'), await body(c), expected))
+  })
+
+  app.delete('/v1/tasks/:id', async (c) => {
+    await api.deleteTask(c.req.param('id'))
+    return c.body(null, 204)
+  })
+
+  app.post('/v1/tasks/:id/move', async (c) => c.json(await api.moveTask(c.req.param('id'), await body(c))))
+
+  app.post('/v1/tasks/:id/archive', async (c) => {
+    const asked = ((await body(c)) ?? {}) as { archived?: unknown }
+    return c.json(await api.archiveTask(c.req.param('id'), asked.archived !== false))
+  })
+
+  app.get('/v1/search', async (c) => c.json(await api.searchTasks(parseTaskSearch(search(c)))))
+
+  app.get('/v1/changes', async (c) => {
+    const since = c.req.query('since')
+    const cursor = since === undefined || since === '' ? null : Number(since)
+    if (cursor !== null && !Number.isInteger(cursor)) {
+      throw new ApiRequestError('invalid', 'since must be an integer cursor')
     }
-    if (!host.authorized(req)) return error('unauthorized', 'missing or wrong bearer token')
-    try {
-      return req.path === '/mcp' ? await mcp(handleMcp, req) : await route(req, host)
-    } catch (err: unknown) {
-      if (err instanceof ApiRequestError) return error(err.code, err.message)
-      console.error('[PM] api request failed', err)
-      return json(500, { error: { code: 'internal', message: 'request failed; see the developer console' } })
-    }
-  }
+    return c.json(await api.changes(cursor))
+  })
+
+  app.notFound((c) => c.json(fail('not_found', `no route for ${c.req.method} ${c.req.path}`), 404))
+
+  app.onError(toResponse)
+
+  return app.fetch
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@valibot/to-json-schema':
         specifier: 1.7.1
         version: 1.7.1(valibot@1.4.2(typescript@6.0.3))
+      hono:
+        specifier: 4.13.7
+        version: 4.13.7
       mcp-lite:
         specifier: 0.10.0
         version: 0.10.0
@@ -1567,6 +1570,10 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
+    engines: {node: '>=16.9.0'}
 
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
@@ -3991,6 +3998,8 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  hono@4.13.7: {}
 
   hookable@6.1.1: {}
 

--- a/src/api/LocalApiServer.test.ts
+++ b/src/api/LocalApiServer.test.ts
@@ -1,5 +1,4 @@
 import { createRequire } from 'node:module'
-import { bearerAuth } from '@dotpm/api'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { FakeApi } from '../../packages/api/test/fakeApi'
 import { LocalApiServer } from './LocalApiServer'
@@ -13,7 +12,7 @@ describe('LocalApiServer', () => {
   beforeAll(async () => {
     ;(globalThis as unknown as { window: unknown }).window = { require: createRequire(import.meta.url) }
     const server = new LocalApiServer(
-      { api: new FakeApi(), info: { name: 'dotpm', version: '9.9.9' }, authorized: bearerAuth(() => TOKEN) },
+      { api: new FakeApi(), info: { name: 'dotpm', version: '9.9.9' }, token: () => TOKEN },
       () => PORT
     )
     await server.start()
@@ -55,6 +54,16 @@ describe('LocalApiServer', () => {
     const body = await res.text()
     expect(body.startsWith('data: ')).toBe(true)
     expect(body).toContain('Demo')
+  })
+
+  it('creates a task over HTTP', async () => {
+    const res = await fetch(`${base}/v1/projects/p1/tasks`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${TOKEN}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ title: 'Over the socket' })
+    })
+    expect(res.status).toBe(201)
+    expect(await res.json()).toMatchObject({ title: 'Over the socket' })
   })
 
   it('refuses a request without the token', async () => {

--- a/src/api/LocalApiServer.ts
+++ b/src/api/LocalApiServer.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import { createRouter, type HttpHost, type HttpRequest, type HttpResponse } from '@dotpm/api'
+import { createRouter, type HttpHost } from '@dotpm/api'
 
 type HttpModule = typeof import('node:http')
 type Server = import('node:http').Server
@@ -15,13 +15,14 @@ export function generateToken(): string {
 }
 
 /**
- * The localhost server in front of the router. Node's `http` is reached through the
+ * The localhost socket in front of the router: a Node request becomes a `Request`, and
+ * whatever comes back is written out as it arrives. Node's `http` is reached through the
  * desktop app's `require`, so this file loads on mobile but `start` refuses there.
  */
 export class LocalApiServer {
   private server: Server | null = null
   private boundPort = 0
-  private readonly route: (req: HttpRequest) => Promise<HttpResponse>
+  private readonly route: (request: Request) => Response | Promise<Response>
 
   constructor(
     host: HttpHost,
@@ -74,53 +75,44 @@ export class LocalApiServer {
   }
 
   private async respond(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+    const body = await this.read(req)
+    if (body === null) {
+      res.writeHead(413).end()
+      return
+    }
+    const headers = new Headers()
+    for (const [name, value] of Object.entries(req.headers)) {
+      headers.set(name, Array.isArray(value) ? value.join(', ') : (value ?? ''))
+    }
+    const method = req.method ?? 'GET'
+    const request = new Request(`http://127.0.0.1${req.url ?? '/'}`, {
+      method,
+      headers,
+      body: method === 'GET' || method === 'HEAD' ? undefined : body
+    })
+    await this.write(res, await this.route(request))
+  }
+
+  /** The body as text, or null when the client sent more than we are willing to hold. */
+  private async read(req: IncomingMessage): Promise<string | null> {
     const decoder = new TextDecoder()
     let raw = ''
     let size = 0
     for await (const chunk of req as AsyncIterable<Uint8Array>) {
       size += chunk.byteLength
-      if (size > MAX_BODY_BYTES) {
-        res.writeHead(413).end()
-        return
-      }
+      if (size > MAX_BODY_BYTES) return null
       raw += decoder.decode(chunk, { stream: true })
     }
-    raw += decoder.decode()
-    let body: unknown
-    if (raw.trim()) {
-      try {
-        body = JSON.parse(raw)
-      } catch {
-        this.write(res, 400, { error: { code: 'invalid', message: 'body is not valid JSON' } })
-        return
-      }
-    }
-    const headers: Record<string, string> = {}
-    for (const [name, value] of Object.entries(req.headers)) {
-      headers[name] = Array.isArray(value) ? value.join(', ') : (value ?? '')
-    }
-    const response = await this.route({
-      method: req.method ?? 'GET',
-      path: url.pathname,
-      query: Object.fromEntries(url.searchParams),
-      headers,
-      body
-    })
-    if (response.stream) {
-      await this.pipe(res, response.status, response.stream, response.headers)
-      return
-    }
-    this.write(res, response.status, response.body, response.headers)
+    return raw + decoder.decode()
   }
 
-  private async pipe(
-    res: ServerResponse,
-    status: number,
-    stream: ReadableStream<Uint8Array>,
-    extra: Record<string, string> = {}
-  ): Promise<void> {
-    res.writeHead(status, { 'cache-control': 'no-store', ...extra })
+  private async write(res: ServerResponse, response: Response): Promise<void> {
+    res.writeHead(response.status, Object.fromEntries(response.headers))
+    const stream = response.body
+    if (!stream) {
+      res.end()
+      return
+    }
     const reader = stream.getReader()
     for (;;) {
       const { done, value } = await reader.read()
@@ -128,16 +120,5 @@ export class LocalApiServer {
       res.write(value)
     }
     res.end()
-  }
-
-  private write(res: ServerResponse, status: number, body: unknown, extra: Record<string, string> = {}): void {
-    const payload = body === undefined ? '' : JSON.stringify(body)
-    res.writeHead(status, {
-      'content-type': 'application/json',
-      'content-length': String(new TextEncoder().encode(payload).byteLength),
-      'cache-control': 'no-store',
-      ...extra
-    })
-    res.end(payload)
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import { MarkdownView, Notice, Platform, Plugin } from 'obsidian'
-import { bearerAuth } from '@dotpm/api'
 import {
   DEFAULT_SETTINGS,
   makeDefaultFilter,
@@ -107,7 +106,7 @@ export default class PMPlugin extends Plugin {
       {
         api,
         info: { name: 'dotpm', version: this.manifest.version },
-        authorized: bearerAuth(() => this.settings.localApiToken)
+        token: () => this.settings.localApiToken
       },
       () => this.settings.localApiPort
     )


### PR DESCRIPTION
The HTTP surface is now a Hono app exposed as a fetch handler; LocalApiServer only turns a Node request into a Request and writes the Response back. The MCP transport already speaks fetch, so its replies pass straight through instead of being unwrapped and rebuilt.

A malformed Authorization header now answers 400 rather than 401, 401s carry WWW-Authenticate, and responses go out chunked with no content-length.