### PR TITLE
write only the reference fields when migrating a note

### DIFF
--- a/src/migration.test.ts
+++ b/src/migration.test.ts
@@ -200,10 +200,39 @@ describe('migrateTaskRefs', () => {
   it('rewrites nothing on a second run', async () => {
     const { plugin } = await idRefVault()
     await migrateTaskRefs(plugin)
-    const rewrite = vi.spyOn(plugin.store, 'rewriteTaskFiles')
+    const rewrite = vi.spyOn(plugin.store, 'normalizeTaskRefs')
 
     await migrateTaskRefs(plugin)
 
     expect(rewrite).not.toHaveBeenCalled()
+  })
+})
+
+describe('migrateTaskRefs leaves the note itself alone', () => {
+  it('keeps the name and the body of a note the user renamed and wrote in', async () => {
+    const { app, vault } = makeFakeApp({ liveMetadataCache: true })
+    const typed = app as unknown as App
+    await vault.create('Projects/Roadmap/Roadmap.md', idRefProject())
+    const body = ['', 'My research notes.', '', '## Subtasks', '', 'Notes I wrote under my own heading.'].join('\n')
+    await vault.create(
+      'Projects/Roadmap/_tasks/my-own-name.md',
+      idRefTask('t1', 'Design the thing', ['subtaskIds:', '  - t2']) + body
+    )
+    await vault.create('Projects/Roadmap/_tasks/child.md', idRefTask('t2', 'Child', ['parentId: t1']))
+
+    const settings: PMSettings = structuredClone(DEFAULT_SETTINGS)
+    const index = new VaultIndex(typed, () => settings)
+    index.build()
+    const store = new ProjectStore(typed, () => settings, index)
+    const plugin = { app, index, store, settings, saveSettings: async () => {} } as unknown as PMPlugin
+
+    await migrateTaskRefs(plugin)
+
+    const content = await contentAt(typed, 'Projects/Roadmap/_tasks/my-own-name.md')
+    expect(content).toContain('subtaskIds: ["[[child|Child]]"]')
+    expect(content).toContain('Notes I wrote under my own heading.')
+    expect(typed.vault.getMarkdownFiles().map((f) => f.path)).not.toContain(
+      'Projects/Roadmap/_tasks/design-the-thing.md'
+    )
   })
 })

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -53,9 +53,9 @@ function frontmatterOf(plugin: PMPlugin, path: string): Record<string, unknown> 
 }
 
 /**
- * Writes the notes that still name a task or project by id rather than by link. Both forms
+ * Points the notes that still name a task or project by id at the note itself. Both forms
  * read the same, so this only makes a vault written across the change consistent. It reads
- * the frontmatter cache rather than the notes, and rewrites nothing in a vault that holds
+ * the frontmatter cache rather than the notes, and touches nothing in a vault that holds
  * no ids, which is what makes a second run free.
  */
 export async function migrateTaskRefs(plugin: PMPlugin): Promise<void> {
@@ -66,12 +66,13 @@ export async function migrateTaskRefs(plugin: PMPlugin): Promise<void> {
       .taskRefs(path)
       .filter((ref) => holdsBareId(frontmatterOf(plugin, ref.path)))
       .map((ref) => ref.id)
-    if (stale.length === 0 && !holdsBareId(frontmatterOf(plugin, path))) continue
+    const projectNoteStale = holdsBareId(frontmatterOf(plugin, path))
+    if (stale.length === 0 && !projectNoteStale) continue
 
     try {
       const project = await plugin.store.loadProjectByPath(path)
       if (!project) continue
-      await plugin.store.rewriteTaskFiles(project, stale)
+      await plugin.store.normalizeTaskRefs(project, stale, projectNoteStale)
       rewritten += stale.length
     } catch (e) {
       console.error(`[PM] Failed to update the references in "${path}":`, e)

--- a/src/store/ProjectStore.ts
+++ b/src/store/ProjectStore.ts
@@ -942,9 +942,47 @@ export class ProjectStore implements TaskSource {
     if (live) live.parentPath = parentPath
   }
 
-  async rewriteTaskFiles(project: Project, taskIds: string[]): Promise<void> {
-    this.markDirty(project, taskIds, 'full')
-    await this.saveProject(project)
+  /**
+   * Writes the reference fields of the named notes, and nothing else: a note keeps its
+   * name, its body and every other property. A note whose references already say what
+   * they would be written as is left alone, so nothing is written twice.
+   */
+  async normalizeTaskRefs(project: Project, taskIds: string[], includeProjectNote: boolean): Promise<void> {
+    for (const id of taskIds) {
+      const entry = project.taskIndex.get(id)
+      const path = entry?.task.filePath
+      if (!entry || !path) continue
+      const file = this.app.vault.getAbstractFileByPath(path)
+      if (!(file instanceof TFile)) continue
+
+      const refs = this.refsFor(project, path)
+      const parent = entry.parentId ? findTaskById(project, entry.parentId) : null
+      const next = {
+        projectId: refs.link(project.filePath, project.title),
+        parentId: parent ? (refs.task(parent) ?? parent.id) : null,
+        subtaskIds: entry.task.subtasks.map((s) => refs.task(s) ?? s.id),
+        dependencies: entry.task.dependencies.map((depId) => refs.dependency(depId) ?? depId)
+      }
+      await this.writeRefFields(file, next)
+    }
+
+    if (!includeProjectNote) return
+    const file = this.app.vault.getAbstractFileByPath(project.filePath)
+    if (!(file instanceof TFile)) return
+    const refs = this.refsFor(project, project.filePath)
+    await this.writeRefFields(file, { taskIds: project.tasks.map((t) => refs.task(t) ?? t.id) })
+  }
+
+  private async writeRefFields(file: TFile, next: Record<string, unknown>): Promise<void> {
+    const current = this.app.metadataCache.getFileCache(file)?.frontmatter
+    const unchanged = Object.entries(next).every(
+      ([key, value]) => JSON.stringify(current?.[key] ?? null) === JSON.stringify(value)
+    )
+    if (unchanged) return
+    this.markSelfWrite(file.path)
+    await this.app.fileManager.processFrontMatter(file, (fm: Record<string, unknown>) => {
+      Object.assign(fm, next)
+    })
   }
 
   async insertTask(project: Project, task: Task, parentId: string | null = null): Promise<void> {

--- a/src/store/TaskSource.ts
+++ b/src/store/TaskSource.ts
@@ -47,8 +47,8 @@ export interface TaskSource {
   moveProjectIntoOwnFolder(projectPath: string): Promise<string | null>
   /** Writes a sub-project's `parent` link again, for when the parent note moved. */
   repointProjectParent(childPath: string, parentPath: string): Promise<void>
-  /** Writes the named task notes again in full, for when only their references changed. */
-  rewriteTaskFiles(project: Project, taskIds: string[]): Promise<void>
+  /** Writes the reference fields of the named notes in place, leaving name and body alone. */
+  normalizeTaskRefs(project: Project, taskIds: string[], includeProjectNote: boolean): Promise<void>
   saveProject(project: Project): Promise<void>
   updateProject(project: Project, patch: ProjectPatch): Promise<void>
   deleteProject(project: Project): Promise<void>


### PR DESCRIPTION
The reference migration on main marks each note dirty as a full save, which renames any note whose file name no longer matches its title and drops everything under a `## Subtasks` heading. A note someone renamed by hand loses its name (inbound links break, since the old file is trashed rather than renamed) and any text they wrote under that heading is gone.

It now writes the four reference properties in place through processFrontMatter, and skips the write when the values already match.

This is a follow-up to #312, which was merged before the fix was pushed.