### PR TITLE
keep task and project notes on case-insensitive filesystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A task failed to save when its note name differed from its title only by capitalization ([#308](https://github.com/dotpm/obsidian-pm/issues/308))
+- Creating a project failed when a note already held its name with different capitalization
 - The task title was not focused when the task dialog opened ([#303](https://github.com/dotpm/obsidian-pm/issues/303))
 - The project name was not focused when the new project dialog opened
 - The project name and icon above a view did nothing when activated with the keyboard

--- a/src/modals/ProjectCreateModal.ts
+++ b/src/modals/ProjectCreateModal.ts
@@ -1,7 +1,7 @@
 import { App, ButtonComponent, ExtraButtonComponent, Keymap, Modal, setIcon } from 'obsidian'
 import type PMPlugin from '../main'
 import { DEFAULT_PROJECT_COLOR, DEFAULT_PROJECT_ICON } from '@dotpm/core'
-import { folderOf, projectFilePath, projectFolderOf } from '../store'
+import { findIgnoringCase, folderOf, projectFilePath, projectFolderOf } from '../store'
 import { safeAsync, renderPropRow, renderIconControl, renderSelectControl } from '@dotpm/ui'
 import { saveShortcutLabel } from '../utils'
 import { renderPersonPicker } from '../ui/PersonPicker'
@@ -254,7 +254,7 @@ export class ProjectCreateModal extends Modal {
   private refreshValidity(): void {
     const title = this.draft.title.trim()
     const path = title ? this.targetPath(title) : ''
-    const taken = !!path && !!this.app.vault.getAbstractFileByPath(path)
+    const taken = !!path && !!findIgnoringCase(this.app, path)
 
     this.crumbFolder.setText(this.targetFolder())
     this.pathHint.lastElementChild?.setText(path)
@@ -284,7 +284,7 @@ export class ProjectCreateModal extends Modal {
 
   private readonly create = safeAsync(async () => {
     const title = this.draft.title.trim()
-    if (!title || this.app.vault.getAbstractFileByPath(this.targetPath(title))) return
+    if (!title || findIgnoringCase(this.app, this.targetPath(title))) return
     const project = await this.plugin.store.createProject(title, this.targetFolder(), {
       icon: this.draft.icon,
       color: this.draft.color,

--- a/src/store/ProjectStore.test.ts
+++ b/src/store/ProjectStore.test.ts
@@ -17,7 +17,7 @@ import {
   findTask,
   flattenTasks
 } from '@dotpm/core'
-import { ProjectStore, UnreadableNoteError } from './ProjectStore'
+import { ProjectStore, TaskFileNameConflictError, UnreadableNoteError } from './ProjectStore'
 import { projectTaskFolder } from './vaultFs'
 import { VaultIndex } from './VaultIndex'
 
@@ -907,6 +907,74 @@ describe('ProjectStore duplicate long titles', () => {
     for (const p of paths) {
       expect(vault.getAbstractFileByPath(expectDefined(p))).toBeInstanceOf(TFile)
     }
+  })
+})
+
+describe('ProjectStore on a case-insensitive filesystem', () => {
+  function newCaseInsensitiveStore(): { store: ProjectStore; vault: FakeVault; app: App } {
+    const { app, vault } = makeFakeApp({ caseInsensitive: true })
+    const store = new ProjectStore(app as unknown as App, () => SETTINGS)
+    return { store, vault, app: app as unknown as App }
+  }
+
+  /** A note the user named themselves, keeping capitals the slug would have dropped. */
+  async function renameOnDisk(app: App, task: Task, to: string): Promise<string> {
+    await app.vault.rename(fileAt(app, expectDefined(task.filePath)), to)
+    task.filePath = to
+    return to
+  }
+
+  it('saves a task whose file name differs from its slug only by case', async () => {
+    const { store, vault, app } = newCaseInsensitiveStore()
+    const project = await store.createProject('Personal', 'Projects')
+    const task = await addNamed(store, project, 'Testproject--water-item')
+    const capitalized = await renameOnDisk(app, task, 'Projects/Personal/_tasks/Testproject--water-item.md')
+
+    await store.updateTask(project, task.id, { status: 'in-progress' })
+
+    expect(task.filePath).toBe(capitalized)
+    expect(vault.getAbstractFileByPath(capitalized)).toBeInstanceOf(TFile)
+    expect(vault.getAbstractFileByPath('Projects/Personal/_tasks/testproject--water-item.md')).toBeNull()
+    expect(await readStatus(app, capitalized)).toBe('in-progress')
+  })
+
+  it('reports a retitle onto a differently-cased note as a file name conflict', async () => {
+    const { store, app } = newCaseInsensitiveStore()
+    const project = await store.createProject('Personal', 'Projects')
+    const task = await addNamed(store, project, 'Alpha')
+    await app.vault.create('Projects/Personal/_tasks/Beta.md', '')
+
+    await expect(store.updateTask(project, task.id, { title: 'Beta' })).rejects.toBeInstanceOf(
+      TaskFileNameConflictError
+    )
+  })
+
+  it('finds the conflict before the save when a differently-cased note holds the name', async () => {
+    const { store, app } = newCaseInsensitiveStore()
+    const project = await store.createProject('Personal', 'Projects')
+    const task = await addNamed(store, project, 'Alpha')
+    await app.vault.create('Projects/Personal/_tasks/Beta.md', '')
+
+    expect(store.findTaskFileConflict(project, { ...task, title: 'Beta' })).toBeInstanceOf(TaskFileNameConflictError)
+  })
+
+  it('refuses a project whose name differs from an existing one only by case', async () => {
+    const { store } = newCaseInsensitiveStore()
+    await store.createProject('Personal', 'Projects')
+
+    await expect(store.createProject('personal', 'Projects')).rejects.toThrow('already exists here')
+  })
+
+  it('leaves a project note alone when its new title is taken by a differently-cased sibling', async () => {
+    const { store, app } = newCaseInsensitiveStore()
+    await store.createProject('Beta', 'Projects')
+    const project = await store.createProject('Alpha', 'Projects')
+
+    await store.updateProject(project, { title: 'beta' })
+
+    expect(project.title).toBe('beta')
+    expect(project.filePath).toBe('Projects/Alpha/Alpha.md')
+    expect(app.vault.getAbstractFileByPath('Projects/Beta/Beta.md')).toBeInstanceOf(TFile)
   })
 })
 

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -51,6 +51,7 @@ import type { VaultIndex } from './VaultIndex'
 import { refLink, refListToIds, refToId } from './refs'
 import {
   ensureFolder,
+  findIgnoringCase,
   folderOf,
   keepProjectStorageWithNote,
   moveTaskAttachmentFolder,
@@ -81,6 +82,9 @@ function resolveTaskPath(task: Task, folder: string, previousPath: string | unde
   const previousFolder = previousPath.slice(0, previousPath.lastIndexOf('/'))
   const previousBasename = previousPath.slice(previousPath.lastIndexOf('/') + 1).replace(/\.md$/, '')
   if (previousFolder !== folder) return desired
+  // A note named by hand keeps capitals the lowercase slug drops; on macOS and Windows
+  // it is already the file the slug names.
+  if (previousBasename.toLowerCase() === desiredBasename.toLowerCase()) return previousPath
   const legacyBasename = `${desiredBasename}-${task.id.slice(0, 8)}`
   if (previousBasename === legacyBasename) return previousPath
   if (previousBasename.length === LEGACY_SLUG_CAP && previousBasename === desiredBasename.slice(0, LEGACY_SLUG_CAP)) {
@@ -643,14 +647,14 @@ export class ProjectStore implements TaskSource {
     if (!desiredBasename) return
     const dir = folderOf(currentPath)
     const target = normalizePath(dir ? `${dir}/${desiredBasename}.md` : `${desiredBasename}.md`)
-    if (target === currentPath || this.app.vault.getAbstractFileByPath(target)) return
+    if (target === currentPath || findIgnoringCase(this.app, target)) return
 
     // The note takes its folder with it; skip the whole rename if that folder's new
     // name is already taken, rather than leaving the note and its folder mismatched.
     const own = projectFolderOf(this.app, currentPath)
     if (own) {
       const folderTarget = normalizePath(`${folderOf(own)}/${desiredBasename}`)
-      if (folderTarget !== own && this.app.vault.getAbstractFileByPath(folderTarget)) return
+      if (folderTarget !== own && findIgnoringCase(this.app, folderTarget)) return
     }
 
     this.markSelfWrite(currentPath)
@@ -791,8 +795,9 @@ export class ProjectStore implements TaskSource {
       }
 
       const existing = this.app.vault.getAbstractFileByPath(filePath)
-      if (existing instanceof TFile && existing.path !== previousPath) {
-        throw new TaskFileNameConflictError(filePath)
+      const taken = existing ?? findIgnoringCase(this.app, filePath)
+      if (taken instanceof TFile && taken.path !== previousPath) {
+        throw new TaskFileNameConflictError(taken.path)
       }
 
       if (existing instanceof TFile) {
@@ -861,12 +866,14 @@ export class ProjectStore implements TaskSource {
     const folder = task.archived ? normalizePath(baseFolder + '/Archive') : baseFolder
     const desired = normalizePath(resolveTaskPath(task, folder, task.filePath))
     if (desired === task.filePath) return null
-    const existing = this.app.vault.getAbstractFileByPath(desired)
-    return existing instanceof TFile ? new TaskFileNameConflictError(desired) : null
+    const existing = findIgnoringCase(this.app, desired)
+    return existing instanceof TFile ? new TaskFileNameConflictError(existing.path) : null
   }
 
   async createProject(title: string, folder: string, patch?: ProjectPatch): Promise<Project> {
-    const project = makeProject(title, projectFilePath(title, folder))
+    const filePath = projectFilePath(title, folder)
+    if (findIgnoringCase(this.app, filePath)) throw new Error(`A project named "${title}" already exists here.`)
+    const project = makeProject(title, filePath)
     if (patch) Object.assign(project, patch)
     await this.saveProject(project)
     return project
@@ -1069,7 +1076,7 @@ export class ProjectStore implements TaskSource {
   async duplicateProject(source: Project, title: string): Promise<Project> {
     const dir = folderOf(projectFolderOf(this.app, source.filePath) ?? source.filePath)
     const filePath = projectFilePath(title, dir)
-    if (this.app.vault.getAbstractFileByPath(filePath) || this.app.vault.getAbstractFileByPath(folderOf(filePath))) {
+    if (findIgnoringCase(this.app, filePath) || findIgnoringCase(this.app, folderOf(filePath))) {
       throw new Error(`A project named "${title}" already exists here.`)
     }
 
@@ -1429,7 +1436,7 @@ export class ProjectStore implements TaskSource {
     const base = dot > 0 ? fileName.slice(0, dot) : fileName
     const ext = dot > 0 ? fileName.slice(dot) : ''
     let candidate = normalizePath(`${folder}/${base}${ext}`)
-    for (let n = 1; this.app.vault.getAbstractFileByPath(candidate); n++) {
+    for (let n = 1; findIgnoringCase(this.app, candidate); n++) {
       candidate = normalizePath(`${folder}/${base} ${n}${ext}`)
     }
     return candidate

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -20,6 +20,7 @@ export {
 } from './people'
 export type { PersonCandidate, PersonLinkState, PersonMatch, PersonRef } from './people'
 export {
+  findIgnoringCase,
   folderOf,
   projectFilePath,
   projectFolderOf,

--- a/src/store/vaultFs.ts
+++ b/src/store/vaultFs.ts
@@ -1,4 +1,4 @@
-import type { App } from 'obsidian'
+import type { App, TAbstractFile } from 'obsidian'
 import { TFile, TFolder, normalizePath } from 'obsidian'
 import { sanitizeFileName } from '@dotpm/core'
 
@@ -130,6 +130,24 @@ export function resolveVaultLink(app: App, raw: unknown, sourcePath: string): st
   const linkpath = inner.split('|')[0].trim()
   if (!linkpath) return undefined
   return app.metadataCache.getFirstLinkpathDest(linkpath, sourcePath)?.path ?? undefined
+}
+
+/**
+ * The note or folder a write to `path` would reach, which on macOS and Windows includes one
+ * whose name differs only in case and which `getAbstractFileByPath` misses. Resolved a
+ * segment at a time, since a parent folder can differ in case too.
+ */
+export function findIgnoringCase(app: App, path: string): TAbstractFile | null {
+  const normalized = normalizePath(path)
+  const exact = app.vault.getAbstractFileByPath(normalized)
+  if (exact) return exact
+  let current: TAbstractFile | null = app.vault.getRoot()
+  for (const segment of normalized.split('/')) {
+    if (!(current instanceof TFolder)) return null
+    const lower = segment.toLowerCase()
+    current = current.children.find((child) => child.name.toLowerCase() === lower) ?? null
+  }
+  return current
 }
 
 /**

--- a/test/fakeVault.ts
+++ b/test/fakeVault.ts
@@ -22,9 +22,19 @@ export class FakeVault {
   createCount = new Map<string, number>()
   trashCount = new Map<string, number>()
 
-  constructor() {
+  constructor(private readonly caseInsensitive = false) {
     const root = makeFolder('', null)
     this.folders.set('', root)
+  }
+
+  /** Windows and default macOS: the path map stays case-sensitive, the filesystem under it does not. */
+  private caseClash(path: string, self?: string): boolean {
+    if (!this.caseInsensitive) return false
+    const lower = path.toLowerCase()
+    for (const known of [...this.files.keys(), ...this.folders.keys()]) {
+      if (known !== self && known !== path && known.toLowerCase() === lower) return true
+    }
+    return false
   }
 
   on(name: string, handler: VaultHandler): VaultHandler {
@@ -44,6 +54,10 @@ export class FakeVault {
   getAbstractFileByPath(path: string): TAbstractFile | null {
     const n = normalizePath(path)
     return this.files.get(n)?.file ?? this.folders.get(n) ?? null
+  }
+
+  getRoot(): TFolder {
+    return expectDefined(this.folders.get(''))
   }
 
   async cachedRead(file: TFile): Promise<string> {
@@ -75,6 +89,7 @@ export class FakeVault {
   async create(path: string, content: string): Promise<TFile> {
     const n = normalizePath(path)
     if (this.files.has(n)) throw new Error(`create: ${n} already exists`)
+    if (this.caseClash(n)) throw new Error('File already exists.')
     const parent = this.ensureFolderForPath(n)
     const file = makeFile(n, parent)
     this.files.set(n, { file, content })
@@ -87,6 +102,7 @@ export class FakeVault {
   async createBinary(path: string, _data: ArrayBuffer): Promise<TFile> {
     const n = normalizePath(path)
     if (this.files.has(n)) throw new Error(`createBinary: ${n} already exists`)
+    if (this.caseClash(n)) throw new Error('File already exists.')
     const parent = this.ensureFolderForPath(n)
     const file = makeFile(n, parent)
     this.files.set(n, { file, content: '' })
@@ -99,6 +115,7 @@ export class FakeVault {
   async createFolder(path: string): Promise<void> {
     const n = normalizePath(path)
     if (this.folders.has(n)) throw new Error('Folder already exists')
+    if (this.caseClash(n)) throw new Error('Folder already exists.')
     const parent = this.ensureFolderForPath(n)
     const folder = makeFolder(n, parent)
     this.folders.set(n, folder)
@@ -109,6 +126,7 @@ export class FakeVault {
     const to = normalizePath(newPath)
     const from = file.path
     if (this.getAbstractFileByPath(to)) throw new Error(`rename: ${to} already exists`)
+    if (this.caseClash(to, from)) throw new Error('File already exists.')
     if (file instanceof TFolder) {
       const folders = [file, ...[...this.folders.values()].filter((f) => f.path.startsWith(from + '/'))]
       const entries = [...this.files.values()].filter((e) => e.file.path.startsWith(from + '/'))
@@ -249,8 +267,11 @@ export class FakeMetadataCache {
   }
 }
 
-export function makeFakeApp(opts: { liveMetadataCache?: boolean } = {}): { app: FakeAppLike; vault: FakeVault } {
-  const vault = new FakeVault()
+export function makeFakeApp(opts: { liveMetadataCache?: boolean; caseInsensitive?: boolean } = {}): {
+  app: FakeAppLike
+  vault: FakeVault
+} {
+  const vault = new FakeVault(opts.caseInsensitive)
   const app: FakeAppLike = {
     vault,
     fileManager: {


### PR DESCRIPTION
A task note keeps its own capitalization instead of being renamed to the lowercase slug, and the checks asking whether a path is free now match the way macOS and Windows compare names.

Saving a task whose file was named by hand, like Testproject--water-item.md, tried to create the lowercase twin, which is the same file on those systems, and failed with a raw "File already exists." from the vault adapter (#308). The same blind spot made a name clash surface as that error rather than the usual conflict message, in the task editor and when creating a project.

Closes #308