### PR TITLE
read the timeline granularity from settings on every render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- An open timeline ignored the granularity chosen in settings until it was reopened
 - A subtask appeared twice under its parent when the parent's properties listed it more than once ([#306](https://github.com/dotpm/obsidian-pm/issues/306))
 - Collapsed parent tasks in the table and timeline expanded again when a task note changed outside the plugin ([#305](https://github.com/dotpm/obsidian-pm/issues/305))
 - A task failed to save when its note name differed from its title only by capitalization ([#308](https://github.com/dotpm/obsidian-pm/issues/308))

--- a/src/views/gantt/GanttView.ts
+++ b/src/views/gantt/GanttView.ts
@@ -42,7 +42,6 @@ import type { RendererContext } from './GanttRenderer'
 import { renderTaskLabel } from './TaskLabelRenderer'
 
 export class GanttView implements SubView {
-  private granularity: GanttGranularity
   private scrollEl!: HTMLElement
   private svgEl!: SVGSVGElement
   private headerSvgEl!: SVGSVGElement
@@ -70,9 +69,7 @@ export class GanttView implements SubView {
     private onRefresh: () => Promise<void>,
     private filter: FilterState,
     private keyScope: Scope
-  ) {
-    this.granularity = plugin.settings.ganttGranularity
-  }
+  ) {}
 
   destroy(): void {
     for (const fn of this.cleanupFns) fn()
@@ -104,7 +101,7 @@ export class GanttView implements SubView {
     const activeTasks = this.getVisibleTasks()
     this.collapsedIds = collapsedTaskIds(this.plugin.settings, this.scope.projects)
     this.flatTasks = flattenTasks(activeTasks, this.collapsedIds).filter((f) => f.visible || f.depth === 0)
-    this.cfg = buildTimelineConfig(activeTasks, this.granularity)
+    this.cfg = buildTimelineConfig(activeTasks, this.plugin.settings.ganttGranularity)
 
     this.renderGranularityControls()
     this.renderGantt()
@@ -123,9 +120,8 @@ export class GanttView implements SubView {
 
     new SegmentedControl<GanttGranularity>(bar, {
       options: levels.map((level) => ({ id: level, label: labels[level] })),
-      active: this.granularity,
+      active: this.plugin.settings.ganttGranularity,
       onChange: (level) => {
-        this.granularity = level
         this.plugin.settings.ganttGranularity = level
         void this.plugin.saveSettings()
         this.render()


### PR DESCRIPTION
The timeline reads its granularity from settings on each render instead of copying it when the view opens, so a change to the granularity setting reaches an open timeline instead of waiting for it to be reopened.