### PR TITLE
read task collapse state from settings instead of mirroring it on tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A subtask appeared twice under its parent when the parent's properties listed it more than once ([#306](https://github.com/dotpm/obsidian-pm/issues/306))
+- Collapsed parent tasks in the table and timeline expanded again when a task note changed outside the plugin ([#305](https://github.com/dotpm/obsidian-pm/issues/305))
 - A task failed to save when its note name differed from its title only by capitalization ([#308](https://github.com/dotpm/obsidian-pm/issues/308))
 - Creating a project failed when a note already held its name with different capitalization
 - The task title was not focused when the task dialog opened ([#303](https://github.com/dotpm/obsidian-pm/issues/303))

--- a/packages/core/src/store/TaskTreeOps.test.ts
+++ b/packages/core/src/store/TaskTreeOps.test.ts
@@ -33,17 +33,22 @@ describe('flattenTasks', () => {
   })
 
   it('marks descendants of a collapsed parent as invisible', () => {
-    const tasks = [task({ id: 'a', collapsed: true, subtasks: [task({ id: 'a1' })] })]
-    const flat = flattenTasks(tasks)
+    const tasks = [task({ id: 'a', subtasks: [task({ id: 'a1' })] })]
+    const flat = flattenTasks(tasks, new Set(['a']))
     expect(flat[0].visible).toBe(true)
     expect(flat[1].visible).toBe(false)
+  })
+
+  it('keeps every row visible when no ids are collapsed', () => {
+    const tasks = [task({ id: 'a', subtasks: [task({ id: 'a1' })] })]
+    expect(flattenTasks(tasks).every((f) => f.visible)).toBe(true)
   })
 
   it('propagates invisibility through multiple levels', () => {
     const grandchild = task({ id: 'a1x' })
     const child = task({ id: 'a1', subtasks: [grandchild] })
-    const root = task({ id: 'a', collapsed: true, subtasks: [child] })
-    const flat = flattenTasks([root])
+    const root = task({ id: 'a', subtasks: [child] })
+    const flat = flattenTasks([root], new Set(['a']))
     expect(flat.find((f) => f.task.id === 'a1x')?.visible).toBe(false)
   })
 })

--- a/packages/core/src/store/TaskTreeOps.ts
+++ b/packages/core/src/store/TaskTreeOps.ts
@@ -6,23 +6,21 @@ export interface FlatTask {
   task: Task
   depth: number
   parentId: string | null
+  /** False when an ancestor is collapsed. Every row is visible when no ids are given. */
   visible: boolean
 }
 
-export function flattenTasks(
-  tasks: Task[],
-  depth = 0,
-  parentId: string | null = null,
-  ancestorCollapsed = false
-): FlatTask[] {
+export function flattenTasks(tasks: Task[], collapsedIds?: ReadonlySet<string>): FlatTask[] {
   const result: FlatTask[] = []
-  for (const task of tasks) {
-    const visible = !ancestorCollapsed
-    result.push({ task, depth, parentId, visible })
-    if (task.subtasks.length > 0) {
-      result.push(...flattenTasks(task.subtasks, depth + 1, task.id, ancestorCollapsed || task.collapsed))
+  const walk = (list: Task[], depth: number, parentId: string | null, hidden: boolean): void => {
+    for (const task of list) {
+      result.push({ task, depth, parentId, visible: !hidden })
+      if (task.subtasks.length > 0) {
+        walk(task.subtasks, depth + 1, task.id, hidden || collapsedIds?.has(task.id) === true)
+      }
     }
   }
+  walk(tasks, 0, null, false)
   return result
 }
 
@@ -101,7 +99,6 @@ function cloneNode(source: Task, includeSubtasks: boolean, idMap: Map<string, st
     filePath: undefined,
     createdAt: now,
     updatedAt: now,
-    collapsed: false,
     subtasks: includeSubtasks ? source.subtasks.map((s) => cloneNode(s, true, idMap)) : [],
     dependencies: [...source.dependencies],
     assignees: [...source.assignees],

--- a/packages/core/src/store/YamlHydrator.ts
+++ b/packages/core/src/store/YamlHydrator.ts
@@ -107,7 +107,6 @@ export function mapRawToTask(r: Record<string, unknown>, overrides?: Partial<Tas
       typeof r.customFields === 'object' && r.customFields !== null
         ? { ...(r.customFields as Record<string, unknown>) }
         : {},
-    collapsed: r.collapsed === true,
     createdAt: (r.createdAt as string) ?? new Date().toISOString(),
     updatedAt: (r.updatedAt as string) ?? new Date().toISOString(),
     ...overrides

--- a/packages/core/src/store/YamlSerializer.ts
+++ b/packages/core/src/store/YamlSerializer.ts
@@ -54,6 +54,7 @@ export const TASK_FRONTMATTER_KEYS: ReadonlySet<string> = new Set([
   'timeEstimate',
   'timeLogs',
   'customFields',
+  // Written by older versions; owned so a save drops it.
   'collapsed'
 ])
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,8 +61,6 @@ export interface Task {
   timeEstimate?: number // hours
   timeLogs?: TimeLog[]
   customFields: Record<string, unknown>
-  /** UI state, persisted per project in plugin settings (data.json), not in frontmatter. */
-  collapsed: boolean
   createdAt: string
   updatedAt: string
   filePath?: string // vault path to this task's .md file
@@ -323,7 +321,6 @@ export function makeTask(overrides: Partial<Task> = {}): Task {
     subtasks: [],
     dependencies: [],
     customFields: {},
-    collapsed: false,
     createdAt: now,
     updatedAt: now,
     ...overrides

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,6 @@ import {
   type Project,
   type Task,
   flattenTasks,
-  findTask,
   dedupePeople,
   displayName,
   localApiPortFor
@@ -498,11 +497,20 @@ export default class PMPlugin extends Plugin {
     }
     const cleanedCollapsed: typeof this.settings.collapsedTasks = {}
     for (const [path, ids] of Object.entries(this.settings.collapsedTasks)) {
-      if (this.app.vault.getAbstractFileByPath(path)) {
-        cleanedCollapsed[path] = ids
-      } else {
+      if (!this.app.vault.getAbstractFileByPath(path)) {
         dirty = true
+        continue
       }
+      // Only a project the index has tasks for can show that a collapsed id is gone.
+      const known = this.index.taskRefs(path)
+      if (!known.length) {
+        cleanedCollapsed[path] = ids
+        continue
+      }
+      const live = new Set(known.map((ref) => ref.id))
+      const kept = ids.filter((id) => live.has(id))
+      if (kept.length !== ids.length) dirty = true
+      cleanedCollapsed[path] = kept
     }
     const collapsedProjects = this.settings.collapsedProjects.filter((path) =>
       this.app.vault.getAbstractFileByPath(path)
@@ -517,24 +525,6 @@ export default class PMPlugin extends Plugin {
     }
   }
 
-  /** A project with no record yet keeps whatever legacy frontmatter said. */
-  applyCollapsedState(project: Project): void {
-    const ids = this.settings.collapsedTasks[project.filePath]
-    if (!ids) return
-    const set = new Set(ids)
-    for (const { task } of flattenTasks(project.tasks)) {
-      task.collapsed = set.has(task.id)
-    }
-  }
-
-  /** Call after toggling task.collapsed. */
-  async persistCollapsedState(project: Project): Promise<void> {
-    this.settings.collapsedTasks[project.filePath] = flattenTasks(project.tasks)
-      .filter((f) => f.task.collapsed)
-      .map((f) => f.task.id)
-    await this.saveSettings()
-  }
-
   isProjectCollapsed(path: string): boolean {
     return this.settings.collapsedProjects.includes(path)
   }
@@ -545,14 +535,6 @@ export default class PMPlugin extends Plugin {
     if (at === -1) collapsed.push(path)
     else collapsed.splice(at, 1)
     await this.saveSettings()
-  }
-
-  /** Resolves by id against the live tree, so it works when a view renders filtered clones. */
-  async toggleTaskCollapsed(project: Project, taskId: string): Promise<void> {
-    const task = findTask(project.tasks, taskId)
-    if (!task) return
-    task.collapsed = !task.collapsed
-    await this.persistCollapsedState(project)
   }
 
   async saveSettings(): Promise<void> {

--- a/src/views/ProjectView.ts
+++ b/src/views/ProjectView.ts
@@ -203,7 +203,6 @@ export class ProjectView extends ItemView {
       this.renderEmptyScope()
       return
     }
-    for (const project of projects) this.plugin.applyCollapsedState(project)
     if (this.defaultViewAppliedFor !== this.projectScope.key) {
       this.defaultViewAppliedFor = this.projectScope.key
       this.currentView = this.projectScope.config.defaultView

--- a/src/views/collapse.test.ts
+++ b/src/views/collapse.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_SETTINGS, makeProject, makeTask, type PMSettings, type Project } from '@dotpm/core'
+import { collapsedTaskIds, setAllCollapsed, toggleCollapsed } from './collapse'
+
+function settings(): PMSettings {
+  return structuredClone(DEFAULT_SETTINGS)
+}
+
+function project(filePath: string, tasks: Project['tasks'] = []): Project {
+  return { ...makeProject('A', filePath), tasks }
+}
+
+const parent = (id: string, childId: string) => makeTask({ id, subtasks: [makeTask({ id: childId })] })
+
+describe('collapsedTaskIds', () => {
+  it('merges the lists of every project in the scope', () => {
+    const cfg = settings()
+    cfg.collapsedTasks['Projects/A.md'] = ['t1']
+    cfg.collapsedTasks['Projects/B.md'] = ['t2']
+
+    const ids = collapsedTaskIds(cfg, [project('Projects/A.md'), project('Projects/B.md')])
+
+    expect([...ids].sort()).toEqual(['t1', 't2'])
+  })
+
+  it('reads nothing for a project with no record', () => {
+    expect(collapsedTaskIds(settings(), [project('Projects/A.md')]).size).toBe(0)
+  })
+})
+
+describe('toggleCollapsed', () => {
+  it('adds an id and takes it back out', () => {
+    const cfg = settings()
+    const p = project('Projects/A.md')
+
+    toggleCollapsed(cfg, p, 't1')
+    expect(cfg.collapsedTasks['Projects/A.md']).toEqual(['t1'])
+
+    toggleCollapsed(cfg, p, 't1')
+    expect(cfg.collapsedTasks['Projects/A.md']).toEqual([])
+  })
+
+  it('leaves the other projects alone', () => {
+    const cfg = settings()
+    cfg.collapsedTasks['Projects/B.md'] = ['t2']
+
+    toggleCollapsed(cfg, project('Projects/A.md'), 't1')
+
+    expect(cfg.collapsedTasks['Projects/B.md']).toEqual(['t2'])
+  })
+
+  it('keeps the state a reload of the tasks cannot reach', () => {
+    const cfg = settings()
+    const p = project('Projects/A.md', [parent('t1', 't1a')])
+    toggleCollapsed(cfg, p, 't1')
+
+    // What an external edit does: the task objects are replaced wholesale.
+    p.tasks = [parent('t1', 't1a')]
+
+    expect(collapsedTaskIds(cfg, [p]).has('t1')).toBe(true)
+  })
+})
+
+describe('setAllCollapsed', () => {
+  it('collapses every task that has subtasks', () => {
+    const cfg = settings()
+    const p = project('Projects/A.md', [parent('t1', 't1a'), makeTask({ id: 't2' })])
+
+    setAllCollapsed(cfg, [p], true)
+
+    expect(cfg.collapsedTasks['Projects/A.md']).toEqual(['t1'])
+  })
+
+  it('expanding clears the project of collapsed ids', () => {
+    const cfg = settings()
+    cfg.collapsedTasks['Projects/A.md'] = ['t1']
+
+    setAllCollapsed(cfg, [project('Projects/A.md')], false)
+
+    expect(cfg.collapsedTasks['Projects/A.md']).toEqual([])
+  })
+})

--- a/src/views/collapse.ts
+++ b/src/views/collapse.ts
@@ -1,0 +1,32 @@
+import { type PMSettings, type Project, flattenTasks } from '@dotpm/core'
+
+/**
+ * Which parents are collapsed is the reader's own state, so it is read from settings at
+ * render time and never carried on the task objects a reload replaces. Task ids are unique
+ * across the vault, so a scope covering several projects reads one merged set.
+ */
+export function collapsedTaskIds(settings: PMSettings, projects: Project[]): ReadonlySet<string> {
+  const ids = new Set<string>()
+  for (const project of projects) {
+    for (const id of settings.collapsedTasks[project.filePath] ?? []) ids.add(id)
+  }
+  return ids
+}
+
+export function toggleCollapsed(settings: PMSettings, project: Project, taskId: string): void {
+  const ids = settings.collapsedTasks[project.filePath] ?? []
+  const at = ids.indexOf(taskId)
+  if (at === -1) ids.push(taskId)
+  else ids.splice(at, 1)
+  settings.collapsedTasks[project.filePath] = ids
+}
+
+export function setAllCollapsed(settings: PMSettings, projects: Project[], collapsed: boolean): void {
+  for (const project of projects) {
+    settings.collapsedTasks[project.filePath] = collapsed
+      ? flattenTasks(project.tasks)
+          .filter((flat) => flat.task.subtasks.length > 0)
+          .map((flat) => flat.task.id)
+      : []
+  }
+}

--- a/src/views/gantt/GanttView.ts
+++ b/src/views/gantt/GanttView.ts
@@ -25,6 +25,7 @@ import {
 } from '@dotpm/ui'
 import { openAddTask } from '../addTask'
 import type { SubView } from '../SubView'
+import { collapsedTaskIds, setAllCollapsed } from '../collapse'
 import { makeDragState } from './GanttDragHandler'
 import type { DragState } from './GanttDragHandler'
 import { makeLinkState, cancelLink } from './GanttLinkHandler'
@@ -46,6 +47,8 @@ export class GanttView implements SubView {
   private svgEl!: SVGSVGElement
   private headerSvgEl!: SVGSVGElement
   private flatTasks: FlatTask[] = []
+  /** Read from settings once per render pass. */
+  private collapsedIds: ReadonlySet<string> = new Set()
   private cfg!: TimelineCfg
   private drag: DragState = makeDragState()
   private link: LinkState = makeLinkState()
@@ -99,7 +102,8 @@ export class GanttView implements SubView {
     this.container.addClass('pm-gantt-view')
 
     const activeTasks = this.getVisibleTasks()
-    this.flatTasks = flattenTasks(activeTasks).filter((f) => f.visible || f.depth === 0)
+    this.collapsedIds = collapsedTaskIds(this.plugin.settings, this.scope.projects)
+    this.flatTasks = flattenTasks(activeTasks, this.collapsedIds).filter((f) => f.visible || f.depth === 0)
     this.cfg = buildTimelineConfig(activeTasks, this.granularity)
 
     this.renderGranularityControls()
@@ -285,6 +289,7 @@ export class GanttView implements SubView {
       plugin: this.plugin,
       scope: this.scope,
       statuses: this.scope.config.statuses,
+      collapsedIds: this.collapsedIds,
       onRefresh: this.onRefresh
     }
     let rowIndex = 0
@@ -293,7 +298,7 @@ export class GanttView implements SubView {
         renderTaskLabel(leftBody, task, depth, rowIndex, labelCtx)
         renderTaskBar(barsGroup, task, rowIndex, depth, ctx)
         rowIndex++
-        if (!task.collapsed && task.subtasks.length) {
+        if (!this.collapsedIds.has(task.id) && task.subtasks.length) {
           renderFlatList(task.subtasks, depth + 1)
         }
       }
@@ -335,10 +340,8 @@ export class GanttView implements SubView {
   }
 
   private setAllCollapsed(collapsed: boolean): void {
-    for (const { task } of flattenTasks(this.scope.tasks())) {
-      if (task.subtasks.length > 0) task.collapsed = collapsed
-    }
-    for (const project of this.scope.projects) void this.plugin.persistCollapsedState(project)
+    setAllCollapsed(this.plugin.settings, this.scope.projects, collapsed)
+    void this.plugin.saveSettings()
     this.render()
   }
 }

--- a/src/views/gantt/TaskLabelRenderer.ts
+++ b/src/views/gantt/TaskLabelRenderer.ts
@@ -4,11 +4,13 @@ import type PMPlugin from '../../main'
 import type { StatusConfig, Task } from '@dotpm/core'
 import type { ProjectScope, TaskRef } from '../../store'
 import { openTaskByPath, openTaskModal } from '../../ui/ModalFactory'
+import { toggleCollapsed } from '../collapse'
 
 export interface LabelContext {
   plugin: PMPlugin
   scope: ProjectScope
   statuses: StatusConfig[]
+  collapsedIds: ReadonlySet<string>
   onRefresh: () => Promise<void>
 }
 
@@ -61,9 +63,10 @@ export function renderTaskLabel(
 
   if (task.subtasks.length > 0) {
     new CollapseToggle(el, {
-      collapsed: task.collapsed,
+      collapsed: ctx.collapsedIds.has(task.id),
       onToggle: safeAsync(async () => {
-        await ctx.plugin.toggleTaskCollapsed(project, task.id)
+        toggleCollapsed(ctx.plugin.settings, project, task.id)
+        await ctx.plugin.saveSettings()
         await ctx.onRefresh()
       })
     })

--- a/src/views/table/TableRenderer.ts
+++ b/src/views/table/TableRenderer.ts
@@ -57,6 +57,7 @@ export interface TableContext {
   priorityIcons: PriorityIconSet
   showSubtreeConnections: boolean
   lineBorders: LineBorders
+  collapsedIds: ReadonlySet<string>
   state: TableState
   onRefresh: () => Promise<void>
   onSelectionChange: () => void
@@ -186,7 +187,7 @@ function fillTableBody(ctx: TableContext): void {
   // rebuilding the table around it.
   ctx.state.wrapper?.setAttr('data-borders', ctx.lineBorders)
 
-  let flat = flattenTasks(ctx.scope.tasks())
+  let flat = flattenTasks(ctx.scope.tasks(), ctx.collapsedIds)
   const hasActiveFilter = isFilterActive(ctx.state.filter)
   flat = applyTaskFilterFlat(flat, ctx.state.filter, ctx.statuses, personKeyer(ctx.plugin.app))
 

--- a/src/views/table/TableRow.ts
+++ b/src/views/table/TableRow.ts
@@ -28,6 +28,7 @@ import { updateSelectCheckboxes, getVisibleTaskIds } from './TableRenderer'
 import type { TableContext, TableState, TableTreeRow } from './TableRenderer'
 import { openTaskModal } from '../../ui/ModalFactory'
 import { buildTaskContextMenu } from '../../ui/TaskContextMenu'
+import { toggleCollapsed } from '../collapse'
 import { linkedRefs } from '../linkedRefs'
 
 export function renderTaskRow(tbody: HTMLElement, flat: TableTreeRow, ctx: TableContext): void {
@@ -79,9 +80,10 @@ export function renderTaskRow(tbody: HTMLElement, flat: TableTreeRow, ctx: Table
 
   new ExpandCell(row, {
     hasSubtasks: task.subtasks.length > 0,
-    collapsed: task.collapsed,
+    collapsed: ctx.collapsedIds.has(task.id),
     onToggle: safeAsync(async () => {
-      await ctx.plugin.toggleTaskCollapsed(project, task.id)
+      toggleCollapsed(ctx.plugin.settings, project, task.id)
+      await ctx.plugin.saveSettings()
       await ctx.onRefresh()
     })
   })

--- a/src/views/table/TableView.ts
+++ b/src/views/table/TableView.ts
@@ -5,6 +5,7 @@ import type { FilterState, Project } from '@dotpm/core'
 import type { ProjectScope } from '../../store'
 import { safeAsync } from '@dotpm/ui'
 import type { SubView } from '../SubView'
+import { collapsedTaskIds } from '../collapse'
 import { renderTable, refreshTableBody, handleTableKeyDown, ROW_HEIGHT_ESTIMATE } from './TableRenderer'
 import type { SortKey, SortDir, TableState } from './TableRenderer'
 import { updateSelectAllCheckbox } from './TableRow'
@@ -233,6 +234,7 @@ export class TableView implements SubView {
       priorityIcons: config.priorityIcons,
       showSubtreeConnections: config.showSubtreeConnections,
       lineBorders: config.lineBorders,
+      collapsedIds: collapsedTaskIds(this.plugin.settings, this.scope.projects),
       state: this.state,
       onRefresh: this.onRefresh,
       onSelectionChange: () => {


### PR DESCRIPTION
Collapse state for parent tasks is read from plugin settings at render time, and `Task.collapsed` is gone.

An external write under a project (another editor, sync, git) reloads it and replaces its task objects, which dropped the mirrored flag: the view redrew fully expanded and the next toggle saved that as the state.

A `collapsed` key left in task properties by older versions is no longer read, so those trees start expanded once.

Closes #305