### PR TITLE
fix focus and keyboard activation in dialogs and the toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The task title was not focused when the task dialog opened ([#303](https://github.com/dotpm/obsidian-pm/issues/303))
+- The project name was not focused when the new project dialog opened
+- The project name and icon above a view did nothing when activated with the keyboard
 - A project or task description was replaced by the entire note when the note's properties could not be read ([#274](https://github.com/dotpm/obsidian-pm/issues/274))
 - Properties other plugins added to a note were removed by the next save when the note's properties could not be read
 

--- a/src/modals/ProjectCreateModal.ts
+++ b/src/modals/ProjectCreateModal.ts
@@ -66,6 +66,7 @@ export class ProjectCreateModal extends Modal {
       return false
     })
     this.refreshValidity()
+    window.setTimeout(() => this.titleInput.focus(), 0)
   }
 
   onClose(): void {
@@ -115,7 +116,6 @@ export class ProjectCreateModal extends Modal {
       if (e.key === 'Enter' && !Keymap.isModifier(e, this.plugin.settings.editorSaveModifier)) e.preventDefault()
     })
     window.setTimeout(autosize, 0)
-    this.titleInput.focus()
   }
 
   private renderIcon(parent: HTMLElement): void {

--- a/src/modals/TaskEditor.ts
+++ b/src/modals/TaskEditor.ts
@@ -53,6 +53,7 @@ export class TaskEditor {
   private shownExtras = new Set<string>()
   private saveKeyHandler: KeymapEventHandler | null = null
   private containerEl: HTMLElement | null = null
+  private titleInput: HTMLTextAreaElement | null = null
 
   constructor(
     private app: App,
@@ -93,6 +94,16 @@ export class TaskEditor {
   mount(container: HTMLElement): void {
     this.containerEl = container
     this.render()
+    this.focusTitle()
+  }
+
+  private focusTitle(): void {
+    window.setTimeout(() => {
+      const input = this.titleInput
+      if (!input) return
+      input.focus()
+      if (this.isNew) input.select()
+    }, 0)
   }
 
   handleClose(): void {
@@ -330,6 +341,7 @@ export class TaskEditor {
 
     const titleWrap = body.createDiv('pm-te-title-wrap')
     const titleInput = titleWrap.createEl('textarea', { cls: 'pm-te-title' })
+    this.titleInput = titleInput
     titleInput.rows = 1
     titleInput.value = this.task.title
     titleInput.placeholder = 'Task title'
@@ -361,8 +373,6 @@ export class TaskEditor {
       if (e.key === 'Enter' && !Keymap.isModifier(e, this.plugin.settings.editorSaveModifier)) e.preventDefault()
     })
     window.setTimeout(autosizeTitle, 0)
-    titleInput.focus()
-    if (this.isNew) titleInput.select()
 
     const props = body.createDiv('pm-te-props')
     renderTaskFormFields(props, {

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -18,7 +18,7 @@ import {
   scopeKey,
   type ScopeSpec
 } from '../store'
-import { safeAsync, ChipButton, ViewSwitcher, ProjectHeader, renderGlyph } from '@dotpm/ui'
+import { safeAsync, ChipButton, ViewSwitcher, ProjectHeader, renderGlyph, makeActivatable } from '@dotpm/ui'
 import type { SubView } from './SubView'
 import { TableView } from './table/TableView'
 import type { TableViewState } from './table/TableView'
@@ -389,17 +389,17 @@ export class ProjectView extends ItemView {
     if (!scope.isMulti) {
       const iconEl = left.createSpan({
         cls: 'pm-toolbar-icon',
-        attr: { 'aria-label': 'Open project page', role: 'button', tabindex: '0' }
+        attr: { 'aria-label': 'Open project page' }
       })
       renderGlyph(iconEl, { icon: primary.icon, color: primary.color })
-      iconEl.addEventListener('click', openOverview)
+      makeActivatable(iconEl, openOverview)
     }
 
     const titleEl = left.createEl('h2', { text: scope.label(), cls: 'pm-toolbar-title' })
     if (!scope.isMulti) {
       titleEl.addClass('pm-toolbar-title--link')
-      titleEl.setAttrs({ 'aria-label': 'Open project page', role: 'button', tabindex: '0' })
-      titleEl.addEventListener('click', openOverview)
+      titleEl.setAttrs({ 'aria-label': 'Open project page' })
+      makeActivatable(titleEl, openOverview)
     }
     this.renderScopeSwitcher(left)
 


### PR DESCRIPTION
The title field in the new-task and new-project dialogs is focused when the dialog opens, and the task title is selected so typing replaces it. Obsidian focuses the first focusable element in a modal once onOpen returns, which was the close button in our header, so the field lost focus straight away (#303).

The project name and icon above a view now respond to Enter and Space. They were tab-reachable and announced as buttons but handled only clicks.

Closes #303
